### PR TITLE
uses bibdata delivery_locations for on_order/in_process items when configured

### DIFF
--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -125,8 +125,7 @@ module Requests
     # move this to requestable object
     # Default pickups should be available
     def pickup_choices requestable, default_pickups
-
-      unless (requestable.pickup_locations.nil? && !requestable.on_order?) || requestable.charged? || (requestable.services.include? 'on_shelf') #(requestable.services & self.default_pickup_services).empty?
+      unless requestable.pickup_locations.nil? || requestable.charged? || (requestable.services.include? 'on_shelf') #(requestable.services & self.default_pickup_services).empty?
         class_list = "well collapse in request--print"
         if requestable.services.include?('recap_edd')
             class_list = "well collapse request--print"
@@ -146,9 +145,7 @@ module Requests
 
     def available_pickups requestable, default_pickups
       locs = []
-      if !(requestable.services & self.default_pickup_services).empty?
-        locs = default_pickups
-      elsif(requestable.services.include? 'trace')
+      if(requestable.services.include? 'trace')
         locs = default_pickups
       elsif requestable.pickup_locations.nil?
         locs = default_pickups

--- a/app/views/requests/request/_form.html.erb
+++ b/app/views/requests/request/_form.html.erb
@@ -29,7 +29,7 @@
         <% unless @request.holdings[mfhd]["location_has"].nil? %>
             <div>
               <h3>Location has: </h3>
-            </td>
+            </div>
             <p>
               <% @request.holdings[mfhd]["location_has"].each do |loc| %>
                 <%= loc %><br/>
@@ -62,7 +62,6 @@
                   <%= status_label requestable %>
                 </td>
               <td class='request--options'>
-            
                 <% if requestable.ill_eligible? %>
                   <span class="ill-data" data-ill-url="<%= requestable.illiad_request_url(@request.ctx, requestable) %>"></span>
                 <% end %>

--- a/app/views/requests/request/_form.html.erb
+++ b/app/views/requests/request/_form.html.erb
@@ -62,7 +62,7 @@
                   <%= status_label requestable %>
                 </td>
               <td class='request--options'>
-
+            
                 <% if requestable.ill_eligible? %>
                   <span class="ill-data" data-ill-url="<%= requestable.illiad_request_url(@request.ctx, requestable) %>"></span>
                 <% end %>


### PR DESCRIPTION
... otherwise lists default pickup locations
Fixes #74 