### PR TITLE
Use ruby 2.3 parser in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,9 +3,15 @@ inherit_gem:
 
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.3
+
 Bundler/DuplicatedGem:
   Exclude:
     - 'Gemfile'
 
 RSpec/MultipleExpectations:
   Max: 5
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -509,3 +509,16 @@ Style/ZeroLengthPredicate:
   Exclude:
     - 'app/models/requests/request.rb'
     - 'app/models/requests/requestable.rb'
+
+Style/SafeNavigation:
+  Exclude:
+    - 'app/helpers/requests/application_helper.rb'
+    - 'app/models/concerns/requests/aeon.rb'
+
+Style/NumericPredicate:
+  Exclude:
+    - 'app/helpers/requests/application_helper.rb'
+    - 'app/models/requests/request.rb'
+    - 'app/models/requests/requestable.rb'
+    - 'spec/models/requests/submission_spec.rb'
+    - 'spec/spec_helper.rb'


### PR DESCRIPTION
Target ruby 2.3 in rubocop. Resolves an annoying message from rubocop and is more appropriate since we are using versions 2.3 and greater. See #168.