### PR TITLE
Aeon mfhd param

### DIFF
--- a/app/models/concerns/requests/aeon.rb
+++ b/app/models/concerns/requests/aeon.rb
@@ -45,12 +45,20 @@ module Requests
     def aeon_openurl(ctx)
       if has_item_data?
         ctx.referent.set_metadata('iteminfo5', item[:id].to_s)
+      else
+        ctx.referent.set_metadata('iteminfo5', nil)
       end
       if enumerated?
         ctx.referent.set_metadata('volume', item[:enum])
         if item[:chron].present?
           ctx.referent.set_metadata('issue', item[:chron])
         end
+      elsif holding.first.last['location_has']
+        ctx.referent.set_metadata('volume', holding.first.last['location_has'].first)
+        ctx.referent.set_metadata('issue', nil)
+      else
+        ctx.referent.set_metadata('volume', nil)
+        ctx.referent.set_metadata('issue', nil)
       end
       aeon_params = aeon_basic_params
       if barcode?

--- a/app/models/concerns/requests/aeon.rb
+++ b/app/models/concerns/requests/aeon.rb
@@ -100,9 +100,7 @@ module Requests
     private
 
       def call_number
-        unless bib[:call_number_display].nil?
-          bib[:call_number_display].first
-        end
+        holding.first.last['call_number']
       end
 
       def pub_date

--- a/spec/factories/requests/request.rb
+++ b/spec/factories/requests/request.rb
@@ -230,4 +230,12 @@ FactoryGirl.define do
     user { FactoryGirl.build(:user) }
     initialize_with { new({ system_id: system_id, user: user, mfhd: mfhd_id, source: source }) }
   end
+
+  factory :request_aeon_holding_volume_note, class: 'Requests::Request' do
+    system_id 616086
+    mfhd_id '5132984'
+    source 'pulsearch'
+    user { FactoryGirl.build(:user) }
+    initialize_with { new({ system_id: system_id, user: user, mfhd: mfhd_id, source: source }) }
+  end
 end

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -414,12 +414,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
         expect(requestable.aeon_basic_params[:Site]).to eq('RBSC')
       end
 
-      it 'shouuld have a Referennce NUmber' do
+      it 'should have a Reference NUmber' do
         expect(requestable.aeon_basic_params.key? :ReferenceNumber).to be true
         expect(requestable.aeon_basic_params[:ReferenceNumber]).to eq(requestable.bib[:id])
       end
 
-      it 'shouuld have Location Param' do
+      it 'should have Location Param' do
        expect(requestable.aeon_basic_params.key? :Location).to be true
        expect(requestable.aeon_basic_params[:Location]).to eq(requestable.holding.first.last['location_code'])
      end
@@ -656,6 +656,21 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
 
       it "should NOT have ILL request service available" do
         expect(requestable_charged.services.include?('ill')).to be false
+      end
+    end
+  end
+  context 'A requestable item from a RBSC holding without an item record, but holding volume info' do
+    let(:user) { FactoryGirl.build(:user) }
+    let(:request) { FactoryGirl.build(:request_aeon_holding_volume_note) }
+    let(:requestable) { request.requestable.select { |m| m.holding.first.first == '5132984' }.first }
+    let(:aeon_ctx) { requestable.aeon_openurl(request.ctx) }
+    describe '#aeon_openurl' do
+      it 'includes the location_has note as the volume' do
+        expect(aeon_ctx).to include('rft.volume=vol.2')
+      end
+
+      it 'includes the call number of the holding' do
+        expect(aeon_ctx).to include('CallNumber=30.3.2')
       end
     end
   end


### PR DESCRIPTION
Updates the aeon request openurl:
 - CallNumber: Rather than passing over the bib record call number, use the call number from the holding record
 - rft.volume: Passes over the holding record location_has field if there isn't an item record associated with the request

Fixes a bug where the ctx object would carry over metadata values from other requestable objects (iteminfo5, volume, issue)