### PR TITLE
WIP - Make umlaut-panel unhidden by default.

### DIFF
--- a/app/views/requests/request/_form.html.erb
+++ b/app/views/requests/request/_form.html.erb
@@ -1,5 +1,5 @@
 <% if @user.guest && @patron.blank? %>
-  <%= simple_form_for(:request, { url: "/requests/#{@request.requestable.first.bib['id']}", method: :post} ) do |l| %>
+  <%= simple_form_for(:request, { url: "/requests/#{@request.requestable.first.bib['id']}", method: :post, html: { id: 'access_form'} } ) do |l| %>
     <%= render partial: 'user_login_options', locals: { l: l } %>
   <% end %>
 <% else %>

--- a/app/views/requests/request/_umlaut_services.html.erb
+++ b/app/views/requests/request/_umlaut_services.html.erb
@@ -29,9 +29,9 @@
             bd_link = $(html).find("a.bd-direct-link").attr("href")
             jQuery('body').data( "bd", { link: bd_link } );
             // comments out display issues with BD
-            // jQuery('.umlaut-services').hide();
-            // jQuery('table.request--available_items').show();
-            // jQuery('.submit--request').show();
+            jQuery('.umlaut-services').hide();
+            jQuery('table.request--available_items').show();
+            jQuery('.submit--request').show();
           }
         }
       });
@@ -39,9 +39,9 @@
     });
     </script>
     <div class='umlaut-services'>
-      <div id="borrow_direct" class='availability--panel availability_borrow-direct availability--panel_umlaut'>
+      <div id="borrow_direct" class='availability--panel availability_borrow-direct'>
         <p>
-          <img style="display:inline-block" src="/assets/requests/spinner.gif"/>
+          <img style="display:inline-block" src="<%= asset_path('requests/spinner.gif') %>"/>
           Checking BorrowDirect availablility for you.
         </p>
       </div>


### PR DESCRIPTION
@sdellis This gets things displaying again. CSS rule used for other umlaut integrations on the OL show page was hiding the form. 

This interaction needs some work. The delay on the API varies so much the user spends a lot of time waiting on their area of primary focus. I'm not opposed to abandoning in in lieu of the API.  Before you take a further look at this branch make sure to update the copy of https://github.com/pulibrary/orangelight/tree/delivery_locations this engine is being mounted in. 

If you do want to try the API the gem is at https://github.com/jrochkind/borrow_direct. @tampakis can provide you with the API key if you want it. Other set-up information is already in borrow_direct.rb initializer in Orangelight. 