### PR TITLE
fixes #185

### DIFF
--- a/app/controllers/requests/request_controller.rb
+++ b/app/controllers/requests/request_controller.rb
@@ -134,6 +134,10 @@ module Requests
             success_message = I18n.t('requests.submit.in_process_success')
           end
 
+          if @submission.service_types.include? 'pres'
+            success_message = I18n.t('requests.submit.pres_success')
+          end
+
           @services.each do |service|
             service.errors.each do |error|
               service_errors << error
@@ -150,6 +154,9 @@ module Requests
             unless bd
               @submission.service_types.each do |type|
                 Requests::RequestMailer.send("#{type}_email", @submission).deliver_now
+                if ['on_order', 'in_process', 'pres'].include? type
+                  Requests::RequestMailer.send("#{type}_confirmation", @submission).deliver_now
+                end
               end
             end
           }

--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -164,14 +164,14 @@ module Requests
         end
         # id = requestable.item? ? requestable.item['id'] : requestable.holding['id']
         content_tag(:div, id: "fields-print__#{requestable.preferred_request_id}", class: class_list) do
-          if (requestable.services & ['on_order', 'in_process']).empty?
-            locs = self.available_pickups(requestable, default_pickups)
-          else
+          if requestable.pending?
             if requestable.location[:holding_library].blank?
               locs = [{ label: requestable.location[:library][:label], gfa_code: gfa_lookup(requestable.location[:library][:code]), staff_only: false }]
             else
               locs = [{ label: requestable.location[:holding_library][:label], gfa_code: gfa_lookup(requestable.location[:holding_library][:code]), staff_only: false }]
             end
+          else
+            locs = self.available_pickups(requestable, default_pickups)
           end
           if locs.size > 1
             concat select_tag "requestable[][pickup]", options_for_select(locs.map { |loc| [loc[:label], loc[:gfa_code]] }), prompt: I18n.t("requests.default.pickup_placeholder")

--- a/app/mailers/requests/request_mailer.rb
+++ b/app/mailers/requests/request_mailer.rb
@@ -14,10 +14,17 @@ module Requests
     def pres_email(submission)
       @submission = submission
       destination_email = I18n.t('requests.pres.email')
-      cc_email = [@submission.email]
       @url = 'http://example.com/login'
       mail(to: destination_email,
-           cc: cc_email,
+           from: @submission.email,
+           subject: subject_line(I18n.t('requests.pres.email_subject'), @submission.user_barcode))
+    end
+
+    def pres_confirmation(submission)
+      @submission = submission
+      destination_email = @submission.email
+      @url = 'http://example.com/login'
+      mail(to: destination_email,
            from: destination_email,
            subject: subject_line(I18n.t('requests.pres.email_subject'), @submission.user_barcode))
     end
@@ -47,10 +54,17 @@ module Requests
     def on_order_email(submission)
       @submission = submission
       destination_email = I18n.t('requests.default.email_destination')
-      cc_email = [@submission.email]
       @url = 'http://example.com/login'
       mail(to: destination_email,
-           cc: cc_email,
+           from: destination_email,
+           subject: subject_line(I18n.t('requests.on_order.email_subject'), @submission.user_barcode))
+    end
+
+    def on_order_confirmation(submission)
+      @submission = submission
+      destination_email = @submission.email
+      @url = 'http://example.com/login'
+      mail(to: destination_email,
            from: destination_email,
            subject: subject_line(I18n.t('requests.on_order.email_subject'), @submission.user_barcode))
     end
@@ -58,10 +72,17 @@ module Requests
     def in_process_email(submission)
       @submission = submission
       destination_email = I18n.t('requests.default.email_destination')
-      cc_email = [@submission.email]
       @url = 'http://example.com/login'
       mail(to: destination_email,
-           cc: cc_email,
+           from: destination_email,
+           subject: subject_line(I18n.t('requests.in_process.email_subject'), @submission.user_barcode))
+    end
+
+    def in_process_confirmation(submission)
+      @submission = submission
+      destination_email = @submission.email
+      @url = 'http://example.com/login'
+      mail(to: destination_email,
            from: destination_email,
            subject: subject_line(I18n.t('requests.in_process.email_subject'), @submission.user_barcode))
     end

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -175,6 +175,14 @@ module Requests
       services.include?('trace') ? true : false
     end
 
+    def pending?
+      if on_order? || in_process? || preservation?
+        true
+      else
+        false
+      end
+    end
+
     def ill_eligible?
       # return true if services.include?('ill')
       services.include?('ill') ? true : false

--- a/app/views/requests/request_mailer/in_process_confirmation.text.erb
+++ b/app/views/requests/request_mailer/in_process_confirmation.text.erb
@@ -1,0 +1,8 @@
+==============================================
+In Process Request
+
+<%= I18n.t('requests.in_process.patron_conf_msg') %>
+
+<%= render 'patron_info' %>
+<%= render 'bib_info' %>
+<%= render 'item_info' %>

--- a/app/views/requests/request_mailer/on_order_confirmation.text.erb
+++ b/app/views/requests/request_mailer/on_order_confirmation.text.erb
@@ -1,0 +1,8 @@
+==============================================
+On Order Request
+
+<%= I18n.t('requests.on_order.patron_conf_msg') %>
+
+<%= render 'patron_info' %>
+<%= render 'bib_info' %>
+<%= render 'item_info' %>

--- a/app/views/requests/request_mailer/pres_confirmation.text.erb
+++ b/app/views/requests/request_mailer/pres_confirmation.text.erb
@@ -1,0 +1,8 @@
+==============================================
+Preservation Office Request
+
+<%= I18n.t('requests.pres.patron_conf_msg') %>
+
+<%= render 'patron_info' %>
+<%= render 'bib_info' %>
+<%= render 'item_info' %>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -16,6 +16,7 @@ en:
       recall_success: "You have successfully placed a recall. The item may not be available for pickup for several weeks, at which point you will be notified. See confirmation email with details about when your item(s) will be available."
       bd_success: "Request submitted to BorrowDirect. You can expect delivery within four business days or less. See confirmation email with details about when your item(s) will be available."
       on_order_success: "Request of On Order item submitted. We will notify you when this item is available."
+      pres_success: "Request of Preservation item submitted. We will notify you when the preservation work is complete and this item is available."
       in_process_success: "Request of In Process item submitted. We will notify you when this item is available."
       annex_success: "Annex item has been Requested."
       annexa_success: "Annex item has been Requested."
@@ -44,7 +45,8 @@ en:
       email: "fstcirc@princeton.edu"
       email_subject: "Preservation Office Request"
       brief_msg: "Item in Preservation Office."
-      email_conf_msg: "You will be notified via email when your item is ready for pickup from the Preservation Office."
+      email_conf_msg: "The following Preservation item has been requested:"
+      patron_conf_msg: "You will be notified via email when your item is ready for pickup from the Preservation Office."
     on_shelf:
       brief_msg: "Item on Shelf. Consult shelf location map."
       access_msg: 'Access Users must obtain a pass to enter the Library.'
@@ -52,7 +54,8 @@ en:
       email: "fstcirc@princeton.edu"
       email_subject: "On Order Request"
       brief_msg: "On Order books have not yet been received. Place a request to be notified when this item has arrived and is ready for your pickup."
-      email_conf_msg: "On Order books have not yet been received. Place a request to be notified when this item has arrived."
+      email_conf_msg: "The following On Order item has been requested:"
+      patron_conf_msg: "On Order books have not yet been received by the library. You have placed a request to be notified when this item has arrived."
       access_msg: 'Access Users are not eligible for On Order requests.'
     paging:
       email_subject: "Firestone Library Paging Request"
@@ -91,7 +94,8 @@ en:
       email: "fstcirc@princeton.edu"
       email_subject: "In Process Request"
       brief_msg: "In Process materials are typically available in several business days."
-      email_conf_msg: "In Process materials can typically be picked up at the Circulation Desk of your choice in several business days. You will receive an email notification when the material is available."
+      email_conf_msg: "The following In Process materials have been requested:"
+      patron_conf_msg: "In Process materials can typically be picked up at the Circulation Desk of your choice in several business days. You will receive an email notification when the material is available."
       access_msg: 'Access Users are not eligible for In Process requests.'
     aeon:
       brief_msg: "Item available for Use in Reading Room Only. Request at least 24 hours in advance."

--- a/spec/mailers/requests/request_mailer_spec.rb
+++ b/spec/mailers/requests/request_mailer_spec.rb
@@ -67,12 +67,65 @@ describe Requests::RequestMailer, :type => :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t('requests.pres.email_subject'))
       expect(mail.to).to eq([I18n.t('requests.pres.email')])
-      expect(mail.cc).to eq([submission_for_preservation.email])
-      expect(mail.from).to eq([I18n.t('requests.pres.email')])
+      expect(mail.from).to eq([submission_for_preservation.email])
     end
 
     it "renders the body" do
       expect(mail.body.encoded).to have_content I18n.t('requests.pres.email_conf_msg')
+    end
+  end
+
+  context "send preservation email patron confirmation" do
+    let(:requestable) {
+      [
+        {
+          "selected" => "true",
+          "mfhd" => "9533612",
+          "call_number" => "TR465 .C666 2016",
+          "location_code" => "pres",
+          "item_id" => "3059236",
+          "barcode" => "32101044283008",
+          "copy_number" => "0",
+          "status" => "Not Charged",
+          "type" => "pres",
+          "pickup" => "PA"
+        }.with_indifferent_access,
+        {
+          "selected" => "false"
+        }.with_indifferent_access
+      ]
+    }
+    let(:bib) {
+      {
+        "id" => "9712355",
+        "title" => "The atlas of water damage on inkjet-printed fine art /",
+        "author" => "Connor, Meghan Burge, Daniel Rochester Institute of Technology"
+      }
+    }
+    let(:params) {
+      {
+        request: user_info,
+        requestable: requestable,
+        bib: bib
+      }
+    }
+
+    let(:submission_for_preservation) {
+      Requests::Submission.new(params)
+    }
+
+    let(:mail) {
+      Requests::RequestMailer.send("pres_confirmation", submission_for_preservation).deliver_now
+    }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t('requests.pres.email_subject'))
+      expect(mail.to).to eq([submission_for_preservation.email])
+      expect(mail.from).to eq([submission_for_preservation.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to have_content I18n.t('requests.pres.patron_conf_msg')
     end
   end
 
@@ -226,12 +279,61 @@ describe Requests::RequestMailer, :type => :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t('requests.on_order.email_subject'))
       expect(mail.to).to eq([I18n.t('requests.default.email_destination')])
-      expect(mail.cc).to eq([submission_for_on_order.email])
       expect(mail.from).to eq([I18n.t('requests.default.email_destination')])
     end
 
     it "renders the body" do
       expect(mail.body.encoded).to have_content I18n.t('requests.on_order.email_conf_msg')
+    end
+  end
+
+  context "send on_order email patron confirmation" do
+    let(:requestable) {
+      [
+        {
+          "selected" => "true",
+          "mfhd" => "9878235",
+          "location_code" => "j",
+          "item_id" => "10081566",
+          "status" => "On-Order",
+          "pickup" => "PA"
+        }.with_indifferent_access,
+        {
+          "selected" => "false"
+        }.with_indifferent_access
+      ]
+    }
+    let(:bib) {
+      {
+        "id" => "10081566",
+        "title" => "Amidakujishiki Goto Seimei shinpojiumu=zadan hen アミダクジ式ゴトウメイセイ【シンポジウム＝座談篇】",
+        "author" => "Goto, Seimei"
+      }.with_indifferent_access
+    }
+    let(:params) {
+      {
+        request: user_info,
+        requestable: requestable,
+        bib: bib
+      }
+    }
+
+    let(:submission_for_on_order) {
+      Requests::Submission.new(params)
+    }
+
+    let(:mail) {
+      Requests::RequestMailer.send("on_order_confirmation", submission_for_on_order).deliver_now
+    }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t('requests.on_order.email_subject'))
+      expect(mail.to).to eq([submission_for_on_order.email])
+      expect(mail.from).to eq([submission_for_on_order.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to have_content I18n.t('requests.on_order.patron_conf_msg')
     end
   end
 
@@ -280,12 +382,64 @@ describe Requests::RequestMailer, :type => :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t('requests.in_process.email_subject'))
       expect(mail.to).to eq([I18n.t('requests.default.email_destination')])
-      expect(mail.cc).to eq([submission_for_in_process.email])
       expect(mail.from).to eq([I18n.t('requests.default.email_destination')])
     end
 
     it "renders the body" do
       expect(mail.body.encoded).to have_content I18n.t('requests.in_process.email_conf_msg')
+    end
+  end
+
+  context "send in_process email patron confirmation" do
+    let(:requestable) {
+      [
+        {
+          "selected" => "true",
+          "mfhd" => "9479064",
+          "call_number" => "PQ8098.429.E58 C37 2015",
+          "location_code" => "f",
+          "item_id" => "7384386",
+          "barcode" => "32101098590092",
+          "copy_number" => "0",
+          "status" => "Not Charged",
+          "type" => "in_process"
+        }.with_indifferent_access,
+        {
+          "selected" => "false"
+        }.with_indifferent_access
+      ]
+    }
+    let(:bib) {
+      {
+        "id" => "9646099",
+        "title" => "Cartas romanas /",
+        "author" => "Serrano del Pozo, Ignacio"
+      }.with_indifferent_access
+    }
+    let(:params) {
+      {
+        request: user_info,
+        requestable: requestable,
+        bib: bib
+      }
+    }
+
+    let(:submission_for_in_process) {
+      Requests::Submission.new(params)
+    }
+
+    let(:mail) {
+      Requests::RequestMailer.send("in_process_confirmation", submission_for_in_process).deliver_now
+    }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t('requests.in_process.email_subject'))
+      expect(mail.to).to eq([submission_for_in_process.email])
+      expect(mail.from).to eq([submission_for_in_process.email])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to have_content I18n.t('requests.in_process.patron_conf_msg')
     end
   end
 


### PR DESCRIPTION
All messages are "stubs" that the Circulation department should confirm or customize accordingly.

This PR also adds Preservation use case to #188, limiting delivery locations to the holding library for pres, on_order, and in_process items.