### PR TITLE
adds message to see circ desk for cas user without barcode

### DIFF
--- a/app/views/requests/request/_cas_user_no_barcode.html.erb
+++ b/app/views/requests/request/_cas_user_no_barcode.html.erb
@@ -1,0 +1,3 @@
+<div class="row alert alert-warning">
+  <%= I18n.t("requests.account.cas_user_no_barcode_msg") %>
+</div>

--- a/app/views/requests/request/_form.html.erb
+++ b/app/views/requests/request/_form.html.erb
@@ -2,6 +2,8 @@
   <%= simple_form_for(:request, { url: "/requests/#{@request.requestable.first.bib['id']}", method: :post, html: { id: 'logins'}} ) do |l| %>
     <%= render partial: 'user_login_options', locals: { l: l } %>
   <% end %>
+<% elsif !@user.guest && @patron['barcode'].blank? %>
+    <%= render partial: 'cas_user_no_barcode' %>
 <% else %>
 <%= simple_form_for(:request, { url: '/requests/submit', method: :post, remote: true} ) do |f| %>
   <%= hidden_fields_request @request %>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -92,3 +92,4 @@ en:
       logged_in: "Logged in as:"
       other_user_login_msg: "I don't have a NetID or a Barcode."
       pul_user_service_msg: 'Princeton Faculty, Staff, and Students need to sign in to see Borrow Direct Services'
+      cas_user_no_barcode_msg: 'You must register with the library and obtain a barcode before you can request materials. Please contact the Circulation Desk for details.'


### PR DESCRIPTION
This assumes that the barcode field coming back from bibdata is `blank?` (either nil or empty string) but the user is not a guest.