### PR TITLE
Update Pickup Location Sort Algorithm

### DIFF
--- a/app/models/concerns/requests/bibdata.rb
+++ b/app/models/concerns/requests/bibdata.rb
@@ -54,18 +54,23 @@ module Requests
     ## Accepts an array of location hashes and sorts them according to our quirks
     def sort_pickups locs
       # staff only locations go at the bottom of the list and Firestone to the top
-      locs.sort_by! { |loc| loc[:staff_only] ? 0 : 1 }
-      locs.each do |loc|
-        if loc[:staff_only]
-          loc[:label] = loc[:label] + " (Staff Only)"
-        end
-      end
-      locs.reverse!
-      firestone = locs.find { |loc| loc[:label] == "Firestone Library" }
+
+      public_locs = locs.select { |loc| loc[:staff_only] == false }
+      public_locs.sort_by! { |loc| loc[:label] }
+
+      firestone = public_locs.find { |loc| loc[:label] == "Firestone Library" }
       unless firestone.nil?
-        locs.insert(0, locs.delete_at(locs.index(firestone)))
+        public_locs.insert(0, public_locs.delete_at(public_locs.index(firestone)))
       end
-      locs
+
+      staff_locs = locs.select { |loc| loc[:staff_only] == true }
+      staff_locs.sort_by! { |loc| loc[:label] }
+
+      staff_locs.each do |loc|
+        loc[:label] = loc[:label] + " (Staff Only)"
+      end
+
+      public_locs + staff_locs
     end
   end
 end

--- a/app/models/concerns/requests/bibdata.rb
+++ b/app/models/concerns/requests/bibdata.rb
@@ -69,7 +69,6 @@ module Requests
       staff_locs.each do |loc|
         loc[:label] = loc[:label] + " (Staff Only)"
       end
-
       public_locs + staff_locs
     end
   end

--- a/app/models/requests/request.rb
+++ b/app/models/requests/request.rb
@@ -355,7 +355,7 @@ module Requests
       pickup_locations = []
       Requests::BibdataService.delivery_locations.values.each do |pickup|
         if pickup["pickup_location"] == true
-          pickup_locations << { label: pickup["label"], gfa_code: pickup["gfa_pickup"] }
+          pickup_locations << { label: pickup["label"], gfa_code: pickup["gfa_pickup"], staff_only: pickup["staff_only"] }
         end
       end
       # pickup_locations.sort_by! { |loc| loc[:label] }

--- a/spec/cassettes/request_features.yml
+++ b/spec/cassettes/request_features.yml
@@ -52,7 +52,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk0OTMzMTgiLCJhdXRob3JfZGlzcGxheSI6WyJTYW1ozKNhzIRuLCBOYWphzIR0Iiwi2LPZhdit2KfZhtiMINmG2KzYp9ip2IwiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FtaMyjYcyEbiwgTmFqYcyEdCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcItiz2YXYrdin2YbYjCDZhtis2KfYqdiMXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNhbWjMo2HMhG4sIE5hamHMhHRcIn0iLCJhdXRob3JfcyI6WyJTYW1ozKNhzIRuLCBOYWphzIR0Iiwi2LPZhdit2KfZhtiMINmG2KzYp9ip2IwiXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIlNhbWjMo2HMhG4sIE5hamHMhHQiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjCIsIsq7QXdhzIR0zKNpZiBtYWRmdcyEbmFoIC8gTmFqYcyEdCBhbC1TYW1ozKNhzIRuLiIsIlNob3J0IHN0b3JpZXMsIEFyYWJpYyJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Isq7QXdhzIR0zKNpZiBtYWRmdcyEbmFoIC8gTmFqYcyEdCBhbC1TYW1ozKNhzIRuLiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6Iti52YjYp9i32YEg2YXYr9mB2YjZhtipIC8g2YbYrNin2Kkg2KfZhNiz2YXYrdin2YYuIiwidGl0bGVfdCI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIE5hamHMhHQgYWwtU2FtaMyjYcyEbi4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIiwi2LnZiNin2LfZgSDZhdiv2YHZiNmG2KkgLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiyrtBd2HMhHTMo2lmIG1hZGZ1zIRuYWggLyBOYWphzIR0IGFsLVNhbWjMo2HMhG4uIiwi2LnZiNin2LfZgSDZhdiv2YHZiNmG2KkgLyDZhtis2KfYqSDYp9mE2LPZhdit2KfZhi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJhbC1RYcyEaGlyYWggOiBEYcyEciBhbC1LaXRhzIRiIGFsLUjMo2FkacyEdGgsIDIwMTYuIiwi2KfZhNmC2KfZh9ix2KkgOiDYr9in2LEg2KfZhNmD2KrYp9ioINin2YTYrdiv2YrYq9iMIDIwMTYuIl0sInB1Yl9jcmVhdGVkX3MiOlsiYWwtUWHMhGhpcmFoIDogRGHMhHIgYWwtS2l0YcyEYiBhbC1IzKNhZGnMhHRoLCAyMDE2LiIsItin2YTZgtin2YfYsdipIDog2K/Yp9ixINin2YTZg9iq2KfYqCDYp9mE2K3Yr9mK2KvYjCAyMDE2LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJhbC1RYcyEaGlyYWg6IERhzIRyIGFsLUtpdGHMhGIgYWwtSMyjYWRpzIR0aCIsItin2YTZgtin2YfYsdipOiDYr9in2LEg2KfZhNmD2KrYp9ioINin2YTYrdiv2YrYq9iMIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNiJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE2LCJjYXRhbG9nZWRfdGR0IjoiMjAxNi0wMS0xOVQxMzo0OTozN1oiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjIzMCBwYWdlcyA7IDIwIGNtIl0sImRlc2NyaXB0aW9uX3QiOlsiMjMwIHBhZ2VzIDsgMjAgY20iXSwibm90ZXNfZGlzcGxheSI6WyJTaG9ydCBzdG9yaWVzLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJBcmFiaWMiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImFyYSJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU2hvcnQgc3RvcmllcywgQXJhYmlj4oCUMjFzdCBjZW50dXJ5Il0sInN1YmplY3RfdCI6WyJTaG9ydCBzdG9yaWVzLCBBcmFiaWPigJQyMXN0IGNlbnR1cnkiXSwic3ViamVjdF9mYWNldCI6WyJTaG9ydCBzdG9yaWVzLCBBcmFiaWPigJQyMXN0IGNlbnR1cnkiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODk3NzM1MDY4MjciLCI5NzczNTA2ODI3Il0sImlzYm5fcyI6WyI5Nzg5NzczNTA2ODI3Il0sImlzYm5fdCI6WyI5Nzg5NzczNTA2ODI3Il0sIm9jbGNfcyI6WyI5MzUyMTkzMTAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjkzNTIxOTMxMCIsIjk3ODk3NzM1MDY4MjciXSwic3ViamVjdF9lcmFfZmFjZXQiOlsiMjFzdCBjZW50dXJ5Il0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTM1MTk2N1wiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiUEo3OTYyLkE1NDk1IEE5NSAyMDE2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIlBKNzk2Mi5BNTQ5NSBBOTUgMjAxNlwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJsb2NhdGlvbiI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTYW1ozKNhzIRuLCBOYWphzIR0LiDKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCIsItiz2YXYrdin2YbYjCDZhtis2KfYqdiMLiDYudmI2KfYt9mBINmF2K/ZgdmI2YbYqSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIlBKNzk2Mi5BNTQ5NSBBOTUgMjAxNiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJQSjc5NjIuQTU0OTUgQTk1IDIwMTYiXSwidGltZXN0YW1wIjoiMjAxNy0wMy0yM1QyMToxMDowNi42ODdaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 01:52:23 GMT
 - request:
     method: get
@@ -102,7 +102,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9351967":{"more_items":false,"location":"rcppa","copy_number":0,"item_id":7303228,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 01:52:23 GMT
 - request:
     method: get
@@ -152,7 +152,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101095798938","id":7303228,"location":"rcppa","copy_number":0,"item_sequence_number":0,"status":"Not
         Charged","label":"ReCAP"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 01:52:23 GMT
 - request:
     method: get
@@ -222,7 +222,7 @@ http_interactions:
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services, Holdings Management","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 01:52:23 GMT
 - request:
     method: get
@@ -276,7 +276,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwiYXV0aG9yX3MiOlsiQXNzb2NpYXRpb24gZGVzIGXMgWNyaXZhaW5zIGR1IFNlzIFuZcyBZ2FsIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiLCJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIiwiQXV0aG9ycywgQWZyaWNhbiIsIlNlbmVnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jcmVhdGVkX3MiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlbmVnYWw6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA5LTIwVDE5OjM0OjE0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsidm9sdW1lcyJdLCJkZXNjcmlwdGlvbl90IjpbInZvbHVtZXMiXSwiY29udGludWVzX2Rpc3BsYXkiOlsiRcyBY3JpdmFpbiwgam91cm5hbCBjdWx0dXJlbCBwYW5hZnJpY2FpbiJdLCJzb3VyY2VfZGVzY19ub3Rlc19kaXNwbGF5IjpbIkRlc2NyaXB0aW9uIGJhc2VkIG9uOiBIb3JzIHNlzIFyaWUgKHB1Ymxpc2hlZCBpbiAyMDE2Pyk7IHRpdGxlIGZyb20gY292ZXIuIiwiTGF0ZXN0IGlzc3VlIGNvbnN1bHRlZDogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJGcmVuY2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImZyZSJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiQXV0aG9ycywgQWZyaWNhbuKAlFBlcmlvZGljYWxzIiwiU2VuZWdhbOKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfdCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTIzVDE4OjIzOjMyLjE0N1oifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:29 GMT
 - request:
     method: get
@@ -326,7 +326,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9757511":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":7467161,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:30 GMT
 - request:
     method: get
@@ -376,7 +376,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098722844","id":7467161,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"2016","label":"ReCAP"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:30 GMT
 - request:
     method: get
@@ -430,7 +430,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwiYXV0aG9yX3MiOlsiQXNzb2NpYXRpb24gZGVzIGXMgWNyaXZhaW5zIGR1IFNlzIFuZcyBZ2FsIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiLCJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIiwiQXV0aG9ycywgQWZyaWNhbiIsIlNlbmVnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jcmVhdGVkX3MiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlbmVnYWw6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA5LTIwVDE5OjM0OjE0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsidm9sdW1lcyJdLCJkZXNjcmlwdGlvbl90IjpbInZvbHVtZXMiXSwiY29udGludWVzX2Rpc3BsYXkiOlsiRcyBY3JpdmFpbiwgam91cm5hbCBjdWx0dXJlbCBwYW5hZnJpY2FpbiJdLCJzb3VyY2VfZGVzY19ub3Rlc19kaXNwbGF5IjpbIkRlc2NyaXB0aW9uIGJhc2VkIG9uOiBIb3JzIHNlzIFyaWUgKHB1Ymxpc2hlZCBpbiAyMDE2Pyk7IHRpdGxlIGZyb20gY292ZXIuIiwiTGF0ZXN0IGlzc3VlIGNvbnN1bHRlZDogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJGcmVuY2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImZyZSJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiQXV0aG9ycywgQWZyaWNhbuKAlFBlcmlvZGljYWxzIiwiU2VuZWdhbOKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfdCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTIzVDE4OjIzOjMyLjE0N1oifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:31 GMT
 - request:
     method: get
@@ -480,7 +480,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9757511":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":7467161,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:31 GMT
 - request:
     method: get
@@ -530,7 +530,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098722844","id":7467161,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"2016","label":"ReCAP"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:31 GMT
 - request:
     method: get
@@ -600,7 +600,7 @@ http_interactions:
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services, Holdings Management","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:31 GMT
 - request:
     method: get
@@ -654,7 +654,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwiYXV0aG9yX3MiOlsiQXNzb2NpYXRpb24gZGVzIGXMgWNyaXZhaW5zIGR1IFNlzIFuZcyBZ2FsIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiLCJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIiwiQXV0aG9ycywgQWZyaWNhbiIsIlNlbmVnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jcmVhdGVkX3MiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlbmVnYWw6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA5LTIwVDE5OjM0OjE0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsidm9sdW1lcyJdLCJkZXNjcmlwdGlvbl90IjpbInZvbHVtZXMiXSwiY29udGludWVzX2Rpc3BsYXkiOlsiRcyBY3JpdmFpbiwgam91cm5hbCBjdWx0dXJlbCBwYW5hZnJpY2FpbiJdLCJzb3VyY2VfZGVzY19ub3Rlc19kaXNwbGF5IjpbIkRlc2NyaXB0aW9uIGJhc2VkIG9uOiBIb3JzIHNlzIFyaWUgKHB1Ymxpc2hlZCBpbiAyMDE2Pyk7IHRpdGxlIGZyb20gY292ZXIuIiwiTGF0ZXN0IGlzc3VlIGNvbnN1bHRlZDogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJGcmVuY2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImZyZSJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiQXV0aG9ycywgQWZyaWNhbuKAlFBlcmlvZGljYWxzIiwiU2VuZWdhbOKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfdCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTIzVDE4OjIzOjMyLjE0N1oifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:32 GMT
 - request:
     method: get
@@ -704,7 +704,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9757511":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":7467161,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:32 GMT
 - request:
     method: get
@@ -754,7 +754,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098722844","id":7467161,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"2016","label":"ReCAP"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:32 GMT
 - request:
     method: get
@@ -824,7 +824,7 @@ http_interactions:
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services, Holdings Management","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:32 GMT
 - request:
     method: get
@@ -878,7 +878,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk2NDYwOTkiLCJhdXRob3JfZGlzcGxheSI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlcnJhbm8gZGVsIFBvem8sIElnbmFjaW8iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvXCJ9IiwiYXV0aG9yX3MiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyIsIkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsIkNoaWxlYW4gbGl0ZXJhdHVyZSIsIkNoaWxlIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsInRpdGxlX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2FydGFzIHJvbWFuYXMgLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sImVkaXRpb25fZGlzcGxheSI6WyJQcmltZXJhIGVkaWNpb8yBbi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NyZWF0ZWRfcyI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FudGlhZ28gZGUgQ2hpbGU6IFJpTCBlZGl0b3JlcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTUiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNSwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTUsImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA1LTEzVDE4OjUzOjM5WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiOTEgcGFnZXMgOyAyMyBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjkxIHBhZ2VzIDsgMjMgY20iXSwic2VyaWVzX2Rpc3BsYXkiOlsiQ29sZWNjaW/MgW4gODAgbXVuZG9zLiIsIkNvbGVjY2lvbiA4MCBtdW5kb3MuIl0sIm1vcmVfaW5fdGhpc19zZXJpZXNfdCI6WyJDb2xlY2Npb8yBbiA4MCBtdW5kb3MuIl0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTGEgbm92ZWxhIGVwaXN0b2xhciBlbmNhcm5hIHNpZW1wcmUgdW4gZGVzYWZpzIFvOiBhc3VtaXIgbGEgdm96IGRlIGxvcyBwZXJzb25hamVzIGRlIG1hbmVyYSB2ZXJvc2nMgW1pbCBwYXJhIHF1ZSwgZW4gZWwgaW50ZXJjYW1iaW8sIHNlIGNvbnN0cnV5YSB1bmEgaGlzdG9yaWEuIElnbmFjaW8gU2VycmFubyBkZWwgUG96byBsbyBhc3VtZSB5IGxsZXZhIHVuIHBvY28gbWHMgXMgYWxsYcyBIHVuIGdlzIFuZXJvIHF1ZSwgYWwgbWVub3MgZGVzZGUgZWwgc2lnbG8gWFZJSSwgaGEgdGVuaWRvIGN1bHRvcmVzIGRlIHBlc28uIFRyYXNsYWRhIGEgbGEgdmllamEgUm9tYSBsYSByZWxhY2lvzIFuIGRlIGRvcyBoZXJtYW5vcyBxdWUgdmVuIGF0cmF2ZXNhZGFzIHN1cyB2aWRhcyBwb3IgbGEgZ3VlcnJhLCBsYSBwZcyBcmRpZGEgZGUgbG9zIHNlcmVzIGFtYWRvcywgbGEgYXBhcmljaW/MgW4gZGVsIGNyaXN0aWFuaXNtbywgbGEgY3Jpc2lzIGRlbCBJbXBlcmlvIHkgY2lyY3Vuc3RhbmNpYXMgdGFuIGNvbXVuZXMgY29tbyBsYSBlbmZlcm1lZGFkIHkgbGEgaW5jb21wcmVuc2lvzIFuLiBDb24gdW4gdG9ubyBlamVtcGxhciwgcXVlIGxvZ3JhIGNvbiBtYWVzdHJpzIFhIGVsIGVmZWN0byBkZSB0cmFzbGFkYXIgYWwgbGVjdG9yIGEgdW5hIHJlYWxpZGFkIGxlamFuYSwgU2VycmFubyBkZWwgUG96byBub3MgY29udmllcnRlIGVuIHRlc3RpZ29zIGRlIHVuIG11bmRvIHF1ZSBtdWVyZSB5IHJlbmFjZSBqdW50byBjb24gc3VzIHByb3RhZ29uaXN0YXMuXCItLVBhZ2UgNCBvZiBjb3Zlci4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiU3BhbmlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsic3BhIl0sInN1YmplY3RfZGlzcGxheSI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfdCI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfZmFjZXQiOlsiQ2hpbGVhbiBsaXRlcmF0dXJlIiwiQ2hpbGXigJRIaXN0b3J54oCURmljdGlvbiJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmljdGlvbi4iLCJIaXN0b3J5LiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4OTU2MDEwMjMxNyIsIjk1NjAxMDIzMTEiXSwiaXNibl9zIjpbIjk3ODk1NjAxMDIzMTciXSwiaXNibl90IjpbIjk3ODk1NjAxMDIzMTciXSwib2NsY19zIjpbIjk1NjUxNjQ1MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTU2NTE2NDUxIiwiOTc4OTU2MDEwMjMxNyJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk0NzkwNjRcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiRmlyZXN0b25lIExpYnJhcnkiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvLiBDYXJ0YXMgcm9tYW5hcyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI4VDA0OjQyOjMwLjEzMloifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:33 GMT
 - request:
     method: get
@@ -928,7 +928,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9479064":{"more_items":false,"location":"f","copy_number":0,"item_id":7384386,"on_reserve":"N","status":"In
         Process","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:33 GMT
 - request:
     method: get
@@ -978,7 +978,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098590092","id":7384386,"location":"f","copy_number":0,"item_sequence_number":1,"status":"In
         Process","label":"Firestone Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:33 GMT
 - request:
     method: get
@@ -1030,7 +1030,7 @@ http_interactions:
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
         Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:33 GMT
 - request:
     method: get
@@ -1084,7 +1084,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk2NDYwOTkiLCJhdXRob3JfZGlzcGxheSI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlcnJhbm8gZGVsIFBvem8sIElnbmFjaW8iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvXCJ9IiwiYXV0aG9yX3MiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyIsIkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsIkNoaWxlYW4gbGl0ZXJhdHVyZSIsIkNoaWxlIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsInRpdGxlX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2FydGFzIHJvbWFuYXMgLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sImVkaXRpb25fZGlzcGxheSI6WyJQcmltZXJhIGVkaWNpb8yBbi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NyZWF0ZWRfcyI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FudGlhZ28gZGUgQ2hpbGU6IFJpTCBlZGl0b3JlcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTUiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNSwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTUsImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA1LTEzVDE4OjUzOjM5WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiOTEgcGFnZXMgOyAyMyBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjkxIHBhZ2VzIDsgMjMgY20iXSwic2VyaWVzX2Rpc3BsYXkiOlsiQ29sZWNjaW/MgW4gODAgbXVuZG9zLiIsIkNvbGVjY2lvbiA4MCBtdW5kb3MuIl0sIm1vcmVfaW5fdGhpc19zZXJpZXNfdCI6WyJDb2xlY2Npb8yBbiA4MCBtdW5kb3MuIl0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTGEgbm92ZWxhIGVwaXN0b2xhciBlbmNhcm5hIHNpZW1wcmUgdW4gZGVzYWZpzIFvOiBhc3VtaXIgbGEgdm96IGRlIGxvcyBwZXJzb25hamVzIGRlIG1hbmVyYSB2ZXJvc2nMgW1pbCBwYXJhIHF1ZSwgZW4gZWwgaW50ZXJjYW1iaW8sIHNlIGNvbnN0cnV5YSB1bmEgaGlzdG9yaWEuIElnbmFjaW8gU2VycmFubyBkZWwgUG96byBsbyBhc3VtZSB5IGxsZXZhIHVuIHBvY28gbWHMgXMgYWxsYcyBIHVuIGdlzIFuZXJvIHF1ZSwgYWwgbWVub3MgZGVzZGUgZWwgc2lnbG8gWFZJSSwgaGEgdGVuaWRvIGN1bHRvcmVzIGRlIHBlc28uIFRyYXNsYWRhIGEgbGEgdmllamEgUm9tYSBsYSByZWxhY2lvzIFuIGRlIGRvcyBoZXJtYW5vcyBxdWUgdmVuIGF0cmF2ZXNhZGFzIHN1cyB2aWRhcyBwb3IgbGEgZ3VlcnJhLCBsYSBwZcyBcmRpZGEgZGUgbG9zIHNlcmVzIGFtYWRvcywgbGEgYXBhcmljaW/MgW4gZGVsIGNyaXN0aWFuaXNtbywgbGEgY3Jpc2lzIGRlbCBJbXBlcmlvIHkgY2lyY3Vuc3RhbmNpYXMgdGFuIGNvbXVuZXMgY29tbyBsYSBlbmZlcm1lZGFkIHkgbGEgaW5jb21wcmVuc2lvzIFuLiBDb24gdW4gdG9ubyBlamVtcGxhciwgcXVlIGxvZ3JhIGNvbiBtYWVzdHJpzIFhIGVsIGVmZWN0byBkZSB0cmFzbGFkYXIgYWwgbGVjdG9yIGEgdW5hIHJlYWxpZGFkIGxlamFuYSwgU2VycmFubyBkZWwgUG96byBub3MgY29udmllcnRlIGVuIHRlc3RpZ29zIGRlIHVuIG11bmRvIHF1ZSBtdWVyZSB5IHJlbmFjZSBqdW50byBjb24gc3VzIHByb3RhZ29uaXN0YXMuXCItLVBhZ2UgNCBvZiBjb3Zlci4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiU3BhbmlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsic3BhIl0sInN1YmplY3RfZGlzcGxheSI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfdCI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfZmFjZXQiOlsiQ2hpbGVhbiBsaXRlcmF0dXJlIiwiQ2hpbGXigJRIaXN0b3J54oCURmljdGlvbiJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmljdGlvbi4iLCJIaXN0b3J5LiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4OTU2MDEwMjMxNyIsIjk1NjAxMDIzMTEiXSwiaXNibl9zIjpbIjk3ODk1NjAxMDIzMTciXSwiaXNibl90IjpbIjk3ODk1NjAxMDIzMTciXSwib2NsY19zIjpbIjk1NjUxNjQ1MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTU2NTE2NDUxIiwiOTc4OTU2MDEwMjMxNyJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk0NzkwNjRcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiRmlyZXN0b25lIExpYnJhcnkiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvLiBDYXJ0YXMgcm9tYW5hcyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI4VDA0OjQyOjMwLjEzMloifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1134,7 +1134,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9479064":{"more_items":false,"location":"f","copy_number":0,"item_id":7384386,"on_reserve":"N","status":"In
         Process","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1184,7 +1184,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098590092","id":7384386,"location":"f","copy_number":0,"item_sequence_number":1,"status":"In
         Process","label":"Firestone Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1236,7 +1236,7 @@ http_interactions:
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
         Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1290,7 +1290,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk2NDYwOTkiLCJhdXRob3JfZGlzcGxheSI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlcnJhbm8gZGVsIFBvem8sIElnbmFjaW8iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvXCJ9IiwiYXV0aG9yX3MiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyIsIkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsIkNoaWxlYW4gbGl0ZXJhdHVyZSIsIkNoaWxlIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsInRpdGxlX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2FydGFzIHJvbWFuYXMgLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sImVkaXRpb25fZGlzcGxheSI6WyJQcmltZXJhIGVkaWNpb8yBbi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NyZWF0ZWRfcyI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FudGlhZ28gZGUgQ2hpbGU6IFJpTCBlZGl0b3JlcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTUiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNSwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTUsImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA1LTEzVDE4OjUzOjM5WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiOTEgcGFnZXMgOyAyMyBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjkxIHBhZ2VzIDsgMjMgY20iXSwic2VyaWVzX2Rpc3BsYXkiOlsiQ29sZWNjaW/MgW4gODAgbXVuZG9zLiIsIkNvbGVjY2lvbiA4MCBtdW5kb3MuIl0sIm1vcmVfaW5fdGhpc19zZXJpZXNfdCI6WyJDb2xlY2Npb8yBbiA4MCBtdW5kb3MuIl0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTGEgbm92ZWxhIGVwaXN0b2xhciBlbmNhcm5hIHNpZW1wcmUgdW4gZGVzYWZpzIFvOiBhc3VtaXIgbGEgdm96IGRlIGxvcyBwZXJzb25hamVzIGRlIG1hbmVyYSB2ZXJvc2nMgW1pbCBwYXJhIHF1ZSwgZW4gZWwgaW50ZXJjYW1iaW8sIHNlIGNvbnN0cnV5YSB1bmEgaGlzdG9yaWEuIElnbmFjaW8gU2VycmFubyBkZWwgUG96byBsbyBhc3VtZSB5IGxsZXZhIHVuIHBvY28gbWHMgXMgYWxsYcyBIHVuIGdlzIFuZXJvIHF1ZSwgYWwgbWVub3MgZGVzZGUgZWwgc2lnbG8gWFZJSSwgaGEgdGVuaWRvIGN1bHRvcmVzIGRlIHBlc28uIFRyYXNsYWRhIGEgbGEgdmllamEgUm9tYSBsYSByZWxhY2lvzIFuIGRlIGRvcyBoZXJtYW5vcyBxdWUgdmVuIGF0cmF2ZXNhZGFzIHN1cyB2aWRhcyBwb3IgbGEgZ3VlcnJhLCBsYSBwZcyBcmRpZGEgZGUgbG9zIHNlcmVzIGFtYWRvcywgbGEgYXBhcmljaW/MgW4gZGVsIGNyaXN0aWFuaXNtbywgbGEgY3Jpc2lzIGRlbCBJbXBlcmlvIHkgY2lyY3Vuc3RhbmNpYXMgdGFuIGNvbXVuZXMgY29tbyBsYSBlbmZlcm1lZGFkIHkgbGEgaW5jb21wcmVuc2lvzIFuLiBDb24gdW4gdG9ubyBlamVtcGxhciwgcXVlIGxvZ3JhIGNvbiBtYWVzdHJpzIFhIGVsIGVmZWN0byBkZSB0cmFzbGFkYXIgYWwgbGVjdG9yIGEgdW5hIHJlYWxpZGFkIGxlamFuYSwgU2VycmFubyBkZWwgUG96byBub3MgY29udmllcnRlIGVuIHRlc3RpZ29zIGRlIHVuIG11bmRvIHF1ZSBtdWVyZSB5IHJlbmFjZSBqdW50byBjb24gc3VzIHByb3RhZ29uaXN0YXMuXCItLVBhZ2UgNCBvZiBjb3Zlci4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiU3BhbmlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsic3BhIl0sInN1YmplY3RfZGlzcGxheSI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfdCI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfZmFjZXQiOlsiQ2hpbGVhbiBsaXRlcmF0dXJlIiwiQ2hpbGXigJRIaXN0b3J54oCURmljdGlvbiJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmljdGlvbi4iLCJIaXN0b3J5LiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4OTU2MDEwMjMxNyIsIjk1NjAxMDIzMTEiXSwiaXNibl9zIjpbIjk3ODk1NjAxMDIzMTciXSwiaXNibl90IjpbIjk3ODk1NjAxMDIzMTciXSwib2NsY19zIjpbIjk1NjUxNjQ1MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTU2NTE2NDUxIiwiOTc4OTU2MDEwMjMxNyJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk0NzkwNjRcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiRmlyZXN0b25lIExpYnJhcnkiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvLiBDYXJ0YXMgcm9tYW5hcyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI4VDA0OjQyOjMwLjEzMloifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1340,7 +1340,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9479064":{"more_items":false,"location":"f","copy_number":0,"item_id":7384386,"on_reserve":"N","status":"In
         Process","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1390,7 +1390,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098590092","id":7384386,"location":"f","copy_number":0,"item_sequence_number":1,"status":"In
         Process","label":"Firestone Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1442,7 +1442,7 @@ http_interactions:
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
         Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1496,7 +1496,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwiYXV0aG9yX2Rpc3BsYXkiOlsiR290bywgU2VpbWVpIiwi5b6M6Jek5piO55SfIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIuW+jOiXpOaYjueUn1wiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvLCBTZWltZWlcIn0iLCJhdXRob3JfcyI6WyJHb3RvLCBTZWltZWkiLCLlvozol6TmmI7nlJ8iXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSIsIuW+jOiXpOaYjueUnyIsIkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6IuOCouODn+ODgOOCr+OCuOW8j+OCtOODiOOCpuODoeOCpOOCu+OCpOOAkOOCt+ODs+ODneOCuOOCpuODoO+8neW6p+irh+evh+OAkSIsInRpdGxlX3QiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744Kk44CQ44K344Oz44Od44K444Km44Og77yd5bqn6KuH56+H44CRIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJBbWlkYWt1amlzaGlraSBHb3RvIFNlaW1laSBzaGlucG9qaXVtdT16YWRhbiBoZW4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJUb2t5byA6IFRzdWthZGFtYSBTaG9ibywgMjAxNyIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNyJdLCJwdWJfY3JlYXRlZF9zIjpbIlRva3lvIDogVHN1a2FkYW1hIFNob2JvLCAyMDE3Iiwi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRva3lvOiBUc3VrYWRhbWEgU2hvYm8iLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywiZm9ybWF0IjpbIkJvb2siXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3QiOlsiOTc4NDkwODYyNDAxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiRWFzdCBBc2lhbiBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJFYXN0IEFzaWFuIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImpcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImoiXSwibG9jYXRpb25fZGlzcGxheSI6WyJFYXN0IEFzaWFuIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRWFzdCBBc2lhbiBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiaiIsIkVhc3QgQXNpYW4gTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkdvdG8sIFNlaW1laS4gQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi5b6M6Jek5piO55SfLiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwidGltZXN0YW1wIjoiMjAxNy0wMy0yM1QyMToyODo0Ni41NTdaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1546,7 +1546,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9878235":{"more_items":false,"location":"j","status":"On-Order","label":"East
         Asian Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1597,7 +1597,7 @@ http_interactions:
       string: '{"label":"","code":"j","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"East
         Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East
         Asian Library","code":"eastasian"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1651,7 +1651,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwiYXV0aG9yX2Rpc3BsYXkiOlsiR290bywgU2VpbWVpIiwi5b6M6Jek5piO55SfIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIuW+jOiXpOaYjueUn1wiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvLCBTZWltZWlcIn0iLCJhdXRob3JfcyI6WyJHb3RvLCBTZWltZWkiLCLlvozol6TmmI7nlJ8iXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSIsIuW+jOiXpOaYjueUnyIsIkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6IuOCouODn+ODgOOCr+OCuOW8j+OCtOODiOOCpuODoeOCpOOCu+OCpOOAkOOCt+ODs+ODneOCuOOCpuODoO+8neW6p+irh+evh+OAkSIsInRpdGxlX3QiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744Kk44CQ44K344Oz44Od44K444Km44Og77yd5bqn6KuH56+H44CRIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJBbWlkYWt1amlzaGlraSBHb3RvIFNlaW1laSBzaGlucG9qaXVtdT16YWRhbiBoZW4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJUb2t5byA6IFRzdWthZGFtYSBTaG9ibywgMjAxNyIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNyJdLCJwdWJfY3JlYXRlZF9zIjpbIlRva3lvIDogVHN1a2FkYW1hIFNob2JvLCAyMDE3Iiwi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRva3lvOiBUc3VrYWRhbWEgU2hvYm8iLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywiZm9ybWF0IjpbIkJvb2siXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3QiOlsiOTc4NDkwODYyNDAxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiRWFzdCBBc2lhbiBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJFYXN0IEFzaWFuIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImpcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImoiXSwibG9jYXRpb25fZGlzcGxheSI6WyJFYXN0IEFzaWFuIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRWFzdCBBc2lhbiBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiaiIsIkVhc3QgQXNpYW4gTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkdvdG8sIFNlaW1laS4gQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi5b6M6Jek5piO55SfLiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwidGltZXN0YW1wIjoiMjAxNy0wMy0yM1QyMToyODo0Ni41NTdaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1701,7 +1701,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9878235":{"more_items":false,"location":"j","status":"On-Order","label":"East
         Asian Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1752,7 +1752,7 @@ http_interactions:
       string: '{"label":"","code":"j","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"East
         Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East
         Asian Library","code":"eastasian"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1806,7 +1806,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwiYXV0aG9yX2Rpc3BsYXkiOlsiR290bywgU2VpbWVpIiwi5b6M6Jek5piO55SfIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIuW+jOiXpOaYjueUn1wiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvLCBTZWltZWlcIn0iLCJhdXRob3JfcyI6WyJHb3RvLCBTZWltZWkiLCLlvozol6TmmI7nlJ8iXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSIsIuW+jOiXpOaYjueUnyIsIkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6IuOCouODn+ODgOOCr+OCuOW8j+OCtOODiOOCpuODoeOCpOOCu+OCpOOAkOOCt+ODs+ODneOCuOOCpuODoO+8neW6p+irh+evh+OAkSIsInRpdGxlX3QiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744Kk44CQ44K344Oz44Od44K444Km44Og77yd5bqn6KuH56+H44CRIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJBbWlkYWt1amlzaGlraSBHb3RvIFNlaW1laSBzaGlucG9qaXVtdT16YWRhbiBoZW4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJUb2t5byA6IFRzdWthZGFtYSBTaG9ibywgMjAxNyIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNyJdLCJwdWJfY3JlYXRlZF9zIjpbIlRva3lvIDogVHN1a2FkYW1hIFNob2JvLCAyMDE3Iiwi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRva3lvOiBUc3VrYWRhbWEgU2hvYm8iLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywiZm9ybWF0IjpbIkJvb2siXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3QiOlsiOTc4NDkwODYyNDAxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiRWFzdCBBc2lhbiBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJFYXN0IEFzaWFuIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImpcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImoiXSwibG9jYXRpb25fZGlzcGxheSI6WyJFYXN0IEFzaWFuIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRWFzdCBBc2lhbiBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiaiIsIkVhc3QgQXNpYW4gTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkdvdG8sIFNlaW1laS4gQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi5b6M6Jek5piO55SfLiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwidGltZXN0YW1wIjoiMjAxNy0wMy0yM1QyMToyODo0Ni41NTdaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1856,7 +1856,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9878235":{"more_items":false,"location":"j","status":"On-Order","label":"East
         Asian Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:36 GMT
 - request:
     method: get
@@ -1907,7 +1907,7 @@ http_interactions:
       string: '{"label":"","code":"j","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"East
         Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East
         Asian Library","code":"eastasian"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:36 GMT
 - request:
     method: get
@@ -1961,7 +1961,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJhdXRob3JfZGlzcGxheSI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJTY2hyb2VkZXIsIENhcm9saW5lIFQuXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkNoaW4sIENhdGhlcmluZSBNLlwifSIsImF1dGhvcl9zIjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iLCJTY2hyb2VkZXIsIENhcm9saW5lIFQuLCAxOTcxLSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIiwiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR5IiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iLCJ0aXRsZV90IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiXCJNZWxhbmlhIHRoZSBFbGRlciBhbmQgaGVyIGdyYW5kZGF1Z2h0ZXIgTWVsYW5pYSB0aGUgWW91bmdlciB3ZXJlIG1ham9yIGZpZ3VyZXMgaW4gZWFybHkgQ2hyaXN0aWFuIGhpc3RvcnksIHVzaW5nIHRoZWlyIHdlYWx0aCwgc3RhdHVzLCBhbmQgZm9yY2VmdWwgcGVyc29uYWxpdGllcyB0byBzaGFwZSB0aGUgZGV2ZWxvcG1lbnQgb2YgbmVhcmx5IGV2ZXJ5IGFzcGVjdCBvZiB0aGUgcmVsaWdpb24gd2Ugbm93IGtub3cgYXMgQ2hyaXN0aWFuaXR5LiBUaGlzIHZvbHVtZSBleGFtaW5lcyB0aGUgaW5mbHVlbmNlIHRoYXQgdGhlc2UgdHdvIHdvbWVuIGhhZCBvbiB0aGUgZGV2ZWxvcG1lbnQgb2YgQ2hyaXN0aWFuaXR5IGFuZCBwcm92aWRlcyBhbiBpbnNpZ2h0ZnVsIHBvcnRyYWl0IG9mIHRoZSB0aGVpciBsZWdhY2llcyBpbiB0aGUgbW9kZXJuIHdvcmxkLiBJbnN0ZWFkIG9mIHRoZSB0cmFkaXRpb25hbGx5IHBhdHJpYXJjaGFsIHZpZXcsIHRoaXMgcGVyc3BlY3RpdmUgZ2l2ZXMgYSBwb2lnbmFudCBhbmQgc29tZXRpbWVzIHN1cnByaXNpbmcgdmlldyBvZiBob3cgdGhlIHJpc2Ugb2YgQ2hyaXN0aWFuIGluc3RpdHV0aW9ucyBpbiB0aGUgUm9tYW4gRW1waXJlIHNoYXBlZCB0aGUgdW5kZXJzdGFuZGluZyBvZiB3b21lbidzIHJvbGVzIGluIHRoZSBsYXJnZXIgd29ybGQuXCItLVByb3ZpZGVkIGJ5IHB1Ymxpc2hlci4iXSwiYmliX3JlZl9ub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGJpYmxpb2dyYXBoaWNhbCByZWZlcmVuY2VzIGFuZCBpbmRleC4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbiBwcmludCB2ZXJzaW9uIHJlY29yZCBhbmQgQ0lQIGRhdGEgcHJvdmlkZWQgYnkgcHVibGlzaGVyOyByZXNvdXJjZSBub3Qgdmlld2VkLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwic3ViamVjdF9kaXNwbGF5IjpbIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR54oCUSGlzdG9yeSJdLCJzdWJqZWN0X3QiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKGVsZWN0cm9uaWMgYmsuKSIsIjA1MjA5NjU2MzkgKGVsZWN0cm9uaWMgYmsuKSJdLCJsY2NuX2Rpc3BsYXkiOlsiICAyMDE2MDIwMzQxIl0sImxjY25fcyI6WyIyMDE2MDIwMzQxIl0sImlzYm5fcyI6WyI5NzgwNTIwOTY1NjM4Il0sImlzYm5fdCI6WyI5NzgwNTIwOTY1NjM4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwNTIwOTY1NjM4IiwiOTc4MDUyMDI5MjA4NiJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4MDA5MTBcIjp7XCJsb2NhdGlvblwiOlwiT25saW5lIC0gT25saW5lIFJlc291cmNlc1wiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYzXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJlbGYzIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiT25saW5lIC0gT25saW5lIFJlc291cmNlcyJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImVsZjMiLCJPbmxpbmUiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItLiBNZWxhbmlhIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJFbGVjdHJvbmljIFJlc291cmNlIl0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMjE6MzI6NTguMzU0WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:36 GMT
 - request:
     method: get
@@ -2011,7 +2011,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9800910":{"more_items":false,"location":"elf3","status":"Order Received","label":"Online
         - Online Resources"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:36 GMT
 - request:
     method: get
@@ -2058,7 +2058,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 9800910 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:37 GMT
 - request:
     method: get
@@ -2107,7 +2107,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"label":"Online Resources","code":"elf3","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:37 GMT
 - request:
     method: get
@@ -2161,7 +2161,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJhdXRob3JfZGlzcGxheSI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJTY2hyb2VkZXIsIENhcm9saW5lIFQuXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkNoaW4sIENhdGhlcmluZSBNLlwifSIsImF1dGhvcl9zIjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iLCJTY2hyb2VkZXIsIENhcm9saW5lIFQuLCAxOTcxLSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIiwiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR5IiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iLCJ0aXRsZV90IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiXCJNZWxhbmlhIHRoZSBFbGRlciBhbmQgaGVyIGdyYW5kZGF1Z2h0ZXIgTWVsYW5pYSB0aGUgWW91bmdlciB3ZXJlIG1ham9yIGZpZ3VyZXMgaW4gZWFybHkgQ2hyaXN0aWFuIGhpc3RvcnksIHVzaW5nIHRoZWlyIHdlYWx0aCwgc3RhdHVzLCBhbmQgZm9yY2VmdWwgcGVyc29uYWxpdGllcyB0byBzaGFwZSB0aGUgZGV2ZWxvcG1lbnQgb2YgbmVhcmx5IGV2ZXJ5IGFzcGVjdCBvZiB0aGUgcmVsaWdpb24gd2Ugbm93IGtub3cgYXMgQ2hyaXN0aWFuaXR5LiBUaGlzIHZvbHVtZSBleGFtaW5lcyB0aGUgaW5mbHVlbmNlIHRoYXQgdGhlc2UgdHdvIHdvbWVuIGhhZCBvbiB0aGUgZGV2ZWxvcG1lbnQgb2YgQ2hyaXN0aWFuaXR5IGFuZCBwcm92aWRlcyBhbiBpbnNpZ2h0ZnVsIHBvcnRyYWl0IG9mIHRoZSB0aGVpciBsZWdhY2llcyBpbiB0aGUgbW9kZXJuIHdvcmxkLiBJbnN0ZWFkIG9mIHRoZSB0cmFkaXRpb25hbGx5IHBhdHJpYXJjaGFsIHZpZXcsIHRoaXMgcGVyc3BlY3RpdmUgZ2l2ZXMgYSBwb2lnbmFudCBhbmQgc29tZXRpbWVzIHN1cnByaXNpbmcgdmlldyBvZiBob3cgdGhlIHJpc2Ugb2YgQ2hyaXN0aWFuIGluc3RpdHV0aW9ucyBpbiB0aGUgUm9tYW4gRW1waXJlIHNoYXBlZCB0aGUgdW5kZXJzdGFuZGluZyBvZiB3b21lbidzIHJvbGVzIGluIHRoZSBsYXJnZXIgd29ybGQuXCItLVByb3ZpZGVkIGJ5IHB1Ymxpc2hlci4iXSwiYmliX3JlZl9ub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGJpYmxpb2dyYXBoaWNhbCByZWZlcmVuY2VzIGFuZCBpbmRleC4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbiBwcmludCB2ZXJzaW9uIHJlY29yZCBhbmQgQ0lQIGRhdGEgcHJvdmlkZWQgYnkgcHVibGlzaGVyOyByZXNvdXJjZSBub3Qgdmlld2VkLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwic3ViamVjdF9kaXNwbGF5IjpbIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR54oCUSGlzdG9yeSJdLCJzdWJqZWN0X3QiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKGVsZWN0cm9uaWMgYmsuKSIsIjA1MjA5NjU2MzkgKGVsZWN0cm9uaWMgYmsuKSJdLCJsY2NuX2Rpc3BsYXkiOlsiICAyMDE2MDIwMzQxIl0sImxjY25fcyI6WyIyMDE2MDIwMzQxIl0sImlzYm5fcyI6WyI5NzgwNTIwOTY1NjM4Il0sImlzYm5fdCI6WyI5NzgwNTIwOTY1NjM4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwNTIwOTY1NjM4IiwiOTc4MDUyMDI5MjA4NiJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4MDA5MTBcIjp7XCJsb2NhdGlvblwiOlwiT25saW5lIC0gT25saW5lIFJlc291cmNlc1wiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYzXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJlbGYzIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiT25saW5lIC0gT25saW5lIFJlc291cmNlcyJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImVsZjMiLCJPbmxpbmUiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItLiBNZWxhbmlhIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJFbGVjdHJvbmljIFJlc291cmNlIl0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMjE6MzI6NTguMzU0WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:37 GMT
 - request:
     method: get
@@ -2211,7 +2211,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9800910":{"more_items":false,"location":"elf3","status":"Order Received","label":"Online
         - Online Resources"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:43 GMT
 - request:
     method: get
@@ -2258,7 +2258,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 9800910 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:43 GMT
 - request:
     method: get
@@ -2307,7 +2307,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"label":"Online Resources","code":"elf3","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:43 GMT
 - request:
     method: get
@@ -2361,7 +2361,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJhdXRob3JfZGlzcGxheSI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJTY2hyb2VkZXIsIENhcm9saW5lIFQuXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkNoaW4sIENhdGhlcmluZSBNLlwifSIsImF1dGhvcl9zIjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iLCJTY2hyb2VkZXIsIENhcm9saW5lIFQuLCAxOTcxLSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIiwiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR5IiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iLCJ0aXRsZV90IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiXCJNZWxhbmlhIHRoZSBFbGRlciBhbmQgaGVyIGdyYW5kZGF1Z2h0ZXIgTWVsYW5pYSB0aGUgWW91bmdlciB3ZXJlIG1ham9yIGZpZ3VyZXMgaW4gZWFybHkgQ2hyaXN0aWFuIGhpc3RvcnksIHVzaW5nIHRoZWlyIHdlYWx0aCwgc3RhdHVzLCBhbmQgZm9yY2VmdWwgcGVyc29uYWxpdGllcyB0byBzaGFwZSB0aGUgZGV2ZWxvcG1lbnQgb2YgbmVhcmx5IGV2ZXJ5IGFzcGVjdCBvZiB0aGUgcmVsaWdpb24gd2Ugbm93IGtub3cgYXMgQ2hyaXN0aWFuaXR5LiBUaGlzIHZvbHVtZSBleGFtaW5lcyB0aGUgaW5mbHVlbmNlIHRoYXQgdGhlc2UgdHdvIHdvbWVuIGhhZCBvbiB0aGUgZGV2ZWxvcG1lbnQgb2YgQ2hyaXN0aWFuaXR5IGFuZCBwcm92aWRlcyBhbiBpbnNpZ2h0ZnVsIHBvcnRyYWl0IG9mIHRoZSB0aGVpciBsZWdhY2llcyBpbiB0aGUgbW9kZXJuIHdvcmxkLiBJbnN0ZWFkIG9mIHRoZSB0cmFkaXRpb25hbGx5IHBhdHJpYXJjaGFsIHZpZXcsIHRoaXMgcGVyc3BlY3RpdmUgZ2l2ZXMgYSBwb2lnbmFudCBhbmQgc29tZXRpbWVzIHN1cnByaXNpbmcgdmlldyBvZiBob3cgdGhlIHJpc2Ugb2YgQ2hyaXN0aWFuIGluc3RpdHV0aW9ucyBpbiB0aGUgUm9tYW4gRW1waXJlIHNoYXBlZCB0aGUgdW5kZXJzdGFuZGluZyBvZiB3b21lbidzIHJvbGVzIGluIHRoZSBsYXJnZXIgd29ybGQuXCItLVByb3ZpZGVkIGJ5IHB1Ymxpc2hlci4iXSwiYmliX3JlZl9ub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGJpYmxpb2dyYXBoaWNhbCByZWZlcmVuY2VzIGFuZCBpbmRleC4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbiBwcmludCB2ZXJzaW9uIHJlY29yZCBhbmQgQ0lQIGRhdGEgcHJvdmlkZWQgYnkgcHVibGlzaGVyOyByZXNvdXJjZSBub3Qgdmlld2VkLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwic3ViamVjdF9kaXNwbGF5IjpbIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR54oCUSGlzdG9yeSJdLCJzdWJqZWN0X3QiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKGVsZWN0cm9uaWMgYmsuKSIsIjA1MjA5NjU2MzkgKGVsZWN0cm9uaWMgYmsuKSJdLCJsY2NuX2Rpc3BsYXkiOlsiICAyMDE2MDIwMzQxIl0sImxjY25fcyI6WyIyMDE2MDIwMzQxIl0sImlzYm5fcyI6WyI5NzgwNTIwOTY1NjM4Il0sImlzYm5fdCI6WyI5NzgwNTIwOTY1NjM4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwNTIwOTY1NjM4IiwiOTc4MDUyMDI5MjA4NiJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4MDA5MTBcIjp7XCJsb2NhdGlvblwiOlwiT25saW5lIC0gT25saW5lIFJlc291cmNlc1wiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYzXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJlbGYzIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiT25saW5lIC0gT25saW5lIFJlc291cmNlcyJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImVsZjMiLCJPbmxpbmUiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItLiBNZWxhbmlhIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJFbGVjdHJvbmljIFJlc291cmNlIl0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMjE6MzI6NTguMzU0WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:43 GMT
 - request:
     method: get
@@ -2411,7 +2411,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9800910":{"more_items":false,"location":"elf3","status":"Order Received","label":"Online
         - Online Resources"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2458,7 +2458,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 9800910 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2507,7 +2507,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"label":"Online Resources","code":"elf3","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2561,7 +2561,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjU2MTc3NCIsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZVwiLFwiTmF0aW9uYWwgQWZmYWlycywgSW5jXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdfSIsImF1dGhvcl9zIjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlIiwiTmF0aW9uYWwgQWZmYWlycywgSW5jIiwiRm9yZWlnbiBwb2xpY3kuIiwiVW5pdGVkIFN0YXRlcyIsIkZvcmVpZ24gcmVsYXRpb25zIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJGb3JlaWduIHBvbGljeSAoTmV3IFlvcmssIE4uWS4pIl0sInRpdGxlX2Rpc3BsYXkiOiJGb3JlaWduIHBvbGljeS4iLCJ0aXRsZV90IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRm9yZWlnbiBwb2xpY3kuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBOYXRpb25hbCBBZmZhaXJzLCBJbmMuLCBjMTk3MC0iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IE5hdGlvbmFsIEFmZmFpcnMsIEluYy4sIGMxOTcwLSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogTmF0aW9uYWwgQWZmYWlycywgSW5jIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk3MSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTcxLCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2LiA6IGlsbC4gOyAxMXgyNiAtIDI4IGNtLiIsIk5vLiAxICh3aW50ZXIgMTk3MC83MSktIl0sImRlc2NyaXB0aW9uX3QiOlsidi4gOiBpbGwuIDsgMTF4MjYgLSAyOCBjbS4iLCJOby4gMSAod2ludGVyIDE5NzAvNzEpLSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJCaW1vbnRobHksIFNlcHQuL09jdC4gMjAwMC1cdTAwM2MyMDEwXHUwMDNlIl0sImZvcm1lcl9mcmVxdWVuY3lfZGlzcGxheSI6WyJRdWFydGVybHksIDE5NzAvNzEtXHUwMDNjZmFsbCAxOTk5XHUwMDNlIl0sIm5vdGVzX2Rpc3BsYXkiOlsiUGxhY2Ugb2YgcHVibGljYXRpb24gdmFyaWVzOiBcdTAwM2MyMDAzLTIwMTBcdTAwM2UsIFdhc2hpbmd0b24sIERDLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IDEzOSAoTm92Li9EZWMuIDIwMDMpLiJdLCJpc3N1aW5nX2JvZHlfbm90ZXNfZGlzcGxheSI6WyJQdWJsaXNoZWQgc3ByaW5nIDE5Nzctc3ByaW5nIDE5NzggaW4gYXNzb2NpYXRpb24gd2l0aDogQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlOyBzdW1tZXIgMTk3OC1cdTAwM2MyMDA3XHUwMDNlLCBieSB0aGUgRW5kb3dtZW50LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwiaW5kZXhlc19kaXNwbGF5IjpbIk5vLiAxICh3aW50ZXIgMTk3MC83MSktOCAoZmFsbCAxOTcyKS4gMSB2LiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF90IjpbIlVuaXRlZCBTdGF0ZXPigJRGb3JlaWduIHJlbGF0aW9uc+KAlDE5NDUtMTk4OeKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJDYXJuZWdpZSBFbmRvd21lbnQgZm9yIEludGVybmF0aW9uYWwgUGVhY2VcIixcIk5hdGlvbmFsIEFmZmFpcnMsIEluY1wiXX0iLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5IiwiRlAgU2VwdC4vT2N0LiAyMDAwLVx1MDAzYzIwMTBcdTAwM2UiXSwiaXNzbl9kaXNwbGF5IjpbIjAwMTUtNzIyOCJdLCJsY2NuX2Rpc3BsYXkiOlsiICAgNzM2NDE4MjUgICJdLCJsY2NuX3MiOlsiNzM2NDE4MjUiXSwiaXNzbl9zIjpbIjAwMTU3MjI4Il0sIm9jbGNfcyI6WyIxNzg1NDg5Il0sIm90aGVyX3ZlcnNpb25fcyI6WyIwMDE1NzIyOCIsIm9jbTAxNzg1NDg5Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjE5NDUtMTk4OSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjYxMjc0MFwiOntcImxvY2F0aW9uXCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjY3NDNcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRTc0NCAuRjY3NDNcIixcImxvY2F0aW9uX2hhc1wiOltcIk5vLiAxMjAgKFNlcHQuL09jdC4gMjAwMCktbm8uIDIxNSAoTm92L0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTM0LCAxNTgsIDE2MCwgMTYyLCAxNjksIDE3MiwgMTczLDE3NVwiLFwiQ1VSUkVOVCBJU1NVRVMgSU46IFBlcmlvZGljYWxzIENvbGxlY3Rpb24gKFBSKS4gRmlyZXN0b25lXCJdfSxcIjYxMjc0MVwiOntcImxvY2F0aW9uXCI6XCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzXCIsXCJsaWJyYXJ5XCI6XCJTdG9rZXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic3BpYXBzXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDEgKHdpbnRlciAxOTcwLzcxKS1uby4gMjE1IChOb3YuL0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTE2LCAxMTgsIDEyOCwgMTM0LTEzNSwgMTU0LTE1OCwgMTYxLTE2MiwgMTcyLTE3NSwgMTc3XCIsXCJDVVJSRU5UIElTU1VFUyBJTjogRG9uYWxkIEUuIFN0b2tlcyBMaWJyYXJ5IChTUElBKS4gV2FsbGFjZSBIYWxsXCJdLFwiaW5kZXhlc1wiOltcIkluZGV4LCBuby4gMS84XCJdfSxcIjYxMjc0MlwiOntcImxvY2F0aW9uXCI6XCJNdWRkIE1hbnVzY3JpcHQgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcIm11ZGRcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTk8gQk9VTkQgSE9MRElOR1NcIixcIkNVUlJFTlQgSVNTVUVTIElOOiBTZWVsZXkgRy4gTXVkZCBMaWJyYXJ5IChNdWRkKVwiXX0sXCI0NzM2NzM1XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIixcImNhbGxfbnVtYmVyXCI6XCIxMDk2LjM1MjVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTA5Ni4zNTI1XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMSAod2ludGVyIDE5NzAvNzEpLW5vLiAxMTYgKGZhbGwgMTk5OSlcIl19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIiwic3BpYXBzIiwibXVkZCIsInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiLCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzIiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJzcGlhcHMiLCJtdWRkIiwicmNwcGEiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMTY6NDQ6NDAuNDQ0WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2608,7 +2608,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 612742 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2661,7 +2661,7 @@ http_interactions:
         Charged","label":"Stokes Library - Periodicals"},"612742":{"more_items":false,"location":"mudd","status":"On-Site","label":"Mudd
         Manuscript Library"},"4736735":{"more_items":true,"location":"rcppa","copy_number":1,"item_id":703398,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2712,7 +2712,7 @@ http_interactions:
       string: '{"label":"Periodicals","code":"spiaps","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2764,7 +2764,7 @@ http_interactions:
         Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd
         Manuscript Library and University Archives","code":"mudd"},"delivery_locations":[{"label":"Mudd
         Manuscript Library","address":"65 Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2818,7 +2818,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjU2MTc3NCIsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZVwiLFwiTmF0aW9uYWwgQWZmYWlycywgSW5jXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdfSIsImF1dGhvcl9zIjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlIiwiTmF0aW9uYWwgQWZmYWlycywgSW5jIiwiRm9yZWlnbiBwb2xpY3kuIiwiVW5pdGVkIFN0YXRlcyIsIkZvcmVpZ24gcmVsYXRpb25zIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJGb3JlaWduIHBvbGljeSAoTmV3IFlvcmssIE4uWS4pIl0sInRpdGxlX2Rpc3BsYXkiOiJGb3JlaWduIHBvbGljeS4iLCJ0aXRsZV90IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRm9yZWlnbiBwb2xpY3kuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBOYXRpb25hbCBBZmZhaXJzLCBJbmMuLCBjMTk3MC0iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IE5hdGlvbmFsIEFmZmFpcnMsIEluYy4sIGMxOTcwLSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogTmF0aW9uYWwgQWZmYWlycywgSW5jIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk3MSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTcxLCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2LiA6IGlsbC4gOyAxMXgyNiAtIDI4IGNtLiIsIk5vLiAxICh3aW50ZXIgMTk3MC83MSktIl0sImRlc2NyaXB0aW9uX3QiOlsidi4gOiBpbGwuIDsgMTF4MjYgLSAyOCBjbS4iLCJOby4gMSAod2ludGVyIDE5NzAvNzEpLSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJCaW1vbnRobHksIFNlcHQuL09jdC4gMjAwMC1cdTAwM2MyMDEwXHUwMDNlIl0sImZvcm1lcl9mcmVxdWVuY3lfZGlzcGxheSI6WyJRdWFydGVybHksIDE5NzAvNzEtXHUwMDNjZmFsbCAxOTk5XHUwMDNlIl0sIm5vdGVzX2Rpc3BsYXkiOlsiUGxhY2Ugb2YgcHVibGljYXRpb24gdmFyaWVzOiBcdTAwM2MyMDAzLTIwMTBcdTAwM2UsIFdhc2hpbmd0b24sIERDLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IDEzOSAoTm92Li9EZWMuIDIwMDMpLiJdLCJpc3N1aW5nX2JvZHlfbm90ZXNfZGlzcGxheSI6WyJQdWJsaXNoZWQgc3ByaW5nIDE5Nzctc3ByaW5nIDE5NzggaW4gYXNzb2NpYXRpb24gd2l0aDogQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlOyBzdW1tZXIgMTk3OC1cdTAwM2MyMDA3XHUwMDNlLCBieSB0aGUgRW5kb3dtZW50LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwiaW5kZXhlc19kaXNwbGF5IjpbIk5vLiAxICh3aW50ZXIgMTk3MC83MSktOCAoZmFsbCAxOTcyKS4gMSB2LiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF90IjpbIlVuaXRlZCBTdGF0ZXPigJRGb3JlaWduIHJlbGF0aW9uc+KAlDE5NDUtMTk4OeKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJDYXJuZWdpZSBFbmRvd21lbnQgZm9yIEludGVybmF0aW9uYWwgUGVhY2VcIixcIk5hdGlvbmFsIEFmZmFpcnMsIEluY1wiXX0iLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5IiwiRlAgU2VwdC4vT2N0LiAyMDAwLVx1MDAzYzIwMTBcdTAwM2UiXSwiaXNzbl9kaXNwbGF5IjpbIjAwMTUtNzIyOCJdLCJsY2NuX2Rpc3BsYXkiOlsiICAgNzM2NDE4MjUgICJdLCJsY2NuX3MiOlsiNzM2NDE4MjUiXSwiaXNzbl9zIjpbIjAwMTU3MjI4Il0sIm9jbGNfcyI6WyIxNzg1NDg5Il0sIm90aGVyX3ZlcnNpb25fcyI6WyIwMDE1NzIyOCIsIm9jbTAxNzg1NDg5Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjE5NDUtMTk4OSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjYxMjc0MFwiOntcImxvY2F0aW9uXCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjY3NDNcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRTc0NCAuRjY3NDNcIixcImxvY2F0aW9uX2hhc1wiOltcIk5vLiAxMjAgKFNlcHQuL09jdC4gMjAwMCktbm8uIDIxNSAoTm92L0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTM0LCAxNTgsIDE2MCwgMTYyLCAxNjksIDE3MiwgMTczLDE3NVwiLFwiQ1VSUkVOVCBJU1NVRVMgSU46IFBlcmlvZGljYWxzIENvbGxlY3Rpb24gKFBSKS4gRmlyZXN0b25lXCJdfSxcIjYxMjc0MVwiOntcImxvY2F0aW9uXCI6XCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzXCIsXCJsaWJyYXJ5XCI6XCJTdG9rZXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic3BpYXBzXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDEgKHdpbnRlciAxOTcwLzcxKS1uby4gMjE1IChOb3YuL0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTE2LCAxMTgsIDEyOCwgMTM0LTEzNSwgMTU0LTE1OCwgMTYxLTE2MiwgMTcyLTE3NSwgMTc3XCIsXCJDVVJSRU5UIElTU1VFUyBJTjogRG9uYWxkIEUuIFN0b2tlcyBMaWJyYXJ5IChTUElBKS4gV2FsbGFjZSBIYWxsXCJdLFwiaW5kZXhlc1wiOltcIkluZGV4LCBuby4gMS84XCJdfSxcIjYxMjc0MlwiOntcImxvY2F0aW9uXCI6XCJNdWRkIE1hbnVzY3JpcHQgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcIm11ZGRcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTk8gQk9VTkQgSE9MRElOR1NcIixcIkNVUlJFTlQgSVNTVUVTIElOOiBTZWVsZXkgRy4gTXVkZCBMaWJyYXJ5IChNdWRkKVwiXX0sXCI0NzM2NzM1XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIixcImNhbGxfbnVtYmVyXCI6XCIxMDk2LjM1MjVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTA5Ni4zNTI1XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMSAod2ludGVyIDE5NzAvNzEpLW5vLiAxMTYgKGZhbGwgMTk5OSlcIl19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIiwic3BpYXBzIiwibXVkZCIsInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiLCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzIiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJzcGlhcHMiLCJtdWRkIiwicmNwcGEiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMTY6NDQ6NDAuNDQ0WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2865,7 +2865,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 612742 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2918,7 +2918,7 @@ http_interactions:
         Charged","label":"Stokes Library - Periodicals"},"612742":{"more_items":false,"location":"mudd","status":"On-Site","label":"Mudd
         Manuscript Library"},"4736735":{"more_items":true,"location":"rcppa","copy_number":1,"item_id":703398,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2969,7 +2969,7 @@ http_interactions:
       string: '{"label":"Periodicals","code":"spiaps","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -3021,7 +3021,7 @@ http_interactions:
         Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd
         Manuscript Library and University Archives","code":"mudd"},"delivery_locations":[{"label":"Mudd
         Manuscript Library","address":"65 Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -3075,7 +3075,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjU2MTc3NCIsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZVwiLFwiTmF0aW9uYWwgQWZmYWlycywgSW5jXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdfSIsImF1dGhvcl9zIjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlIiwiTmF0aW9uYWwgQWZmYWlycywgSW5jIiwiRm9yZWlnbiBwb2xpY3kuIiwiVW5pdGVkIFN0YXRlcyIsIkZvcmVpZ24gcmVsYXRpb25zIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJGb3JlaWduIHBvbGljeSAoTmV3IFlvcmssIE4uWS4pIl0sInRpdGxlX2Rpc3BsYXkiOiJGb3JlaWduIHBvbGljeS4iLCJ0aXRsZV90IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRm9yZWlnbiBwb2xpY3kuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBOYXRpb25hbCBBZmZhaXJzLCBJbmMuLCBjMTk3MC0iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IE5hdGlvbmFsIEFmZmFpcnMsIEluYy4sIGMxOTcwLSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogTmF0aW9uYWwgQWZmYWlycywgSW5jIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk3MSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTcxLCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2LiA6IGlsbC4gOyAxMXgyNiAtIDI4IGNtLiIsIk5vLiAxICh3aW50ZXIgMTk3MC83MSktIl0sImRlc2NyaXB0aW9uX3QiOlsidi4gOiBpbGwuIDsgMTF4MjYgLSAyOCBjbS4iLCJOby4gMSAod2ludGVyIDE5NzAvNzEpLSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJCaW1vbnRobHksIFNlcHQuL09jdC4gMjAwMC1cdTAwM2MyMDEwXHUwMDNlIl0sImZvcm1lcl9mcmVxdWVuY3lfZGlzcGxheSI6WyJRdWFydGVybHksIDE5NzAvNzEtXHUwMDNjZmFsbCAxOTk5XHUwMDNlIl0sIm5vdGVzX2Rpc3BsYXkiOlsiUGxhY2Ugb2YgcHVibGljYXRpb24gdmFyaWVzOiBcdTAwM2MyMDAzLTIwMTBcdTAwM2UsIFdhc2hpbmd0b24sIERDLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IDEzOSAoTm92Li9EZWMuIDIwMDMpLiJdLCJpc3N1aW5nX2JvZHlfbm90ZXNfZGlzcGxheSI6WyJQdWJsaXNoZWQgc3ByaW5nIDE5Nzctc3ByaW5nIDE5NzggaW4gYXNzb2NpYXRpb24gd2l0aDogQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlOyBzdW1tZXIgMTk3OC1cdTAwM2MyMDA3XHUwMDNlLCBieSB0aGUgRW5kb3dtZW50LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwiaW5kZXhlc19kaXNwbGF5IjpbIk5vLiAxICh3aW50ZXIgMTk3MC83MSktOCAoZmFsbCAxOTcyKS4gMSB2LiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF90IjpbIlVuaXRlZCBTdGF0ZXPigJRGb3JlaWduIHJlbGF0aW9uc+KAlDE5NDUtMTk4OeKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJDYXJuZWdpZSBFbmRvd21lbnQgZm9yIEludGVybmF0aW9uYWwgUGVhY2VcIixcIk5hdGlvbmFsIEFmZmFpcnMsIEluY1wiXX0iLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5IiwiRlAgU2VwdC4vT2N0LiAyMDAwLVx1MDAzYzIwMTBcdTAwM2UiXSwiaXNzbl9kaXNwbGF5IjpbIjAwMTUtNzIyOCJdLCJsY2NuX2Rpc3BsYXkiOlsiICAgNzM2NDE4MjUgICJdLCJsY2NuX3MiOlsiNzM2NDE4MjUiXSwiaXNzbl9zIjpbIjAwMTU3MjI4Il0sIm9jbGNfcyI6WyIxNzg1NDg5Il0sIm90aGVyX3ZlcnNpb25fcyI6WyIwMDE1NzIyOCIsIm9jbTAxNzg1NDg5Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjE5NDUtMTk4OSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjYxMjc0MFwiOntcImxvY2F0aW9uXCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjY3NDNcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRTc0NCAuRjY3NDNcIixcImxvY2F0aW9uX2hhc1wiOltcIk5vLiAxMjAgKFNlcHQuL09jdC4gMjAwMCktbm8uIDIxNSAoTm92L0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTM0LCAxNTgsIDE2MCwgMTYyLCAxNjksIDE3MiwgMTczLDE3NVwiLFwiQ1VSUkVOVCBJU1NVRVMgSU46IFBlcmlvZGljYWxzIENvbGxlY3Rpb24gKFBSKS4gRmlyZXN0b25lXCJdfSxcIjYxMjc0MVwiOntcImxvY2F0aW9uXCI6XCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzXCIsXCJsaWJyYXJ5XCI6XCJTdG9rZXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic3BpYXBzXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDEgKHdpbnRlciAxOTcwLzcxKS1uby4gMjE1IChOb3YuL0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTE2LCAxMTgsIDEyOCwgMTM0LTEzNSwgMTU0LTE1OCwgMTYxLTE2MiwgMTcyLTE3NSwgMTc3XCIsXCJDVVJSRU5UIElTU1VFUyBJTjogRG9uYWxkIEUuIFN0b2tlcyBMaWJyYXJ5IChTUElBKS4gV2FsbGFjZSBIYWxsXCJdLFwiaW5kZXhlc1wiOltcIkluZGV4LCBuby4gMS84XCJdfSxcIjYxMjc0MlwiOntcImxvY2F0aW9uXCI6XCJNdWRkIE1hbnVzY3JpcHQgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcIm11ZGRcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTk8gQk9VTkQgSE9MRElOR1NcIixcIkNVUlJFTlQgSVNTVUVTIElOOiBTZWVsZXkgRy4gTXVkZCBMaWJyYXJ5IChNdWRkKVwiXX0sXCI0NzM2NzM1XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIixcImNhbGxfbnVtYmVyXCI6XCIxMDk2LjM1MjVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTA5Ni4zNTI1XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMSAod2ludGVyIDE5NzAvNzEpLW5vLiAxMTYgKGZhbGwgMTk5OSlcIl19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIiwic3BpYXBzIiwibXVkZCIsInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiLCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzIiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJzcGlhcHMiLCJtdWRkIiwicmNwcGEiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMTY6NDQ6NDAuNDQ0WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3122,7 +3122,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 612742 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3175,7 +3175,7 @@ http_interactions:
         Charged","label":"Stokes Library - Periodicals"},"612742":{"more_items":false,"location":"mudd","status":"On-Site","label":"Mudd
         Manuscript Library"},"4736735":{"more_items":true,"location":"rcppa","copy_number":1,"item_id":703398,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3226,7 +3226,7 @@ http_interactions:
       string: '{"label":"Periodicals","code":"spiaps","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3278,7 +3278,7 @@ http_interactions:
         Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd
         Manuscript Library and University Archives","code":"mudd"},"delivery_locations":[{"label":"Mudd
         Manuscript Library","address":"65 Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3332,7 +3332,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJhdXRob3JfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkIiwiQm9obmVyLCBLYXRlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiQm9obmVyLCBLYXRlXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlRydW1wLCBEb25hbGRcIn0iLCJhdXRob3JfcyI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJvaG5lciwgS2F0ZSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCb2huZXIsIEthdGUiLCJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8gRG9uYWxkIEouIFRydW1wIHdpdGggS2F0ZSBCb2huZXIuIiwiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbiIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iLCJ0aXRsZV90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfdCI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI0VDE1OjQwOjM0LjE0M1oifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:53 GMT
 - request:
     method: get
@@ -3382,7 +3382,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101032361436","id":2114223,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Charged","due_date":"4/13/2017","label":"Firestone
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:53 GMT
 - request:
     method: get
@@ -3436,7 +3436,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJhdXRob3JfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkIiwiQm9obmVyLCBLYXRlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiQm9obmVyLCBLYXRlXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlRydW1wLCBEb25hbGRcIn0iLCJhdXRob3JfcyI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJvaG5lciwgS2F0ZSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCb2huZXIsIEthdGUiLCJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8gRG9uYWxkIEouIFRydW1wIHdpdGggS2F0ZSBCb2huZXIuIiwiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbiIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iLCJ0aXRsZV90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfdCI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI0VDE1OjQwOjM0LjE0M1oifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:53 GMT
 - request:
     method: get
@@ -3486,7 +3486,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101032361436","id":2114223,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Charged","due_date":"4/13/2017","label":"Firestone
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:53 GMT
 - request:
     method: get
@@ -3540,7 +3540,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJhdXRob3JfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkIiwiQm9obmVyLCBLYXRlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiQm9obmVyLCBLYXRlXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlRydW1wLCBEb25hbGRcIn0iLCJhdXRob3JfcyI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJvaG5lciwgS2F0ZSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCb2huZXIsIEthdGUiLCJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8gRG9uYWxkIEouIFRydW1wIHdpdGggS2F0ZSBCb2huZXIuIiwiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbiIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iLCJ0aXRsZV90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfdCI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI0VDE1OjQwOjM0LjE0M1oifX19
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:54 GMT
 - request:
     method: get
@@ -3590,71 +3590,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101032361436","id":2114223,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Charged","due_date":"4/13/2017","label":"Firestone
         Library"}]'
-    http_version: 
-  recorded_at: Wed, 29 Mar 2017 16:52:54 GMT
-- request:
-    method: get
-    uri: https://pulsearch.princeton.edu/catalog/2286894.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.11.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Status:
-      - 200 OK
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Request-Id:
-      - aab2c8e3-d17b-4e39-8fc6-fd467243612e
-      X-Ua-Compatible:
-      - IE=edge,chrome=1
-      Etag:
-      - W/"588a17575ac7735dfbab44963664e38c"
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Runtime:
-      - '0.025391'
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 29 Mar 2017 16:52:54 GMT
-      X-Powered-By:
-      - Phusion Passenger 5.0.30
-      Server:
-      - nginx/1.10.1 + Phusion Passenger 5.0.30
-    body:
-      encoding: UTF-8
-      string: '{"response":{"document":{"id":"2286894","author_roles_1display":"{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}","title_display":"Birth
-        control news.","title_t":["Birth control news."],"opensearch_display":["Birth
-        control news."],"title_citation_display":["Birth control news."],"compiled_created_t":["Birth
-        control news."],"pub_created_display":["London."],"pub_created_s":["London."],"pub_citation_display":["London"],"pub_date_display":["1000"],"pub_date_start_sort":1000,"pub_date_end_sort":1000,"cataloged_tdt":"2006-05-10T14:30:23Z","format":["Journal"],"notes_display":["Caption
-        title."],"language_facet":["English"],"language_code_s":["eng"],"oclc_s":["1536494"],"other_version_s":["ocm01536494"],"holdings_1display":"{\"2576882\":{\"location\":\"Forrestal
-        Annex - Locked Books\",\"library\":\"Forrestal Annex\",\"location_code\":\"l\",\"copy_number\":\"1\",\"call_number\":\"Oversize
-        HQ766 .B53f\",\"call_number_browse\":\"HQ766 .B53f\",\"location_has\":[\"v.[1]-7\"]},\"2576883\":{\"location\":\"Firestone
-        Library\",\"library\":\"Firestone Library\",\"location_code\":\"f\",\"copy_number\":\"1\",\"call_number\":\"HQ766
-        .B53\",\"call_number_browse\":\"HQ766 .B53\",\"location_has\":[\"v.8-23\"]}}","location_code_s":["l","f"],"location_display":["Forrestal
-        Annex - Locked Books","Firestone Library"],"location":["Forrestal Annex","Firestone
-        Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone Library"],"call_number_display":["Oversize
-        HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766 .B53f","HQ766 .B53"],"timestamp":"2017-03-23T15:10:21.059Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:54 GMT
 - request:
     method: get
@@ -3705,7 +3641,7 @@ http_interactions:
       string: '{"2576882":{"more_items":false,"location":"l","status":"On Shelf","label":"Forrestal
         Annex - Locked Books"},"2576883":{"more_items":true,"location":"f","copy_number":1,"item_id":4288427,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:54 GMT
 - request:
     method: get
@@ -3752,7 +3688,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2576882 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3809,7 +3745,7 @@ http_interactions:
         Charged","enum":"v. 10 (1931-32)","label":"Firestone Library"},{"barcode":"32101100259587","id":7079626,"location":"f","copy_number":1,"item_sequence_number":2,"status":"Not
         Charged","enum":"v. 9 (1930-31)","label":"Firestone Library"},{"barcode":"32101100259561","id":4288428,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"v. 8 (1929-30)","label":"Firestone Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3859,7 +3795,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"label":"Locked Books","code":"l","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Forrestal
         Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3923,7 +3859,7 @@ http_interactions:
         Annex - Locked Books","Firestone Library"],"location":["Forrestal Annex","Firestone
         Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone Library"],"call_number_display":["Oversize
         HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766 .B53f","HQ766 .B53"],"timestamp":"2017-03-23T15:10:21.059Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3974,7 +3910,7 @@ http_interactions:
       string: '{"2576882":{"more_items":false,"location":"l","status":"On Shelf","label":"Forrestal
         Annex - Locked Books"},"2576883":{"more_items":true,"location":"f","copy_number":1,"item_id":4288427,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -4021,7 +3957,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2576882 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -4078,7 +4014,7 @@ http_interactions:
         Charged","enum":"v. 10 (1931-32)","label":"Firestone Library"},{"barcode":"32101100259587","id":7079626,"location":"f","copy_number":1,"item_sequence_number":2,"status":"Not
         Charged","enum":"v. 9 (1930-31)","label":"Firestone Library"},{"barcode":"32101100259561","id":4288428,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"v. 8 (1929-30)","label":"Firestone Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -4128,7 +4064,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"label":"Locked Books","code":"l","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Forrestal
         Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4192,7 +4128,7 @@ http_interactions:
         Annex - Locked Books","Firestone Library"],"location":["Forrestal Annex","Firestone
         Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone Library"],"call_number_display":["Oversize
         HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766 .B53f","HQ766 .B53"],"timestamp":"2017-03-23T15:10:21.059Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4243,7 +4179,7 @@ http_interactions:
       string: '{"2576882":{"more_items":false,"location":"l","status":"On Shelf","label":"Forrestal
         Annex - Locked Books"},"2576883":{"more_items":true,"location":"f","copy_number":1,"item_id":4288427,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4290,7 +4226,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2576882 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4347,7 +4283,7 @@ http_interactions:
         Charged","enum":"v. 10 (1931-32)","label":"Firestone Library"},{"barcode":"32101100259587","id":7079626,"location":"f","copy_number":1,"item_sequence_number":2,"status":"Not
         Charged","enum":"v. 9 (1930-31)","label":"Firestone Library"},{"barcode":"32101100259561","id":4288428,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"v. 8 (1929-30)","label":"Firestone Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4397,7 +4333,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"label":"Locked Books","code":"l","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Forrestal
         Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 29 Mar 2017 16:52:57 GMT
 - request:
     method: get
@@ -4467,7 +4403,7 @@ http_interactions:
         - Marquand Library use only\",\"library\":\"ReCAP\",\"location_code\":\"rcppj\"}}","location_code_s":["rcppj"],"location_display":["ReCAP
         - Marquand Library use only"],"location":["ReCAP"],"advanced_location_s":["rcppj","ReCAP"],"name_title_browse_s":["Dyk,
         Janna. ADAM GOLFER: A HOUSE WITHOUT A ROOF"],"timestamp":"2017-03-31T04:41:46.037Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:12 GMT
 - request:
     method: get
@@ -4517,7 +4453,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9933878":{"more_items":false,"location":"rcppj","copy_number":0,"item_id":7584750,"on_reserve":"N","status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:12 GMT
 - request:
     method: get
@@ -4567,7 +4503,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101099207571","id":7584750,"location":"rcppj","copy_number":0,"item_sequence_number":1,"status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4622,7 +4558,7 @@ http_interactions:
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Preservation","address":"One
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4692,7 +4628,7 @@ http_interactions:
         - Marquand Library use only\",\"library\":\"ReCAP\",\"location_code\":\"rcppj\"}}","location_code_s":["rcppj"],"location_display":["ReCAP
         - Marquand Library use only"],"location":["ReCAP"],"advanced_location_s":["rcppj","ReCAP"],"name_title_browse_s":["Dyk,
         Janna. ADAM GOLFER: A HOUSE WITHOUT A ROOF"],"timestamp":"2017-03-31T04:41:46.037Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4742,7 +4678,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9933878":{"more_items":false,"location":"rcppj","copy_number":0,"item_id":7584750,"on_reserve":"N","status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4792,7 +4728,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101099207571","id":7584750,"location":"rcppj","copy_number":0,"item_sequence_number":1,"status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4847,7 +4783,7 @@ http_interactions:
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Preservation","address":"One
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:14 GMT
 - request:
     method: get
@@ -4917,7 +4853,7 @@ http_interactions:
         - Marquand Library use only\",\"library\":\"ReCAP\",\"location_code\":\"rcppj\"}}","location_code_s":["rcppj"],"location_display":["ReCAP
         - Marquand Library use only"],"location":["ReCAP"],"advanced_location_s":["rcppj","ReCAP"],"name_title_browse_s":["Dyk,
         Janna. ADAM GOLFER: A HOUSE WITHOUT A ROOF"],"timestamp":"2017-03-31T04:41:46.037Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:14 GMT
 - request:
     method: get
@@ -4967,7 +4903,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9933878":{"more_items":false,"location":"rcppj","copy_number":0,"item_id":7584750,"on_reserve":"N","status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:15 GMT
 - request:
     method: get
@@ -5017,7 +4953,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101099207571","id":7584750,"location":"rcppj","copy_number":0,"item_sequence_number":1,"status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:15 GMT
 - request:
     method: get
@@ -5072,7 +5008,7 @@ http_interactions:
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Preservation","address":"One
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 31 Mar 2017 19:24:15 GMT
 - request:
     method: get
@@ -5149,7 +5085,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"timestamp":"2017-03-23T17:22:00.830Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:43 GMT
 - request:
     method: get
@@ -5199,7 +5135,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101059892883","id":4397582,"location":"spia","temp_loc":"strr","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"Engineering Library - Reserve"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:47 GMT
 - request:
     method: get
@@ -5250,7 +5186,7 @@ http_interactions:
       string: '{"label":"","code":"sci","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Lewis
         Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis
         Library","code":"lewis"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:48 GMT
 - request:
     method: get
@@ -5301,7 +5237,7 @@ http_interactions:
       string: '{"label":"SPIA","code":"spia","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:48 GMT
 - request:
     method: get
@@ -5353,7 +5289,7 @@ http_interactions:
         Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand
         Library of Art and Archaeology","code":"marquand"},"delivery_locations":[{"label":"Marquand
         Library of Art and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:48 GMT
 - request:
     method: get
@@ -5404,7 +5340,7 @@ http_interactions:
       string: '{"label":"Reserve","code":"strr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Engineering
         Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering
         Library","code":"engineering"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:49 GMT
 - request:
     method: get
@@ -5481,7 +5417,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"timestamp":"2017-03-23T17:22:00.830Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:50 GMT
 - request:
     method: get
@@ -5531,7 +5467,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101059892883","id":4397582,"location":"spia","temp_loc":"strr","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"Engineering Library - Reserve"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:50 GMT
 - request:
     method: get
@@ -5582,7 +5518,7 @@ http_interactions:
       string: '{"label":"","code":"sci","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Lewis
         Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis
         Library","code":"lewis"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:51 GMT
 - request:
     method: get
@@ -5633,7 +5569,7 @@ http_interactions:
       string: '{"label":"SPIA","code":"spia","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:51 GMT
 - request:
     method: get
@@ -5685,7 +5621,7 @@ http_interactions:
         Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand
         Library of Art and Archaeology","code":"marquand"},"delivery_locations":[{"label":"Marquand
         Library of Art and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:51 GMT
 - request:
     method: get
@@ -5736,7 +5672,7 @@ http_interactions:
       string: '{"label":"Reserve","code":"strr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Engineering
         Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering
         Library","code":"engineering"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 13 Apr 2017 05:38:52 GMT
 - request:
     method: get
@@ -5791,7 +5727,7 @@ http_interactions:
         Charged","label":"Engineering Library - Reserve"},"5039570":{"more_items":false,"location":"f","copy_number":1,"item_id":4428451,"on_reserve":"N","due_date":"6/15/2017","status":"Renewed","label":"Firestone
         Library"},"5674398":{"more_items":false,"location":"sa","copy_number":1,"item_id":5084627,"on_reserve":"N","status":"On-Site","label":"Marquand
         Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5841,7 +5777,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101059938264","id":4380458,"location":"sci","copy_number":1,"item_sequence_number":1,"status":"Renewed","due_date":"5/22/2017","label":"Lewis
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5891,7 +5827,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101061133466","id":4428451,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Renewed","due_date":"6/15/2017","label":"Firestone
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5941,7 +5877,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101067508992","id":5084627,"location":"sa","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Marquand
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5996,7 +5932,7 @@ http_interactions:
         Charged","label":"Engineering Library - Reserve"},"5039570":{"more_items":false,"location":"f","copy_number":1,"item_id":4428451,"on_reserve":"N","due_date":"6/15/2017","status":"Renewed","label":"Firestone
         Library"},"5674398":{"more_items":false,"location":"sa","copy_number":1,"item_id":5084627,"on_reserve":"N","status":"On-Site","label":"Marquand
         Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -6046,7 +5982,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101059938264","id":4380458,"location":"sci","copy_number":1,"item_sequence_number":1,"status":"Renewed","due_date":"5/22/2017","label":"Lewis
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:33 GMT
 - request:
     method: get
@@ -6096,7 +6032,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101061133466","id":4428451,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Renewed","due_date":"6/15/2017","label":"Firestone
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:33 GMT
 - request:
     method: get
@@ -6146,7 +6082,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101067508992","id":5084627,"location":"sa","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Marquand
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:33 GMT
 - request:
     method: get
@@ -6196,7 +6132,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"2053005":{"more_items":false,"location":"f","copy_number":1,"item_id":2114223,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:37 GMT
 - request:
     method: get
@@ -6246,7 +6182,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"2053005":{"more_items":false,"location":"f","copy_number":1,"item_id":2114223,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:37 GMT
 - request:
     method: get
@@ -6296,7 +6232,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"2053005":{"more_items":false,"location":"f","copy_number":1,"item_id":2114223,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Apr 2017 21:22:37 GMT
 - request:
     method: get
@@ -6350,7 +6286,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJhdXRob3JfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcyIsIkVkaXRpb25zIGRlIE1pbnVpdCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkVkaXRpb25zIGRlIE1pbnVpdFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzXCJ9IiwiYXV0aG9yX3MiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcywgMTkwMi0xOTkzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiLCJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwiR3JlYXQgQnJpdGFpbiIsIlJlbGF0aW9ucyIsIkZyYW5jZSIsIkZyYW5jZSIsIlJlbGF0aW9ucyIsIkdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWluIiwiQ2l2aWxpemF0aW9uIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iLCJ0aXRsZV90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkgW3Bhcl0gQXJnb25uZSBbcHNldWQuXSJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQYXJpcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5NDMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk0MywicHViX2RhdGVfZW5kX3NvcnQiOjE5NDUsImNhdGFsb2dlZF90ZHQiOiIyMDA2LTEwLTA1VDE4OjE5OjIyWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNjEgcC4gMTcgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiNjEgcC4gMTcgY20uIl0sIm5vdGVzX2Rpc3BsYXkiOlsiXCJQcmVtaWXMgHJlIGXMgWRpdGlvbiBwdWJsaXF1ZS5cIiIsIkF1dGhvcidzIHBzZXVkLiwgQXJnb25uZSwgYXQgaGVhZCBvZiB0aXRsZS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF90IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF9mYWNldCI6WyJHcmVhdCBCcml0YWlu4oCUUmVsYXRpb25z4oCURnJhbmNlIiwiRnJhbmNl4oCUUmVsYXRpb25z4oCUR3JlYXQgQnJpdGFpbiIsIkdyZWF0IEJyaXRhaW7igJRDaXZpbGl6YXRpb27igJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiUmVsYXRlZCBuYW1lXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdfSIsImxjY25fZGlzcGxheSI6WyIgICA0NzAyODc5OSAgIl0sImxjY25fcyI6WyI0NzAyODc5OSJdLCJvY2xjX3MiOlsiNjY3ODY4MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NtMDY2Nzg2ODEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyNDUzNjkzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvblwiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiYmVhY1wiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEQTQ3LjEgLkQzNSAxOTQ1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIn0sXCIyNDUzNjk0XCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCIzMjI5LjMxOS4yOFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIzMjI5LjMxOS4yOFwifSxcIjM1MjA1NDFcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIjE0NTkuMjg3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjE0NTkuMjg3XCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSJdLCJsb2NhdGlvbiI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gU3lsdmlhIEJlYWNoIENvbGxlY3Rpb24iLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rcyIsIlJlQ0FQIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiYmVhYyIsImV4IiwicmNwcGEiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMuIEFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwidGltZXN0YW1wIjoiMjAxNy0wNC0yNFQwNjoyNjo1NC40NTZaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:53 GMT
 - request:
     method: get
@@ -6402,7 +6338,7 @@ http_interactions:
         Books and Special Collections - Sylvia Beach Collection"},"2453694":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"},"3520541":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":4410328,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6452,7 +6388,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101091596450","id":6924622,"location":"beac","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Rare
         Books and Special Collections - Sylvia Beach Collection"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6499,7 +6435,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2453694 not found.'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6549,7 +6485,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101062195498","id":4410328,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"ReCAP"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6600,7 +6536,7 @@ http_interactions:
       string: '{"label":"Sylvia Beach Collection","code":"beac","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"library":{"label":"Rare
         Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6653,7 +6589,7 @@ http_interactions:
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[{"label":"Rare
         Books and Special Collections","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6707,7 +6643,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJhdXRob3JfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcyIsIkVkaXRpb25zIGRlIE1pbnVpdCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkVkaXRpb25zIGRlIE1pbnVpdFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzXCJ9IiwiYXV0aG9yX3MiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcywgMTkwMi0xOTkzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiLCJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwiR3JlYXQgQnJpdGFpbiIsIlJlbGF0aW9ucyIsIkZyYW5jZSIsIkZyYW5jZSIsIlJlbGF0aW9ucyIsIkdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWluIiwiQ2l2aWxpemF0aW9uIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iLCJ0aXRsZV90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkgW3Bhcl0gQXJnb25uZSBbcHNldWQuXSJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQYXJpcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5NDMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk0MywicHViX2RhdGVfZW5kX3NvcnQiOjE5NDUsImNhdGFsb2dlZF90ZHQiOiIyMDA2LTEwLTA1VDE4OjE5OjIyWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNjEgcC4gMTcgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiNjEgcC4gMTcgY20uIl0sIm5vdGVzX2Rpc3BsYXkiOlsiXCJQcmVtaWXMgHJlIGXMgWRpdGlvbiBwdWJsaXF1ZS5cIiIsIkF1dGhvcidzIHBzZXVkLiwgQXJnb25uZSwgYXQgaGVhZCBvZiB0aXRsZS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF90IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF9mYWNldCI6WyJHcmVhdCBCcml0YWlu4oCUUmVsYXRpb25z4oCURnJhbmNlIiwiRnJhbmNl4oCUUmVsYXRpb25z4oCUR3JlYXQgQnJpdGFpbiIsIkdyZWF0IEJyaXRhaW7igJRDaXZpbGl6YXRpb27igJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiUmVsYXRlZCBuYW1lXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdfSIsImxjY25fZGlzcGxheSI6WyIgICA0NzAyODc5OSAgIl0sImxjY25fcyI6WyI0NzAyODc5OSJdLCJvY2xjX3MiOlsiNjY3ODY4MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NtMDY2Nzg2ODEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyNDUzNjkzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvblwiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiYmVhY1wiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEQTQ3LjEgLkQzNSAxOTQ1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIn0sXCIyNDUzNjk0XCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCIzMjI5LjMxOS4yOFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIzMjI5LjMxOS4yOFwifSxcIjM1MjA1NDFcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIjE0NTkuMjg3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjE0NTkuMjg3XCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSJdLCJsb2NhdGlvbiI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gU3lsdmlhIEJlYWNoIENvbGxlY3Rpb24iLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rcyIsIlJlQ0FQIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiYmVhYyIsImV4IiwicmNwcGEiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMuIEFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwidGltZXN0YW1wIjoiMjAxNy0wNC0yNFQwNjoyNjo1NC40NTZaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6759,7 +6695,7 @@ http_interactions:
         Books and Special Collections - Sylvia Beach Collection"},"2453694":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"},"3520541":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":4410328,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6809,7 +6745,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101091596450","id":6924622,"location":"beac","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Rare
         Books and Special Collections - Sylvia Beach Collection"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6856,7 +6792,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2453694 not found.'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6906,7 +6842,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101062195498","id":4410328,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"ReCAP"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6957,7 +6893,7 @@ http_interactions:
       string: '{"label":"Sylvia Beach Collection","code":"beac","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"library":{"label":"Rare
         Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -7010,7 +6946,7 @@ http_interactions:
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[{"label":"Rare
         Books and Special Collections","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -7064,7 +7000,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJhdXRob3JfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcyIsIkVkaXRpb25zIGRlIE1pbnVpdCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkVkaXRpb25zIGRlIE1pbnVpdFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzXCJ9IiwiYXV0aG9yX3MiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcywgMTkwMi0xOTkzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiLCJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwiR3JlYXQgQnJpdGFpbiIsIlJlbGF0aW9ucyIsIkZyYW5jZSIsIkZyYW5jZSIsIlJlbGF0aW9ucyIsIkdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWluIiwiQ2l2aWxpemF0aW9uIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iLCJ0aXRsZV90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkgW3Bhcl0gQXJnb25uZSBbcHNldWQuXSJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQYXJpcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5NDMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk0MywicHViX2RhdGVfZW5kX3NvcnQiOjE5NDUsImNhdGFsb2dlZF90ZHQiOiIyMDA2LTEwLTA1VDE4OjE5OjIyWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNjEgcC4gMTcgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiNjEgcC4gMTcgY20uIl0sIm5vdGVzX2Rpc3BsYXkiOlsiXCJQcmVtaWXMgHJlIGXMgWRpdGlvbiBwdWJsaXF1ZS5cIiIsIkF1dGhvcidzIHBzZXVkLiwgQXJnb25uZSwgYXQgaGVhZCBvZiB0aXRsZS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF90IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF9mYWNldCI6WyJHcmVhdCBCcml0YWlu4oCUUmVsYXRpb25z4oCURnJhbmNlIiwiRnJhbmNl4oCUUmVsYXRpb25z4oCUR3JlYXQgQnJpdGFpbiIsIkdyZWF0IEJyaXRhaW7igJRDaXZpbGl6YXRpb27igJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiUmVsYXRlZCBuYW1lXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdfSIsImxjY25fZGlzcGxheSI6WyIgICA0NzAyODc5OSAgIl0sImxjY25fcyI6WyI0NzAyODc5OSJdLCJvY2xjX3MiOlsiNjY3ODY4MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NtMDY2Nzg2ODEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyNDUzNjkzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvblwiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiYmVhY1wiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEQTQ3LjEgLkQzNSAxOTQ1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIn0sXCIyNDUzNjk0XCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCIzMjI5LjMxOS4yOFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIzMjI5LjMxOS4yOFwifSxcIjM1MjA1NDFcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIjE0NTkuMjg3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjE0NTkuMjg3XCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSJdLCJsb2NhdGlvbiI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gU3lsdmlhIEJlYWNoIENvbGxlY3Rpb24iLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rcyIsIlJlQ0FQIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiYmVhYyIsImV4IiwicmNwcGEiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMuIEFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwidGltZXN0YW1wIjoiMjAxNy0wNC0yNFQwNjoyNjo1NC40NTZaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -7116,7 +7052,7 @@ http_interactions:
         Books and Special Collections - Sylvia Beach Collection"},"2453694":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"},"3520541":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":4410328,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:02:00 GMT
 - request:
     method: get
@@ -7166,7 +7102,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101091596450","id":6924622,"location":"beac","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Rare
         Books and Special Collections - Sylvia Beach Collection"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:02:00 GMT
 - request:
     method: get
@@ -7213,7 +7149,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2453694 not found.'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:02:00 GMT
 - request:
     method: get
@@ -7263,7 +7199,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101062195498","id":4410328,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"ReCAP"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:02:01 GMT
 - request:
     method: get
@@ -7314,7 +7250,7 @@ http_interactions:
       string: '{"label":"Sylvia Beach Collection","code":"beac","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"library":{"label":"Rare
         Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:02:01 GMT
 - request:
     method: get
@@ -7367,7 +7303,7 @@ http_interactions:
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[{"label":"Rare
         Books and Special Collections","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 27 Apr 2017 19:02:01 GMT
 - request:
     method: get
@@ -7451,7 +7387,7 @@ http_interactions:
         Library","Online"],"name_title_browse_s":["Gray, Brayton, 1940-. Abelian Properties
         of Anick Spaces"],"call_number_display":["QA3 .A57 no.1162","Electronic Resource"],"call_number_browse_s":["QA3
         .A57 no.1162","Electronic Resource"],"timestamp":"2017-04-22T07:14:25.173Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 01 Jun 2017 23:05:00 GMT
 - request:
     method: get
@@ -7502,7 +7438,7 @@ http_interactions:
       string: '{"9939337":{"more_items":false,"location":"sci","copy_number":0,"item_id":7572217,"on_reserve":"N","status":"Inaccessible","label":"Lewis
         Library"},"9956499":{"more_items":false,"location":"elf1","status":"Online","label":"Online
         - *ONLINE*"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 01 Jun 2017 23:05:01 GMT
 - request:
     method: get
@@ -7552,7 +7488,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101097688129","id":7572217,"location":"sci","copy_number":0,"item_sequence_number":1,"status":"Inaccessible","on_reserve":"N","label":"Lewis
         Library"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 01 Jun 2017 23:05:02 GMT
 - request:
     method: get
@@ -7601,7 +7537,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"label":"*ONLINE*","code":"elf1","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 01 Jun 2017 23:05:03 GMT
 - request:
     method: get
@@ -7655,7 +7591,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMjQ3ODA2IiwiYXV0aG9yX2Rpc3BsYXkiOlsiRGluY8ynYXNsYW4sIE0uIEJhaGFkxLFyaGFuIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhblwifSIsImF1dGhvcl9zIjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiRGluY8ynYXNsYW4sIE0uIEJhaGFkxLFyaGFuIiwiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyBCaXIgVHXMiHJrIG1pbGxpeWV0Y8ynaXNpbmluIG1pdG9sb2ppIGRlZnRlcmluZGVuIC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyBCaXIgVHXMiHJrIG1pbGxpeWV0Y8ynaXNpbmluIG1pdG9sb2ppIGRlZnRlcmluZGVuIC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIiwidGl0bGVfdCI6WyJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IEJpciBUdcyIcmsgbWlsbGl5ZXRjzKdpc2luaW4gbWl0b2xvamkgZGVmdGVyaW5kZW4gLyBNLiBCYWhhZMSxcmhhbiBEaW5jzKdhc2xhbi4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IEJpciBUdcyIcmsgbWlsbGl5ZXRjzKdpc2luaW4gbWl0b2xvamkgZGVmdGVyaW5kZW4gLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyBCaXIgVHXMiHJrIG1pbGxpeWV0Y8ynaXNpbmluIG1pdG9sb2ppIGRlZnRlcmluZGVuIC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiSXN0YW5idWwgOiBBeWdhbiBZYXnEsW5jxLFsxLFrLCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9zIjpbIklzdGFuYnVsIDogQXlnYW4gWWF5xLFuY8SxbMSxaywgMjAxNy4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiSXN0YW5idWw6IEF5Z2FuIFlhecSxbmPEsWzEsWsiXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE3Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTcsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTA2LTA1VDE2OjA0OjQwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTY5IHAuIl0sImRlc2NyaXB0aW9uX3QiOlsiMTY5IHAuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIlR1cmtpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbInR1ciJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NjA1OTcwNzI0NCJdLCJpc2JuX3MiOlsiOTc4NjA1OTcwNzI0NCJdLCJpc2JuX3QiOlsiOTc4NjA1OTcwNzI0NCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4NjA1OTcwNzI0NCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjEwMDI4MTAyXCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiRGluY8ynYXNsYW4sIE0uIEJhaGFkxLFyaGFuLiBLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIl0sInRpbWVzdGFtcCI6IjIwMTctMDYtMDZUMDQ6NDQ6MDAuNTEyWiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Wed, 21 Jun 2017 18:32:52 GMT
 - request:
     method: get
@@ -7705,7 +7641,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"10028102":{"more_items":false,"location":"rcppa","copy_number":0,"item_id":7626545,"on_reserve":"N","status":"In
         Process","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 21 Jun 2017 18:32:52 GMT
 - request:
     method: get
@@ -7755,7 +7691,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101101305488","id":7626545,"location":"rcppa","copy_number":0,"item_sequence_number":1,"status":"In
         Process","on_reserve":"N","label":"ReCAP"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 21 Jun 2017 18:32:52 GMT
 - request:
     method: get
@@ -7822,7 +7758,7 @@ http_interactions:
         p. HC."],"description_t":["343 p. HC."],"language_code_s":["und"],"holdings_1display":"{\"9929080\":{\"location\":\"ReCAP\",\"library\":\"ReCAP\",\"location_code\":\"rcppa\"}}","location_code_s":["rcppa"],"location":["ReCAP"],"location_display":["ReCAP"],"advanced_location_s":["rcppa","ReCAP"],"name_title_browse_s":["Jab
         al-Khayr, Sa''id. Abhath fi al-tasawwuf wa al-turuq al-sufiyah: al-zawayah
         wa al-marja''iyah al-diniyah.."],"timestamp":"2017-09-24T05:26:53.165Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 17 Oct 2017 14:02:14 GMT
 - request:
     method: get
@@ -7871,7 +7807,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"9929080":{"more_items":false,"location":"rcppa","status":"On Shelf","label":"ReCAP"}}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 17 Oct 2017 14:02:14 GMT
 - request:
     method: get
@@ -7918,7 +7854,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 9929080 not found.'
-    http_version: 
+    http_version:
   recorded_at: Tue, 17 Oct 2017 14:02:15 GMT
 - request:
     method: get
@@ -7972,7 +7908,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMwOCIsImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W10sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwidW5pZm9ybV90aXRsZV9zIjpbIkhhcmQgdGltZXMgKFdhc2hpbmd0b24sIEQuQy4pIl0sInRpdGxlX2Rpc3BsYXkiOiJIYXJkIHRpbWVzLiIsInRpdGxlX3QiOlsiSGFyZCB0aW1lcy4iXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIkhhcmQgdGltZXMuIiwiUmFkaWNhbGlzbSIsIlVuaXRlZCBTdGF0ZXMiLCJQZXJpb2RpY2FscyJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkhhcmQgdGltZXMuIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJIYXJkIHRpbWVzLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIldhc2hpbmd0b24sIEQuQy4gOiBOZXcgV2Vla2x5IFByb2plY3QsIl0sInB1Yl9jcmVhdGVkX3MiOlsiV2FzaGluZ3RvbiwgRC5DLiA6IE5ldyBXZWVrbHkgUHJvamVjdCwiXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiV2FzaGluZ3RvbiwgRC5DLjogTmV3IFdlZWtseSBQcm9qZWN0Il0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk2OSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTY5LCJwdWJfZGF0ZV9lbmRfc29ydCI6MTk3MCwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyI2NiB2LiA7IDI4IGNtLiIsIk5vLiAyMiAoTWFyLiAxMC8xNyAxOTY5KS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKS4iXSwiZGVzY3JpcHRpb25fdCI6WyI2NiB2LiA7IDI4IGNtLiIsIk5vLiAyMiAoTWFyLiAxMC8xNyAxOTY5KS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKS4iXSwiZ2VvY29kZV9kaXNwbGF5IjpbIlVuaXRlZCBTdGF0ZXMiXSwiY29udGludWVzX2Rpc3BsYXkiOlsiTWF5ZGF5IChXYXNoaW5ndG9uLCBELiBDLikiXSwiYWJzb3JiZWRfYnlfZGlzcGxheSI6WyJSYW1wYXJ0cyAoQmVya2VsZXksIENhbGlmLikiXSwiZnJlcXVlbmN5X2Rpc3BsYXkiOlsiV2Vla2x5IChiaXdlZWtseSBkdXJpbmcgSnVseSBhbmQgQXVnLikiXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sInN1YmplY3RfZGlzcGxheSI6WyJSYWRpY2FsaXNt4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfdCI6WyJSYWRpY2FsaXNt4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiUmFkaWNhbGlzbeKAlFVuaXRlZCBTdGF0ZXPigJRQZXJpb2RpY2FscyJdLCJpc3NuX2Rpc3BsYXkiOlsiMDAyNS02MTQ1Il0sImlzc25fcyI6WyIwMDI1NjE0NSJdLCJvY2xjX3MiOlsiMjI0NDYxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiMDAyNTYxNDUiLCJvY20wMjI0NDYxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjM0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIFVzZSBpbiBGaXJlc3RvbmUgTWljcm9mb3JtcyBvbmx5XCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiTUlDUk9GSUxNIFMwMDUzNFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJNSUNST0ZJTE0gUzAwNTM0XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMjIgKE1hci4gMTAvMTcgMTk2OSktbm8uIDQ3IChPY3QuIDYsIDE5NjkpXCIsXCJOby4gMjItNDcgb24gcmVlbCB3aXRoIG5vLiAxLTIxIG9mIHRoZSBlYXJsaWVyIHRpdGxlLlwiXX0sXCIzNDJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIk92ZXJzaXplIEhYMSAuSDM3M3FcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSFgxIC5IMzczcVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDgyIChKdW5lIDI5LCAxOTcwKS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKVwiLFwiTEFDS1M6IG5vLiA4M1wiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBmIiwiZiJdLCJsb2NhdGlvbiI6WyJSZUNBUCIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBVc2UgaW4gRmlyZXN0b25lIE1pY3JvZm9ybXMgb25seSIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsicmNwcGYiLCJmIiwiUmVDQVAiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJPdmVyc2l6ZSBIWDEgLkgzNzNxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJIWDEgLkgzNzNxIl0sInRpbWVzdGFtcCI6IjIwMTctMDktMjNUMjA6MTM6MjcuODAxWiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Tue, 24 Oct 2017 19:41:32 GMT
 - request:
     method: get
@@ -8023,7 +7959,7 @@ http_interactions:
       string: '{"341":{"more_items":false,"location":"rcppf","status":"On Shelf","label":"ReCAP
         - Use in Firestone Microforms only"},"342":{"more_items":false,"location":"f","status":"On
         Shelf","label":"Firestone Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 24 Oct 2017 19:41:32 GMT
 - request:
     method: get
@@ -8070,7 +8006,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 341 not found.'
-    http_version: 
+    http_version:
   recorded_at: Tue, 24 Oct 2017 19:41:33 GMT
 - request:
     method: get
@@ -8117,7 +8053,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 342 not found.'
-    http_version: 
+    http_version:
   recorded_at: Tue, 24 Oct 2017 19:41:33 GMT
 - request:
     method: get
@@ -8173,7 +8109,7 @@ http_interactions:
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services HMT","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"ReCAP
         ILL","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 24 Oct 2017 19:41:33 GMT
 - request:
     method: get
@@ -8227,7 +8163,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMzNjUyNSIsImF1dGhvcl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJTcGllZ2VsbWFuLCBBcnQiLCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVycyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNwaWVnZWxtYW4sIEFydFwifSIsImF1dGhvcl9zIjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJTcGllZ2VsbWFuLCBBcnQiLCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVycyIsIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiIsIlNwaWVnZWxtYW4sIFZsYWRlayIsIkNvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUpIiwiUG9sYW5kIiwiQmlvZ3JhcGh5IiwiQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9ycyIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnQiLCJDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3JzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSIsIkNvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiIsInRpdGxlX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIk5ldyBZb3JrIDogUGFudGhlb24gQm9va3MsIGMxOTg2LiJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogUGFudGhlb24gQm9va3MsIGMxOTg2LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogUGFudGhlb24gQm9va3MiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTg2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5ODYsImNhdGFsb2dlZF90ZHQiOiIyMDAwLTA2LTEzVDA0OjAwOjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjE1OSBwLiA6IGlsbC4gOyAyMyBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgVmxhZGVr4oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0LCBKZXdpc2ggKDE5MzktMTk0NSnigJRQb2xhbmTigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIlNwaWVnZWxtYW4sIEFydOKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkNoaWxkcmVuIG9mIEhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIl0sInN1YmplY3RfdCI6WyJTcGllZ2VsbWFuLCBWbGFkZWvigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3QsIEpld2lzaCAoMTkzOS0xOTQ1KeKAlFBvbGFuZOKAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiU3BpZWdlbG1hbiwgQXJ04oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiQ2hpbGRyZW4gb2YgSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiXSwic3ViamVjdF9mYWNldCI6WyJTcGllZ2VsbWFuLCBWbGFkZWvigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3QsIEpld2lzaCAoMTkzOS0xOTQ1KeKAlFBvbGFuZOKAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiU3BpZWdlbG1hbiwgQXJ04oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiQ2hpbGRyZW4gb2YgSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVyc1wiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDM5NDc0NzIzMiA6Il0sImxjY25fZGlzcGxheSI6WyIgICA4NjA0MjY0MiAiXSwibGNjbl9zIjpbIjg2MDQyNjQyIl0sImlzYm5fcyI6WyI5NzgwMzk0NzQ3MjMxIl0sImlzYm5fdCI6WyI5NzgwMzk0NzQ3MjMxIl0sIm9jbGNfcyI6WyIxMzUyNDMxNCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDM5NDc0NzIzMSIsIm9jbTEzNTI0MzE0Il0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiMzY3ODgyXCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJEODEwLko0IFM2NDMgMTk4NlwifSxcIjM2Nzg4M1wiOntcImxvY2F0aW9uXCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rc1wiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiZXhcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtV1wiLFwibG9jYXRpb25faGFzXCI6W1wiUHJpbmNldG9uIGNvcHkgMVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbImYiLCJleCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiZiIsImV4IiwiRmlyZXN0b25lIExpYnJhcnkiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiU3BpZWdlbG1hbiwgQXJ0LiBNYXVzIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRDgxMC5KNCBTNjQzIDE5ODYiLCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRDgxMC5KNCBTNjQzIDE5ODYiLCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVciXSwidGltZXN0YW1wIjoiMjAxNy0xMC0wNFQwNDo0MjoxOS40NDhaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:53 GMT
 - request:
     method: get
@@ -8279,7 +8215,7 @@ http_interactions:
         Trauma, Accountability","course_number":"ANT 432","section_id":0,"instructor_first_name":"John","instructor_last_name":"Borneman"}],"copy_number":1,"item_id":381096,"on_reserve":"Y","status":"Not
         Charged","label":"Firestone Library - Circulation Desk (3 Hour Reserve)"},"367883":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:54 GMT
 - request:
     method: get
@@ -8330,7 +8266,7 @@ http_interactions:
       string: '[{"barcode":"32101011317193","id":381096,"location":"f","temp_loc":"resc","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","on_reserve":"Y","label":"Firestone Library - Circulation Desk (3
         Hour Reserve)"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:55 GMT
 - request:
     method: get
@@ -8377,7 +8313,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 367883 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:55 GMT
 - request:
     method: get
@@ -8428,7 +8364,7 @@ http_interactions:
       string: '{"label":"Circulation Desk (3 Hour Reserve)","code":"resc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Firestone
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:56 GMT
 - request:
     method: get
@@ -8482,7 +8418,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMzNjUyNSIsImF1dGhvcl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJTcGllZ2VsbWFuLCBBcnQiLCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVycyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNwaWVnZWxtYW4sIEFydFwifSIsImF1dGhvcl9zIjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJTcGllZ2VsbWFuLCBBcnQiLCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVycyIsIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiIsIlNwaWVnZWxtYW4sIFZsYWRlayIsIkNvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUpIiwiUG9sYW5kIiwiQmlvZ3JhcGh5IiwiQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9ycyIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnQiLCJDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3JzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSIsIkNvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiIsInRpdGxlX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIk5ldyBZb3JrIDogUGFudGhlb24gQm9va3MsIGMxOTg2LiJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogUGFudGhlb24gQm9va3MsIGMxOTg2LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogUGFudGhlb24gQm9va3MiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTg2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5ODYsImNhdGFsb2dlZF90ZHQiOiIyMDAwLTA2LTEzVDA0OjAwOjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjE1OSBwLiA6IGlsbC4gOyAyMyBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgVmxhZGVr4oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0LCBKZXdpc2ggKDE5MzktMTk0NSnigJRQb2xhbmTigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIlNwaWVnZWxtYW4sIEFydOKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkNoaWxkcmVuIG9mIEhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIl0sInN1YmplY3RfdCI6WyJTcGllZ2VsbWFuLCBWbGFkZWvigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3QsIEpld2lzaCAoMTkzOS0xOTQ1KeKAlFBvbGFuZOKAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiU3BpZWdlbG1hbiwgQXJ04oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiQ2hpbGRyZW4gb2YgSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiXSwic3ViamVjdF9mYWNldCI6WyJTcGllZ2VsbWFuLCBWbGFkZWvigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3QsIEpld2lzaCAoMTkzOS0xOTQ1KeKAlFBvbGFuZOKAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiU3BpZWdlbG1hbiwgQXJ04oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiQ2hpbGRyZW4gb2YgSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVyc1wiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDM5NDc0NzIzMiA6Il0sImxjY25fZGlzcGxheSI6WyIgICA4NjA0MjY0MiAiXSwibGNjbl9zIjpbIjg2MDQyNjQyIl0sImlzYm5fcyI6WyI5NzgwMzk0NzQ3MjMxIl0sImlzYm5fdCI6WyI5NzgwMzk0NzQ3MjMxIl0sIm9jbGNfcyI6WyIxMzUyNDMxNCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDM5NDc0NzIzMSIsIm9jbTEzNTI0MzE0Il0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiMzY3ODgyXCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJEODEwLko0IFM2NDMgMTk4NlwifSxcIjM2Nzg4M1wiOntcImxvY2F0aW9uXCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rc1wiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiZXhcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtV1wiLFwibG9jYXRpb25faGFzXCI6W1wiUHJpbmNldG9uIGNvcHkgMVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbImYiLCJleCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiZiIsImV4IiwiRmlyZXN0b25lIExpYnJhcnkiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiU3BpZWdlbG1hbiwgQXJ0LiBNYXVzIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRDgxMC5KNCBTNjQzIDE5ODYiLCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRDgxMC5KNCBTNjQzIDE5ODYiLCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVciXSwidGltZXN0YW1wIjoiMjAxNy0xMC0wNFQwNDo0MjoxOS40NDhaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:56 GMT
 - request:
     method: get
@@ -8534,7 +8470,7 @@ http_interactions:
         Trauma, Accountability","course_number":"ANT 432","section_id":0,"instructor_first_name":"John","instructor_last_name":"Borneman"}],"copy_number":1,"item_id":381096,"on_reserve":"Y","status":"Not
         Charged","label":"Firestone Library - Circulation Desk (3 Hour Reserve)"},"367883":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:57 GMT
 - request:
     method: get
@@ -8585,7 +8521,7 @@ http_interactions:
       string: '[{"barcode":"32101011317193","id":381096,"location":"f","temp_loc":"resc","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","on_reserve":"Y","label":"Firestone Library - Circulation Desk (3
         Hour Reserve)"}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:57 GMT
 - request:
     method: get
@@ -8632,7 +8568,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 367883 not found.'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:58 GMT
 - request:
     method: get
@@ -8683,7 +8619,7 @@ http_interactions:
       string: '{"label":"Circulation Desk (3 Hour Reserve)","code":"resc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Firestone
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Nov 2017 23:29:58 GMT
 - request:
     method: get
@@ -8737,7 +8673,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjQ4ODg0OTQiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlNhbmJvcm4gTWFwIENvbXBhbnkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FuYm9ybiBNYXAgQ29tcGFueSIsIkxpYnJhcnkgb2YgQ29uZ3Jlc3MiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJMaWJyYXJ5IG9mIENvbmdyZXNzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNhbmJvcm4gTWFwIENvbXBhbnlcIn0iLCJhdXRob3JfcyI6WyJTYW5ib3JuIE1hcCBDb21wYW55IiwiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJTYW5ib3JuIE1hcCBDb21wYW55IiwiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uIiwiRnJlZWhvbGQsIE4uIEouIFttYXBdLiIsIlJlYWwgcHJvcGVydHkiLCJOZXcgSmVyc2V5IiwiRnJlZWhvbGQiLCJGcmVlaG9sZCAoTi5KLikiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJGcmVlaG9sZCwgTi4gSi4gW21hcF0uIiwidGl0bGVfdCI6WyJGcmVlaG9sZCwgTi4gSi4gW21hcF0uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRnJlZWhvbGQsIE4uIEouIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJGcmVlaG9sZCwgTi4gSi4gW21hcF0uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiW05ldyBZb3JrOiBTYW5ib3JuIE1hcCBcdTAwMjYgUHVibGlzaGluZyBDby4sIExpbWl0ZWQsIDE4ODVdIl0sInB1Yl9jcmVhdGVkX3MiOlsiW05ldyBZb3JrOiBTYW5ib3JuIE1hcCBcdTAwMjYgUHVibGlzaGluZyBDby4sIExpbWl0ZWQsIDE4ODVdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBTYW5ib3JuIE1hcCBcdTAwMjYgUHVibGlzaGluZyBDby4sIExpbWl0ZWQiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxODg1Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE4ODUsImNhdGFsb2dlZF90ZHQiOiIyMDA2LTEwLTE4VDE4OjU5OjAwWiIsImZvcm1hdCI6WyJNYXAiXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwczovL3B1bHNlYXJjaC5wcmluY2V0b24uZWR1L2NhdGFsb2cvNDg4ODQ5NCN2aWV3XCI6W1wiYXJrcy5wcmluY2V0b24uZWR1XCJdLFwiaWlpZl9tYW5pZmVzdF9wYXRoc1wiOntcImh0dHA6Ly9hcmtzLnByaW5jZXRvbi5lZHUvYXJrOi84ODQzNS9uNTgzeHg5MXhcIjpcImh0dHBzOi8vZmlnZ3kucHJpbmNldG9uLmVkdS9jb25jZXJuL21hcF9zZXRzL3BjcjU2cW0wOG0vbWFuaWZlc3RcIn19IiwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJTY2FsZSBbY2EuIDE6NjAwXS4gNTAgZnQuIHRvIGFuIGluY2guIiwiMSBtYXAgb24gMyBzaGVldHMgOiBjb2wuIDsgZWFjaCA2NCB4IDU0IGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIlNjYWxlIFtjYS4gMTo2MDBdLiA1MCBmdC4gdG8gYW4gaW5jaC4iLCIxIG1hcCBvbiAzIHNoZWV0cyA6IGNvbC4gOyBlYWNoIDY0IHggNTQgY20uIl0sImdlb2NvZGVfZGlzcGxheSI6WyJOZXcgSmVyc2V5Il0sInNjYWxlX2Rpc3BsYXkiOlsiU2NhbGUgW2NhLiAxOjYwMF0uIDUwIGZ0LiB0byBhbiBpbmNoLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiSmFuLiAxODg1LlwiIiwiSW5jbHVkZXMga2V5IGFuZCB0ZXh0LiIsIk5vcnRoIG9yaWVudGVkIHRvd2FyZCB1cHBlciBsZWZ0LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwicHJvdmVuYW5jZV9kaXNwbGF5IjpbIkhpc3RvcmljIE1hcHMgY29weSBoYXMgc3RhbXAgb2YgTWFwIERpdmlzaW9uLCBMaWJyYXJ5IG9mIENvbmdyZXNzLCBkYXRlZCBNYXIuIDYsIDE4ODUuIl0sInN1YmplY3RfZGlzcGxheSI6WyJSZWFsIHByb3BlcnR54oCUTmV3IEplcnNleeKAlEZyZWVob2xk4oCUTWFwcyIsIkZyZWVob2xkIChOLkouKeKAlE1hcHMiXSwic3ViamVjdF90IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmlyZSBpbnN1cmFuY2UgbWFwcyBOZXcgSmVyc2V5IEZyZWVob2xkIDE4ODUuIiwiTWFwcyBOZXcgSmVyc2V5IEZyZWVob2xkIDE4ODUuIl0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiRm9ybWVyIG93bmVyXCI6W1wiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uXCJdfSIsImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiNTA4NTQ5M1wiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIEhpc3RvcmljIE1hcHMgT2ZmLVNpdGUgU3RvcmFnZVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHhwXCIsXCJjYWxsX251bWJlclwiOlwiSE1DMDQgKEZyZWVob2xkKVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJITUMwNCAoRnJlZWhvbGQpXCJ9LFwiNzQyNjI3MlwiOntcImxvY2F0aW9uXCI6XCJPbmxpbmUgLSAqT05MSU5FKlwiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYxXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJyY3B4cCIsImVsZjEiXSwibG9jYXRpb24iOlsiUmVDQVAiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBIaXN0b3JpYyBNYXBzIE9mZi1TaXRlIFN0b3JhZ2UiLCJPbmxpbmUgLSAqT05MSU5FKiJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHhwIiwiZWxmMSIsIlJlQ0FQIiwiT25saW5lIiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlNhbmJvcm4gTWFwIENvbXBhbnkuIEZyZWVob2xkLCBOLiBKLiJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhNQzA0IChGcmVlaG9sZCkiLCJFbGVjdHJvbmljIFJlc291cmNlIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkhNQzA0IChGcmVlaG9sZCkiLCJFbGVjdHJvbmljIFJlc291cmNlIl0sInRpbWVzdGFtcCI6IjIwMTgtMDEtMjRUMjE6MTE6MDcuNzA4WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Sat, 27 Jan 2018 21:24:21 GMT
 - request:
     method: get
@@ -8790,7 +8726,7 @@ http_interactions:
       string: '{"5085493":{"more_items":true,"location":"rcpxp","copy_number":1,"item_id":4420352,"on_reserve":"N","status":"On-Site","label":"ReCAP
         - Historic Maps Off-Site Storage"},"7426272":{"more_items":false,"location":"elf1","status":"Online","label":"Online
         - *ONLINE*"}}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 27 Jan 2018 21:24:22 GMT
 - request:
     method: get
@@ -8844,7 +8780,7 @@ http_interactions:
         3","enum_display":"Sheet 3","label":"ReCAP - Historic Maps Off-Site Storage"},{"barcode":"32101054078603","id":4420354,"location":"rcpxp","copy_number":1,"item_sequence_number":2,"status":"On-Site","on_reserve":"N","enum":"Sheet
         2","enum_display":"Sheet 2","label":"ReCAP - Historic Maps Off-Site Storage"},{"barcode":"32101054078595","id":4420352,"location":"rcpxp","copy_number":1,"item_sequence_number":1,"status":"On-Site","on_reserve":"N","enum":"Sheet
         1","enum_display":"Sheet 1","label":"ReCAP - Historic Maps Off-Site Storage"}]'
-    http_version: 
+    http_version:
   recorded_at: Sat, 27 Jan 2018 21:24:22 GMT
 - request:
     method: get
@@ -8897,7 +8833,7 @@ http_interactions:
       string: '{"label":"Historic Maps Off-Site Storage","code":"rcpxp","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare
         Books and Special Collections","code":"rare","order":2},"hours_location":null,"delivery_locations":[{"label":"Firestone,
         Historic Maps","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":false}]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 27 Jan 2018 21:24:22 GMT
 - request:
     method: get
@@ -8949,7 +8885,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"3334792":{"more_items":false,"location":"p","status":"On Shelf","label":"Forrestal
         Annex - Princeton Collection"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 May 2018 00:07:44 GMT
 - request:
     method: get
@@ -8998,7 +8934,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: 'Record: 3334792 not found.'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 May 2018 00:07:44 GMT
 - request:
     method: get
@@ -9050,7 +8986,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"label":"Princeton Collection","code":"p","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Forrestal
         Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 17 May 2018 00:07:44 GMT
 - request:
     method: get
@@ -9104,7 +9040,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb3RvzIQsIE1laXNlaSwgMTkzMi0xOTk5Iiwi5b6M6Jek5piO55SfLCAxOTMyLTE5OTkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR290b8yELCBNZWlzZWkiLCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wi5b6M6Jek5piO55SfXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1XCIsXCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrlcIl0sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvzIQsIE1laXNlaVwifSIsImF1dGhvcl9zIjpbIkdvdG/MhCwgTWVpc2VpLCAxOTMyLTE5OTkiLCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1Iiwi5b6M6Jek5piO55SfLCAxOTMyLTE5OTkiLCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrkiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiSW50ZXJ2aWV3ZWUiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRhIGt1amlzaGlraSBHb3RvzIQgTWVpc2VpLiBaYWRhbiBoZW4gLyBHb3RvzIQgTWVpc2VpIDsgQcyEcmnMhCBCYcyEZG8gQnVra3VzdSBoZW4uIiwidGl0bGVfdmVybl9kaXNwbGF5Ijoi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744KkLiDluqfoq4fnr4cgLyDlvozol6TmmI7nlJ8gOyDjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrnnt6guIiwidGl0bGVfdCI6WyJBbWlkYSBrdWppc2hpa2kgR290b8yEIE1laXNlaS4gWmFkYW4gaGVuIC8gR290b8yEIE1laXNlaSA7IEHMhHJpzIQgQmHMhGRvIEJ1a2t1c3UgaGVuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkFtaWRhIGt1amlzaGlraSBHb3RvzIQgTWVpc2VpIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744KkLiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW1pZGEga3VqaXNoaWtpIEdvdG/MhCBNZWlzZWkuIFphZGFuIGhlbiAvIEdvdG/MhCBNZWlzZWkgOyBBzIRyacyEIEJhzIRkbyBCdWtrdXN1IGhlbi4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqQuIOW6p+irh+evhyAvIOW+jOiXpOaYjueUnyA7IOOCouODvOODquODvOODkOODvOODieODu+ODluODg+OCr+OCuee3qC4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIkRhaSAxLWhhbi4iLCLnrKwx54mILiJdLCJwdWJfY3JlYXRlZF92ZXJuX2Rpc3BsYXkiOlsi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlRvzIRreW/MhCA6IFRzdWthZGFtYSBTaG9ib8yELCAyMDE3LiIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNy4iXSwicHViX2NyZWF0ZWRfcyI6WyJUb8yEa3lvzIQgOiBUc3VrYWRhbWEgU2hvYm/MhCwgMjAxNy4iLCLmnbHkuqwgOiDjgaTjgYvjgaDjgb7mm7jmiL8sIDIwMTcuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRvzIRreW/MhDogVHN1a2FkYW1hIFNob2JvzIQiLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywicHViX2RhdGVfZW5kX3NvcnQiOjIwMTcsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTA4LTI0VDE3OjI2OjM3WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNDQ2IHBhZ2VzIDsgMjIgY20iXSwiZGVzY3JpcHRpb25fdCI6WyI0NDYgcGFnZXMgOyAyMiBjbSJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI0NDYgcGFnZXMiXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiamEiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJFZGl0b3JcIjpbXCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1XCIsXCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrlcIl19Iiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyLluqfoq4fnr4ciXSwiYWx0X3RpdGxlXzI0Nl9kaXNwbGF5IjpbIuW6p+irh+evhyJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCIsIjQ5MDg2MjQwMTEiXSwiaXNibl9zIjpbIjk3ODQ5MDg2MjQwMTgiXSwiaXNibl90IjpbIjk3ODQ5MDg2MjQwMTgiXSwib2NsY19zIjpbIjk4ODI1MzIwMyJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTg4MjUzMjAzIiwiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIlBMODUxLk84MyBBNjIyIDIwMTdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiUEw4NTEuTzgzIEE2MjIgMjAxN1wifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb3RvzIQsIE1laXNlaSwgMTkzMi0xOTk5LiBBbWlkYSBrdWppc2hpa2kgR290b8yEIE1laXNlaSIsIuW+jOiXpOaYjueUnywgMTkzMi0xOTk5LiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqQuIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUEw4NTEuTzgzIEE2MjIgMjAxNyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJQTDg1MS5PODMgQTYyMiAyMDE3Il0sIl92ZXJzaW9uXyI6MTYxMjA0ODE0MTk2MTM5NjIyNCwidGltZXN0YW1wIjoiMjAxOC0wOS0xOVQxNDo1NTowOS43MDRaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:43 GMT
 - request:
     method: get
@@ -9158,7 +9094,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMwOCIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJ1bmlmb3JtX3RpdGxlX3MiOlsiSGFyZCB0aW1lcyAoV2FzaGluZ3RvbiwgRC5DLikiXSwidGl0bGVfZGlzcGxheSI6IkhhcmQgdGltZXMuIiwidGl0bGVfdCI6WyJIYXJkIHRpbWVzLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkhhcmQgdGltZXMiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkhhcmQgdGltZXMuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiV2FzaGluZ3RvbiwgRC5DLiA6IE5ldyBXZWVrbHkgUHJvamVjdCwiXSwicHViX2NyZWF0ZWRfcyI6WyJXYXNoaW5ndG9uLCBELkMuIDogTmV3IFdlZWtseSBQcm9qZWN0LCJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJXYXNoaW5ndG9uLCBELkMuOiBOZXcgV2Vla2x5IFByb2plY3QiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTY5Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NjksInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTcwLCJmb3JtYXQiOlsiSm91cm5hbCJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjY2IHYuIDsgMjggY20uIiwiTm8uIDIyIChNYXIuIDEwLzE3IDE5NjkpLW5vLiA4NyAoU2VwdC4gMTQsIDE5NzApLiJdLCJkZXNjcmlwdGlvbl90IjpbIjY2IHYuIDsgMjggY20uIiwiTm8uIDIyIChNYXIuIDEwLzE3IDE5NjkpLW5vLiA4NyAoU2VwdC4gMTQsIDE5NzApLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2NiB2LiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJjb250aW51ZXNfZGlzcGxheSI6WyJNYXlkYXkgKFdhc2hpbmd0b24sIEQuIEMuKSJdLCJhYnNvcmJlZF9ieV9kaXNwbGF5IjpbIlJhbXBhcnRzIChCZXJrZWxleSwgQ2FsaWYuKSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJXZWVrbHkgKGJpd2Vla2x5IGR1cmluZyBKdWx5IGFuZCBBdWcuKSJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJSYWRpY2FsaXNt4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiUmFkaWNhbGlzbeKAlFVuaXRlZCBTdGF0ZXPigJRQZXJpb2RpY2FscyJdLCJpc3NuX2Rpc3BsYXkiOlsiMDAyNS02MTQ1Il0sImlzc25fcyI6WyIwMDI1NjE0NSJdLCJvY2xjX3MiOlsiMjI0NDYxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiMDAyNTYxNDUiLCJvY20wMjI0NDYxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjM0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIFVzZSBpbiBGaXJlc3RvbmUgTWljcm9mb3JtcyBvbmx5XCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiTUlDUk9GSUxNIFMwMDUzNFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJNSUNST0ZJTE0gUzAwNTM0XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMjIgKE1hci4gMTAvMTcgMTk2OSktbm8uIDQ3IChPY3QuIDYsIDE5NjkpXCIsXCJOby4gMjItNDcgb24gcmVlbCB3aXRoIG5vLiAxLTIxIG9mIHRoZSBlYXJsaWVyIHRpdGxlLlwiXX0sXCIzNDJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIk92ZXJzaXplIEhYMSAuSDM3M3FcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSFgxIC5IMzczcVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDgyIChKdW5lIDI5LCAxOTcwKS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKVwiLFwiTEFDS1M6IG5vLiA4M1wiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBmIiwiZiJdLCJsb2NhdGlvbiI6WyJSZUNBUCIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBVc2UgaW4gRmlyZXN0b25lIE1pY3JvZm9ybXMgb25seSIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsicmNwcGYiLCJmIiwiUmVDQVAiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJPdmVyc2l6ZSBIWDEgLkgzNzNxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJIWDEgLkgzNzNxIl0sIl92ZXJzaW9uXyI6MTYxMTU4ODkzOTA5ODg4MjA0OCwidGltZXN0YW1wIjoiMjAxOC0wOS0xNFQxMzoxNjoxOS43NzBaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:44 GMT
 - request:
     method: get
@@ -9212,7 +9148,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk0OTMzMTgiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlNhbWjMo2HMhG4sIE5hamHMhHQiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjCJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJTYW1ozKNhzIRuLCBOYWphzIR0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wi2LPZhdit2KfZhtiMINmG2KzYp9ip2IxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU2FtaMyjYcyEbiwgTmFqYcyEdFwifSIsImF1dGhvcl9zIjpbIlNhbWjMo2HMhG4sIE5hamHMhHQiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjCJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Isq7QXdhzIR0zKNpZiBtYWRmdcyEbmFoIC8gTmFqYcyEdCBhbC1TYW1ozKNhzIRuLiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6Iti52YjYp9i32YEg2YXYr9mB2YjZhtipIC8g2YbYrNin2Kkg2KfZhNiz2YXYrdin2YYuIiwidGl0bGVfdCI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIE5hamHMhHQgYWwtU2FtaMyjYcyEbi4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCIsIti52YjYp9i32YEg2YXYr9mB2YjZhtipIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIE5hamHMhHQgYWwtU2FtaMyjYcyEbi4iLCLYudmI2KfYt9mBINmF2K/ZgdmI2YbYqSAvINmG2KzYp9ipINin2YTYs9mF2K3Yp9mGLiJdLCJwdWJfY3JlYXRlZF92ZXJuX2Rpc3BsYXkiOlsi2KfZhNmC2KfZh9ix2KkgOiDYr9in2LEg2KfZhNmD2KrYp9ioINin2YTYrdiv2YrYq9iMIDIwMTYuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiYWwtUWHMhGhpcmFoIDogRGHMhHIgYWwtS2l0YcyEYiBhbC1IzKNhZGnMhHRoLCAyMDE2LiIsItin2YTZgtin2YfYsdipIDog2K/Yp9ixINin2YTZg9iq2KfYqCDYp9mE2K3Yr9mK2KvYjCAyMDE2LiJdLCJwdWJfY3JlYXRlZF9zIjpbImFsLVFhzIRoaXJhaCA6IERhzIRyIGFsLUtpdGHMhGIgYWwtSMyjYWRpzIR0aCwgMjAxNi4iLCLYp9mE2YLYp9mH2LHYqSA6INiv2KfYsSDYp9mE2YPYqtin2Kgg2KfZhNit2K/Zitir2IwgMjAxNi4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiYWwtUWHMhGhpcmFoOiBEYcyEciBhbC1LaXRhzIRiIGFsLUjMo2FkacyEdGgiLCLYp9mE2YLYp9mH2LHYqTog2K/Yp9ixINin2YTZg9iq2KfYqCDYp9mE2K3Yr9mK2KvYjCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDEtMTlUMTM6NDk6MzdaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIyMzAgcGFnZXMgOyAyMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjIzMCBwYWdlcyA7IDIwIGNtIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjIzMCBwYWdlcyJdLCJub3Rlc19kaXNwbGF5IjpbIlNob3J0IHN0b3JpZXMuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJhciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU2hvcnQgc3RvcmllcywgQXJhYmlj4oCUMjFzdCBjZW50dXJ5Il0sInN1YmplY3RfZmFjZXQiOlsiU2hvcnQgc3RvcmllcywgQXJhYmlj4oCUMjFzdCBjZW50dXJ5Il0sImlzYm5fZGlzcGxheSI6WyI5Nzg5NzczNTA2ODI3IiwiOTc3MzUwNjgyNyJdLCJpc2JuX3MiOlsiOTc4OTc3MzUwNjgyNyJdLCJpc2JuX3QiOlsiOTc4OTc3MzUwNjgyNyJdLCJvY2xjX3MiOlsiOTM1MjE5MzEwIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY245MzUyMTkzMTAiLCI5Nzg5NzczNTA2ODI3Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjIxc3QgY2VudHVyeSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjkzNTE5NjdcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIlBKNzk2Mi5BNTQ5NSBBOTUgMjAxNlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJQSjc5NjIuQTU0OTUgQTk1IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiU2FtaMyjYcyEbiwgTmFqYcyEdC4gyrtBd2HMhHTMo2lmIG1hZGZ1zIRuYWgiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjC4g2LnZiNin2LfZgSDZhdiv2YHZiNmG2KkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJQSjc5NjIuQTU0OTUgQTk1IDIwMTYiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiUEo3OTYyLkE1NDk1IEE5NSAyMDE2Il0sIl92ZXJzaW9uXyI6MTYxMTYyMzYzMTU0MDk3NzY2NCwidGltZXN0YW1wIjoiMjAxOC0wOS0xNFQyMjoyNzo0NC45MjFaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:46 GMT
 - request:
     method: get
@@ -9266,7 +9202,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMjQ3ODA2IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJEaW5jzKdhc2xhbiwgTS4gQmFoYWTEsXJoYW4sIDE5OTAtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhblwifSIsImF1dGhvcl9zIjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiwgMTk5MC0iXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIiwidGl0bGVfdCI6WyJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyAvIE0uIEJhaGFkxLFyaGFuIERpbmPMp2FzbGFuLiJdLCJlZGl0aW9uX2Rpc3BsYXkiOlsiMS4gYmFza8SxLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkthZMSxa2/MiHksIEnMh3N0YW5idWwgOiBBeWdhbiBZYXnEsW5jxLFsxLFrLCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9zIjpbIkthZMSxa2/MiHksIEnMh3N0YW5idWwgOiBBeWdhbiBZYXnEsW5jxLFsxLFrLCAyMDE3LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJLYWTEsWtvzIh5LCBJzIdzdGFuYnVsOiBBeWdhbiBZYXnEsW5jxLFsxLFrIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE3LCJjYXRhbG9nZWRfdGR0IjoiMjAxNy0wNi0wNVQxNjowNDo0MFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjE2OSBwYWdlcyA7IDIwIGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjE2OSBwYWdlcyA7IDIwIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNjkgcGFnZXMiXSwic2VyaWVzX2Rpc3BsYXkiOlsiQXlnYW4gWWF5xLFuY8SxbMSxayA7IG5vOiA0NSJdLCJub3Rlc19kaXNwbGF5IjpbIlwiQmlyIFR1zIhyayBtaWxsaXlldGPMp2lzaW5pbiBtaXRvbG9qaSBkZWZ0ZXJpbmRlbi5cIiJdLCJsYW5ndWFnZV9mYWNldCI6WyJUdXJraXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJ0dXIiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbInRyIl0sInN1YmplY3RfZGlzcGxheSI6WyJNeXRob2xvZ3kiXSwic3ViamVjdF9mYWNldCI6WyJNeXRob2xvZ3kiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODYwNTk3MDcyNDQiXSwiaXNibl9zIjpbIjk3ODYwNTk3MDcyNDQiXSwiaXNibl90IjpbIjk3ODYwNTk3MDcyNDQiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODYwNTk3MDcyNDQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIxMDAyODEwMlwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiQkwzMTIgLkQ1NSAyMDE3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkJMMzEyIC5ENTUgMjAxN1wifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEaW5jzKdhc2xhbiwgTS4gQmFoYWTEsXJoYW4sIDE5OTAtLiBLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiQkwzMTIgLkQ1NSAyMDE3Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkJMMzEyIC5ENTUgMjAxNyJdLCJfdmVyc2lvbl8iOjE2MTE2MjY1NDU3Mjg3MTY4MDAsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjM6MTQ6MDQuMjM5WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:48 GMT
 - request:
     method: get
@@ -9320,7 +9256,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMTQ0Njk4IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb2xmZXIsIEFkYW0iLCLXkteV15zXpNeoLCDXkNeT150iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiR29sZmVyLCBBZGFtXCIsXCJHb2xmZXIsIEFkYW1cIixcIkdvbGZlciwgQWRhbVwiLFwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlXCIsXCLXkteV15zXpNeoLCDXkNeT151cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiR29sZmVyLCBBZGFtXCJ9IiwiYXV0aG9yX3MiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIiwi15LXldec16TXqCwg15DXk9edIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIlBob3RvZ3JhcGhlciJdLCJ1bmlmb3JtX3RpdGxlX3MiOlsiUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwidGl0bGVfZGlzcGxheSI6IkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIiwidGl0bGVfdCI6WyJBIGhvdXNlIHdpdGhvdXQgYSByb29mIC8gQWRhbSBHb2xmZXIgOyB0cmFuc2xhdGlvbnM6IE1vc3RhZmEgT3VhamphbmkgKEFyYWJpYyksIEdhYnJpZWxhIFZhaW5zZW5jaGVyIChIZWJyZXcpLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIl0sImVkaXRpb25fZGlzcGxheSI6WyJGaXJzdCBlZGl0aW9uLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY3JlYXRlZF9zIjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJCcm9va2x5biwgTmV3IFlvcms6IEJvb2tseW4iXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTYsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTAzLTMwVDE4OjQ2OjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIDogaWxsdXN0cmF0aW9ucyAoY2hpZWZseSBjb2xvcikgOyAzMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjE2MSBwYWdlcyA6IGlsbHVzdHJhdGlvbnMgKGNoaWVmbHkgY29sb3IpIDsgMzAgY20iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJJc3JhZWwiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiU2hvcnRsaXN0ZWQgZm9yIHRoZSBQYXJpcy1QaG90by8gQXBlcnR1cmUgRmlyc3QgQm9vayBBd2FyZCwgJ0EgSG91c2UgV2l0aG91dCBhIFJvb2YnIGNvbnNpZGVycyB0aGUgb3ZlcmxhcHBpbmcgaGlzdG9yaWVzIG9mIHZpb2xlbmNlIGFuZCBkaXNwbGFjZW1lbnQgY29ubmVjdGluZyBFdXJvcGUsIElzcmFlbCBhbmQgUGFsZXN0aW5lLiBXaXRoIHBob3RvZ3JhcGhzLCBhcmNoaXZhbCBpbWFnZXJ5IGFuZCBvcmlnaW5hbCB0ZXh0cywgQnJvb2tseW4tYmFzZWQgYXJ0aXN0IEFkYW0gR29sZmVyIHdlYXZlcyB0b2dldGhlciBmaWN0aW9ucyBvZiBoaXMgZmFtaWx5IGhpc3Rvcnkgd2l0aCByZXByZXNlbnRhdGlvbnMgZnJvbSBJc3JhZWw/cyBmb3VuZGluZyBhbmQgb25nb2luZyBtaWxpdGFyeSBvY2N1cGF0aW9uLiBFdGhuaWMgYW5kIG5hdGlvbmFsIGlkZW50aXRpZXMgYXJlIHJ1cHR1cmVkIGFuZCByZWFzc2VtYmxlZCBhcyBoZSBpbnRlcnJvZ2F0ZXMgY29udHJhZGljdG9yeSBoaXN0b3JpZXMgYW5kIG5vdGlvbnMgb2Ygc2VsZmhvb2QsIGV4cGxvcmluZyBzdHJhbmRzIHRoYXQgY29ubmVjdCB0aGUgSmV3aXNoIERpYXNwb3JhIG91dCBvZiBFdXJvcGUgYW5kIGZvcmNlZCBtYXNzIG1pZ3JhdGlvbnMgZnJvbSBQYWxlc3RpbmUgZm9sbG93aW5nIFdvcmxkIFdhciBJSS4gR29sZmVyIHNpdHVhdGVzIHRoaXMgaW5xdWlyeSB0aHJvdWdoIHRoZSB0cmlhbmd1bGFyIHJlbGF0aW9uc2hpcCBiZXR3ZWVuIGhpcyBncmFuZGZhdGhlciAoYSBzdXJ2aXZvciBvZiBEYWNoYXUpLCBoaXMgZmF0aGVyICh3aG8gbGl2ZWQgb24gYSBraWJidXR6IGluIHRoZSBlYXJseSAxOTcwcykgYW5kIGhpbXNlbGYuIl0sIm5vdGVzX2Rpc3BsYXkiOlsiQ292ZXIgdGl0bGUuIiwiUHVibGlzaGVkIG9uIHRoZSBvY2Nhc2lvbiBvZiBhbiBleGhpYml0aW9uIGhlbGQgYXQgQm9va2x5biwgSnVseSAxMC1TZXB0ZW1iZXIgNSwgMjAxNS4iXSwibGFuZ3VhZ2VfZGlzcGxheSI6WyJUZXh0IGluIEVuZ2xpc2ggd2l0aCBIZWJyZXcgYW5kIEFyYWJpYyBhdCB0aGUgYm90dG9tIG9mIHRoZSBwYWdlcy4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCIsIkhlYnJldyIsIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIiwiaGViIiwiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiIsImhlIiwiYXIiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIkhvc3QgaW5zdGl0dXRpb25cIjpbXCJCb29rbHluIEFydGlzdHMgQWxsaWFuY2VcIl19IiwiY29udGFpbnNfMWRpc3BsYXkiOiJbW1wiR29sZmVyLCBBZGFtLlwiLFwiSG91c2Ugd2l0aG91dCBhIHJvb2YuXCJdLFtcIkdvbGZlciwgQWRhbS5cIixcIkhvdXNlIHdpdGhvdXQgYSByb29mLlwiLFwiSGVicmV3LlwiXSxbXCJHb2xmZXIsIEFkYW0uXCIsXCJIb3VzZSB3aXRob3V0IGEgcm9vZi5cIixcIkFyYWJpYy5cIl1dIiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyJCYXlpdCBiZWxpIGdhZyIsIteR15nXqiDXkdec15kg15LXkiJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiQmF5aXQgYmVsaSBnYWciLCLXkdeZ16og15HXnNeZINeS15IiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODA2OTI3MjY1MDEiLCIwNjkyNzI2NTAwIl0sImlzYm5fcyI6WyI5NzgwNjkyNzI2NTAxIl0sImlzYm5fdCI6WyI5NzgwNjkyNzI2NTAxIl0sIm9jbGNfcyI6WyI5ODE3NjY2NjAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjk4MTc2NjY2MCIsIjk3ODA2OTI3MjY1MDEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5OTMzODc4XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBqXCIsXCJjYWxsX251bWJlclwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBqIl0sImxvY2F0aW9uIjpbIlJlQ0FQIiwiTWFycXVhbmQgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBqIiwiUmVDQVAiLCJNYXJxdWFuZCBMaWJyYXJ5Il0sIm5hbWVfdW5pZm9ybV90aXRsZV8xZGlzcGxheSI6IltbXCJHb2xmZXIsIEFkYW0uXCIsXCJQaG90b2dyYXBocy5cIixcIlNlbGVjdGlvbnNcIl1dIiwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb2xmZXIsIEFkYW0uIEhvdXNlIHdpdGhvdXQgYSByb29mIiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gSGVicmV3IiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gQXJhYmljIiwiR29sZmVyLCBBZGFtLiBQaG90b2dyYXBocyIsIkdvbGZlciwgQWRhbS4gUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJfdmVyc2lvbl8iOjE2MTE2MjU2OTc5NTE4NzUwNzIsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjM6MDA6MzUuNzUzWiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:50 GMT
 - request:
     method: get
@@ -9374,7 +9310,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjQ4ODg0OTQiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlNhbmJvcm4gTWFwIENvbXBhbnkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FuYm9ybiBNYXAgQ29tcGFueSIsIkxpYnJhcnkgb2YgQ29uZ3Jlc3MiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJMaWJyYXJ5IG9mIENvbmdyZXNzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNhbmJvcm4gTWFwIENvbXBhbnlcIn0iLCJhdXRob3JfcyI6WyJTYW5ib3JuIE1hcCBDb21wYW55IiwiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiRnJlZWhvbGQsIE4uIEouIFttYXBdLiIsInRpdGxlX3QiOlsiRnJlZWhvbGQsIE4uIEouIFttYXBdLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZyZWVob2xkLCBOLiBKLiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRnJlZWhvbGQsIE4uIEouIFttYXBdLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIk5ldyBZb3JrIDogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkLCAxODg1LiJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkLCAxODg1LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTg4NSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxODg1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0xOFQxNzo1OTowMFoiLCJmb3JtYXQiOlsiTWFwIl0sImVsZWN0cm9uaWNfYWNjZXNzXzFkaXNwbGF5Ijoie1wiaHR0cHM6Ly9jYXRhbG9nLnByaW5jZXRvbi5lZHUvY2F0YWxvZy80ODg4NDk0I3ZpZXdcIjpbXCJEaWdpdGFsIGNvbnRlbnRcIl0sXCJpaWlmX21hbmlmZXN0X3BhdGhzXCI6e1wiaHR0cDovL2Fya3MucHJpbmNldG9uLmVkdS9hcms6Lzg4NDM1L241ODN4eDkxeFwiOlwiaHR0cHM6Ly9maWdneS5wcmluY2V0b24uZWR1L2NvbmNlcm4vc2Nhbm5lZF9tYXBzL2JhMjhkYTFhLTBiMmQtNDRhMC1iNDU1LTIyYjVmZTc1MzJmMy9tYW5pZmVzdFwifX0iLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjEgbWFwIG9uIDMgc2hlZXRzIDogY29sLiA7IGVhY2ggNjQgeCA1NCBjbS4iXSwiZGVzY3JpcHRpb25fdCI6WyJTY2FsZSBbY2EuIDE6NjAwXS4gNTAgZnQuIHRvIGFuIGluY2guIiwiMSBtYXAgb24gMyBzaGVldHMgOiBjb2wuIDsgZWFjaCA2NCB4IDU0IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxIG1hcCBvbiAzIHNoZWV0cyJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiTmV3IEplcnNleSJdLCJzY2FsZV9kaXNwbGF5IjpbIlNjYWxlIFtjYS4gMTo2MDBdLiA1MCBmdC4gdG8gYW4gaW5jaC4iXSwibm90ZXNfZGlzcGxheSI6WyJcIkphbi4gMTg4NS5cIiIsIkluY2x1ZGVzIGtleSBhbmQgdGV4dC4iLCJOb3J0aCBvcmllbnRlZCB0b3dhcmQgdXBwZXIgbGVmdC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJwcm92ZW5hbmNlX2Rpc3BsYXkiOlsiSGlzdG9yaWMgTWFwcyBjb3B5IGhhcyBzdGFtcCBvZiBNYXAgRGl2aXNpb24sIExpYnJhcnkgb2YgQ29uZ3Jlc3MsIGRhdGVkIE1hci4gNiwgMTg4NS4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmlyZSBpbnN1cmFuY2UgbWFwcyBOZXcgSmVyc2V5IEZyZWVob2xkIDE4ODUuIiwiTWFwcyBOZXcgSmVyc2V5IEZyZWVob2xkIDE4ODUuIl0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiRm9ybWVyIG93bmVyXCI6W1wiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uXCJdfSIsImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiNTA4NTQ5M1wiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIEhpc3RvcmljIE1hcHMgT2ZmLVNpdGUgU3RvcmFnZVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHhwXCIsXCJjYWxsX251bWJlclwiOlwiSE1DMDQgKEZyZWVob2xkKVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJITUMwNCAoRnJlZWhvbGQpXCJ9LFwiNzQyNjI3MlwiOntcImxvY2F0aW9uXCI6XCJPbmxpbmUgLSAqT05MSU5FKlwiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYxXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJyY3B4cCIsImVsZjEiXSwibG9jYXRpb24iOlsiUmVDQVAiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBIaXN0b3JpYyBNYXBzIE9mZi1TaXRlIFN0b3JhZ2UiLCJPbmxpbmUgLSAqT05MSU5FKiJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHhwIiwiZWxmMSIsIlJlQ0FQIiwiT25saW5lIiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlNhbmJvcm4gTWFwIENvbXBhbnkuIEZyZWVob2xkLCBOLiBKLiJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhNQzA0IChGcmVlaG9sZCkiLCJFbGVjdHJvbmljIFJlc291cmNlIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkhNQzA0IChGcmVlaG9sZCkiLCJFbGVjdHJvbmljIFJlc291cmNlIl0sIl92ZXJzaW9uXyI6MTYxMTYwODQ5MzI0NTA3MTM2MCwidGltZXN0YW1wIjoiMjAxOC0wOS0xNFQxODoyNzowOC4wNTRaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:52 GMT
 - request:
     method: get
@@ -9455,7 +9391,7 @@ http_interactions:
         Library","Online"],"name_title_browse_s":["Gray, Brayton, 1940-. Abelian Properties
         of Anick Spaces"],"call_number_display":["QA3 .A57 no.1162","Electronic Resource"],"call_number_browse_s":["QA3
         .A57 no.1162","Electronic Resource"],"_version_":1611625682445533184,"timestamp":"2018-09-14T23:00:20.987Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:53 GMT
 - request:
     method: get
@@ -9509,7 +9445,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMwMTg1NjciLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIk1hcnlsYW5kIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hcnlsYW5kIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W10sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiTWFyeWxhbmRcIn0iLCJhdXRob3JfcyI6WyJNYXJ5bGFuZCJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQuIiwidGl0bGVfdCI6WyJBbiBhY3QgdG8gc2VjdXJlIGZhaXIgZWxlY3Rpb25zIGluIE1hcnlsYW5kLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiW24ucC4sIG4uZC5dIl0sInB1Yl9jcmVhdGVkX3MiOlsiW24ucC4sIG4uZC5dIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIm4ucC4iXSwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyI0MSBwLiAyNCBjbS4iXSwiZGVzY3JpcHRpb25fdCI6WyI0MSBwLiAyNCBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiNDEgcC4iXSwic2VyaWVzX2Rpc3BsYXkiOlsiSGlzdG9yeSwgdi4gMzU2LiJdLCJtb3JlX2luX3RoaXNfc2VyaWVzX3QiOlsiSGlzdG9yeSJdLCJub3Rlc19kaXNwbGF5IjpbIkhhbGYtdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIkVsZWN0aW9uIGxhd+KAlE1hcnlsYW5kIl0sInN1YmplY3RfZmFjZXQiOlsiRWxlY3Rpb24gbGF34oCUTWFyeWxhbmQiXSwib2NsY19zIjpbIjI3NDEyOTA4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20yNzQxMjkwOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjMzMzQ3OTJcIjp7XCJsb2NhdGlvblwiOlwiRm9ycmVzdGFsIEFubmV4IC0gUHJpbmNldG9uIENvbGxlY3Rpb25cIixcImxpYnJhcnlcIjpcIkZvcnJlc3RhbCBBbm5leFwiLFwibG9jYXRpb25fY29kZVwiOlwicFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJQOTQuODQ5LjAzNi4xNVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJQOTQuODQ5LjAzNi4xNVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicCJdLCJsb2NhdGlvbiI6WyJGb3JyZXN0YWwgQW5uZXgiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGb3JyZXN0YWwgQW5uZXggLSBQcmluY2V0b24gQ29sbGVjdGlvbiJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInAiLCJGb3JyZXN0YWwgQW5uZXgiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJNYXJ5bGFuZC4gQW4gYWN0IHRvIHNlY3VyZSBmYWlyIGVsZWN0aW9ucyBpbiBNYXJ5bGFuZCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIlA5NC44NDkuMDM2LjE1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIlA5NC44NDkuMDM2LjE1Il0sIl92ZXJzaW9uXyI6MTYxMTYwMTEzNzI0MDExMzE1MywidGltZXN0YW1wIjoiMjAxOC0wOS0xNFQxNjozMDoxMC41NTZaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:55 GMT
 - request:
     method: get
@@ -9563,7 +9499,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJhdXRob3JfcyI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NyZWF0ZWRfcyI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2VuZWdhbDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNiJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE2LCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDktMjBUMTk6MzQ6MTRaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJBZnJpY2EiLCJTZW5lZ2FsIl0sImNvbnRpbnVlc19kaXNwbGF5IjpbIkXMgWNyaXZhaW4sIGpvdXJuYWwgY3VsdHVyZWwgcGFuYWZyaWNhaW4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbjogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pOyB0aXRsZSBmcm9tIGNvdmVyLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IEhvcnMgc2XMgXJpZSAocHVibGlzaGVkIGluIDIwMTY/KS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImZyIl0sInN1YmplY3RfZGlzcGxheSI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJfdmVyc2lvbl8iOjE2MTE2MTI4Njc3OTYxNDAwMzIsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTk6MzY6MzkuODk2WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:56:56 GMT
 - request:
     method: get
@@ -9617,7 +9553,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQiLCJCb2huZXIsIEthdGUiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJCb2huZXIsIEthdGVcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiVHJ1bXAsIERvbmFsZFwifSIsImF1dGhvcl9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIiwiQm9obmVyLCBLYXRlIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiIsInRpdGxlX3QiOlsiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2siXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsieHgsIDI0NCBwLiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGluZGV4LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJfdmVyc2lvbl8iOjE2MTE1OTY0NDMyNzYwMTc2NjQsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTU6MTU6MzYuMjcwWiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:57:00 GMT
 - request:
     method: get
@@ -9671,7 +9607,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5MyJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXNcIn0iLCJhdXRob3JfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwidGl0bGVfdCI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NyZWF0ZWRfcyI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGFyaXMiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTQzIl0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NDMsInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTQ1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0wNVQxODoxOToyMloiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjYxIHAuIDE3IGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjYxIHAuIDE3IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2MSBwLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiUHJlbWllzIByZSBlzIFkaXRpb24gcHVibGlxdWUuXCIiLCJBdXRob3IncyBwc2V1ZC4sIEFyZ29ubmUsIGF0IGhlYWQgb2YgdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkZyZW5jaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZnJlIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJmciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiR3JlYXQgQnJpdGFpbuKAlFJlbGF0aW9uc+KAlEZyYW5jZSIsIkZyYW5jZeKAlFJlbGF0aW9uc+KAlEdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWlu4oCUQ2l2aWxpemF0aW9u4oCUSGlzdG9yeSJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJFZGl0aW9ucyBkZSBNaW51aXRcIl19IiwibGNjbl9kaXNwbGF5IjpbIiAgIDQ3MDI4Nzk5ICAiXSwibGNjbl9zIjpbIjQ3MDI4Nzk5Il0sIm9jbGNfcyI6WyI2Njc4NjgxIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20wNjY3ODY4MSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjI0NTM2OTNcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFN5bHZpYSBCZWFjaCBDb2xsZWN0aW9uXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJiZWFjXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiREE0Ny4xIC5EMzUgMTk0NVwifSxcIjI0NTM2OTRcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3NcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImV4XCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIjMyMjkuMzE5LjI4XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjMyMjkuMzE5LjI4XCJ9LFwiMzUyMDU0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiMTQ1OS4yODdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTQ1OS4yODdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImJlYWMiLCJleCIsInJjcHBhIl0sImxvY2F0aW9uIjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvbiIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIiwiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5My4gQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJfdmVyc2lvbl8iOjE2MTE1OTc4NjEwNzEzNTU5MDQsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTU6Mzg6MDguMzc2WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:57:06 GMT
 - request:
     method: get
@@ -9725,7 +9661,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMzNjUyNSIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgQXJ0Il0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnNcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU3BpZWdlbG1hbiwgQXJ0XCJ9IiwiYXV0aG9yX3MiOlsiU3BpZWdlbG1hbiwgQXJ0IiwiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnMiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJNYXVzIDogYSBzdXJ2aXZvcidzIHRhbGUgLyBieSBBcnQgU3BpZWdlbG1hbi4iLCJ0aXRsZV90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBQYW50aGVvbiBCb29rcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5ODYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk4NiwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIxNTkgcC4gOiBpbGwuIDsgMjMgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNTkgcC4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdfSIsImlzYm5fZGlzcGxheSI6WyIwMzk0NzQ3MjMyIDoiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDg2MDQyNjQyICJdLCJsY2NuX3MiOlsiODYwNDI2NDIiXSwiaXNibl9zIjpbIjk3ODAzOTQ3NDcyMzEiXSwiaXNibl90IjpbIjk3ODAzOTQ3NDcyMzEiXSwib2NsY19zIjpbIjEzNTI0MzE0Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwMzk0NzQ3MjMxIiwib2NtMTM1MjQzMTQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIzNjc4ODJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCJ9LFwiMzY3ODgzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJQcmluY2V0b24gY29weSAxXCJdfX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiIsImV4Il0sImxvY2F0aW9uIjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3MiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiZXgiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTcGllZ2VsbWFuLCBBcnQuIE1hdXMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJfdmVyc2lvbl8iOjE2MTE1OTAzODkyMzk2NDQxNjAsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTM6Mzk6MjIuNzQyWiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:57:10 GMT
 - request:
     method: get
@@ -9779,7 +9715,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uIiwiU2Nocm9lZGVyLCBDYXJvbGluZSBULiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC5cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiQ2hpbiwgQ2F0aGVyaW5lIE0uXCJ9IiwiYXV0aG9yX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsInRpdGxlX3QiOlsiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5Il0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEgb25saW5lIHJlc291cmNlIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwicmVsYXRlZF9yZWNvcmRfaW5mb19kaXNwbGF5IjpbIlByaW50IHZlcnNpb246Il0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTWVsYW5pYSB0aGUgRWxkZXIgYW5kIGhlciBncmFuZGRhdWdodGVyIE1lbGFuaWEgdGhlIFlvdW5nZXIgd2VyZSBtYWpvciBmaWd1cmVzIGluIGVhcmx5IENocmlzdGlhbiBoaXN0b3J5LCB1c2luZyB0aGVpciB3ZWFsdGgsIHN0YXR1cywgYW5kIGZvcmNlZnVsIHBlcnNvbmFsaXRpZXMgdG8gc2hhcGUgdGhlIGRldmVsb3BtZW50IG9mIG5lYXJseSBldmVyeSBhc3BlY3Qgb2YgdGhlIHJlbGlnaW9uIHdlIG5vdyBrbm93IGFzIENocmlzdGlhbml0eS4gVGhpcyB2b2x1bWUgZXhhbWluZXMgdGhlIGluZmx1ZW5jZSB0aGF0IHRoZXNlIHR3byB3b21lbiBoYWQgb24gdGhlIGRldmVsb3BtZW50IG9mIENocmlzdGlhbml0eSBhbmQgcHJvdmlkZXMgYW4gaW5zaWdodGZ1bCBwb3J0cmFpdCBvZiB0aGUgdGhlaXIgbGVnYWNpZXMgaW4gdGhlIG1vZGVybiB3b3JsZC4gSW5zdGVhZCBvZiB0aGUgdHJhZGl0aW9uYWxseSBwYXRyaWFyY2hhbCB2aWV3LCB0aGlzIHBlcnNwZWN0aXZlIGdpdmVzIGEgcG9pZ25hbnQgYW5kIHNvbWV0aW1lcyBzdXJwcmlzaW5nIHZpZXcgb2YgaG93IHRoZSByaXNlIG9mIENocmlzdGlhbiBpbnN0aXR1dGlvbnMgaW4gdGhlIFJvbWFuIEVtcGlyZSBzaGFwZWQgdGhlIHVuZGVyc3RhbmRpbmcgb2Ygd29tZW4ncyByb2xlcyBpbiB0aGUgbGFyZ2VyIHdvcmxkLlwiLS1Qcm92aWRlZCBieSBwdWJsaXNoZXIuIl0sImJpYl9yZWZfbm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBiaWJsaW9ncmFwaGljYWwgcmVmZXJlbmNlcyBhbmQgaW5kZXguIl0sInNvdXJjZV9kZXNjX25vdGVzX2Rpc3BsYXkiOlsiRGVzY3JpcHRpb24gYmFzZWQgb24gcHJpbnQgdmVyc2lvbiByZWNvcmQgYW5kIENJUCBkYXRhIHByb3ZpZGVkIGJ5IHB1Ymxpc2hlcjsgcmVzb3VyY2Ugbm90IHZpZXdlZC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKChlbGVjdHJvbmljIGJrLikpIiwiMDUyMDk2NTYzOSAoKGVsZWN0cm9uaWMgYmsuKSkiLCIiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxNjAyMDM0MSJdLCJsY2NuX3MiOlsiMjAxNjAyMDM0MSJdLCJpc2JuX3MiOlsiOTc4MDUyMDk2NTYzOCJdLCJpc2JuX3QiOlsiOTc4MDUyMDk2NTYzOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDUyMDk2NTYzOCIsIjk3ODA1MjAyOTIwODYiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5ODAwOTEwXCI6e1wibG9jYXRpb25cIjpcIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXNcIixcImxpYnJhcnlcIjpcIk9ubGluZVwiLFwibG9jYXRpb25fY29kZVwiOlwiZWxmM1wiLFwiY2FsbF9udW1iZXJcIjpcIkVsZWN0cm9uaWMgUmVzb3VyY2VcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZWxmMyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXMiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJlbGYzIiwiT25saW5lIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLS4gTWVsYW5pYSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkVsZWN0cm9uaWMgUmVzb3VyY2UiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJfdmVyc2lvbl8iOjE2MTE2MjUwODk2MjY4MDAxMjgsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjI6NTA6NTUuNjQ4WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:57:13 GMT
 - request:
     method: get
@@ -9843,7 +9779,7 @@ http_interactions:
         Books","Firestone Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone
         Library"],"call_number_display":["Oversize HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766
         .B53f","HQ766 .B53"],"_version_":1611598476842369024,"timestamp":"2018-09-14T15:47:55.672Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:57:19 GMT
 - request:
     method: get
@@ -9919,7 +9855,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"_version_":1611608287253364736,"timestamp":"2018-09-14T18:23:51.638Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 20 Sep 2018 20:57:25 GMT
 - request:
     method: get
@@ -9973,7 +9909,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMTQ0Njk4IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb2xmZXIsIEFkYW0iLCLXkteV15zXpNeoLCDXkNeT150iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiR29sZmVyLCBBZGFtXCIsXCJHb2xmZXIsIEFkYW1cIixcIkdvbGZlciwgQWRhbVwiLFwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlXCIsXCLXkteV15zXpNeoLCDXkNeT151cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiR29sZmVyLCBBZGFtXCJ9IiwiYXV0aG9yX3MiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIiwi15LXldec16TXqCwg15DXk9edIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIlBob3RvZ3JhcGhlciJdLCJ1bmlmb3JtX3RpdGxlX3MiOlsiUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwidGl0bGVfZGlzcGxheSI6IkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIiwidGl0bGVfdCI6WyJBIGhvdXNlIHdpdGhvdXQgYSByb29mIC8gQWRhbSBHb2xmZXIgOyB0cmFuc2xhdGlvbnM6IE1vc3RhZmEgT3VhamphbmkgKEFyYWJpYyksIEdhYnJpZWxhIFZhaW5zZW5jaGVyIChIZWJyZXcpLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIl0sImVkaXRpb25fZGlzcGxheSI6WyJGaXJzdCBlZGl0aW9uLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY3JlYXRlZF9zIjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJCcm9va2x5biwgTmV3IFlvcms6IEJvb2tseW4iXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTYsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTAzLTMwVDE4OjQ2OjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIDogaWxsdXN0cmF0aW9ucyAoY2hpZWZseSBjb2xvcikgOyAzMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjE2MSBwYWdlcyA6IGlsbHVzdHJhdGlvbnMgKGNoaWVmbHkgY29sb3IpIDsgMzAgY20iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJJc3JhZWwiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiU2hvcnRsaXN0ZWQgZm9yIHRoZSBQYXJpcy1QaG90by8gQXBlcnR1cmUgRmlyc3QgQm9vayBBd2FyZCwgJ0EgSG91c2UgV2l0aG91dCBhIFJvb2YnIGNvbnNpZGVycyB0aGUgb3ZlcmxhcHBpbmcgaGlzdG9yaWVzIG9mIHZpb2xlbmNlIGFuZCBkaXNwbGFjZW1lbnQgY29ubmVjdGluZyBFdXJvcGUsIElzcmFlbCBhbmQgUGFsZXN0aW5lLiBXaXRoIHBob3RvZ3JhcGhzLCBhcmNoaXZhbCBpbWFnZXJ5IGFuZCBvcmlnaW5hbCB0ZXh0cywgQnJvb2tseW4tYmFzZWQgYXJ0aXN0IEFkYW0gR29sZmVyIHdlYXZlcyB0b2dldGhlciBmaWN0aW9ucyBvZiBoaXMgZmFtaWx5IGhpc3Rvcnkgd2l0aCByZXByZXNlbnRhdGlvbnMgZnJvbSBJc3JhZWw/cyBmb3VuZGluZyBhbmQgb25nb2luZyBtaWxpdGFyeSBvY2N1cGF0aW9uLiBFdGhuaWMgYW5kIG5hdGlvbmFsIGlkZW50aXRpZXMgYXJlIHJ1cHR1cmVkIGFuZCByZWFzc2VtYmxlZCBhcyBoZSBpbnRlcnJvZ2F0ZXMgY29udHJhZGljdG9yeSBoaXN0b3JpZXMgYW5kIG5vdGlvbnMgb2Ygc2VsZmhvb2QsIGV4cGxvcmluZyBzdHJhbmRzIHRoYXQgY29ubmVjdCB0aGUgSmV3aXNoIERpYXNwb3JhIG91dCBvZiBFdXJvcGUgYW5kIGZvcmNlZCBtYXNzIG1pZ3JhdGlvbnMgZnJvbSBQYWxlc3RpbmUgZm9sbG93aW5nIFdvcmxkIFdhciBJSS4gR29sZmVyIHNpdHVhdGVzIHRoaXMgaW5xdWlyeSB0aHJvdWdoIHRoZSB0cmlhbmd1bGFyIHJlbGF0aW9uc2hpcCBiZXR3ZWVuIGhpcyBncmFuZGZhdGhlciAoYSBzdXJ2aXZvciBvZiBEYWNoYXUpLCBoaXMgZmF0aGVyICh3aG8gbGl2ZWQgb24gYSBraWJidXR6IGluIHRoZSBlYXJseSAxOTcwcykgYW5kIGhpbXNlbGYuIl0sIm5vdGVzX2Rpc3BsYXkiOlsiQ292ZXIgdGl0bGUuIiwiUHVibGlzaGVkIG9uIHRoZSBvY2Nhc2lvbiBvZiBhbiBleGhpYml0aW9uIGhlbGQgYXQgQm9va2x5biwgSnVseSAxMC1TZXB0ZW1iZXIgNSwgMjAxNS4iXSwibGFuZ3VhZ2VfZGlzcGxheSI6WyJUZXh0IGluIEVuZ2xpc2ggd2l0aCBIZWJyZXcgYW5kIEFyYWJpYyBhdCB0aGUgYm90dG9tIG9mIHRoZSBwYWdlcy4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCIsIkhlYnJldyIsIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIiwiaGViIiwiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiIsImhlIiwiYXIiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIkhvc3QgaW5zdGl0dXRpb25cIjpbXCJCb29rbHluIEFydGlzdHMgQWxsaWFuY2VcIl19IiwiY29udGFpbnNfMWRpc3BsYXkiOiJbW1wiR29sZmVyLCBBZGFtLlwiLFwiSG91c2Ugd2l0aG91dCBhIHJvb2YuXCJdLFtcIkdvbGZlciwgQWRhbS5cIixcIkhvdXNlIHdpdGhvdXQgYSByb29mLlwiLFwiSGVicmV3LlwiXSxbXCJHb2xmZXIsIEFkYW0uXCIsXCJIb3VzZSB3aXRob3V0IGEgcm9vZi5cIixcIkFyYWJpYy5cIl1dIiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyJCYXlpdCBiZWxpIGdhZyIsIteR15nXqiDXkdec15kg15LXkiJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiQmF5aXQgYmVsaSBnYWciLCLXkdeZ16og15HXnNeZINeS15IiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODA2OTI3MjY1MDEiLCIwNjkyNzI2NTAwIl0sImlzYm5fcyI6WyI5NzgwNjkyNzI2NTAxIl0sImlzYm5fdCI6WyI5NzgwNjkyNzI2NTAxIl0sIm9jbGNfcyI6WyI5ODE3NjY2NjAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjk4MTc2NjY2MCIsIjk3ODA2OTI3MjY1MDEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5OTMzODc4XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBqXCIsXCJjYWxsX251bWJlclwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBqIl0sImxvY2F0aW9uIjpbIlJlQ0FQIiwiTWFycXVhbmQgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBqIiwiUmVDQVAiLCJNYXJxdWFuZCBMaWJyYXJ5Il0sIm5hbWVfdW5pZm9ybV90aXRsZV8xZGlzcGxheSI6IltbXCJHb2xmZXIsIEFkYW0uXCIsXCJQaG90b2dyYXBocy5cIixcIlNlbGVjdGlvbnNcIl1dIiwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb2xmZXIsIEFkYW0uIEhvdXNlIHdpdGhvdXQgYSByb29mIiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gSGVicmV3IiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gQXJhYmljIiwiR29sZmVyLCBBZGFtLiBQaG90b2dyYXBocyIsIkdvbGZlciwgQWRhbS4gUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJfdmVyc2lvbl8iOjE2MTE2MjU2OTc5NTE4NzUwNzIsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjM6MDA6MzUuNzUzWiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:12:02 GMT
 - request:
     method: get
@@ -10027,7 +9963,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMzNjUyNSIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgQXJ0Il0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnNcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU3BpZWdlbG1hbiwgQXJ0XCJ9IiwiYXV0aG9yX3MiOlsiU3BpZWdlbG1hbiwgQXJ0IiwiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnMiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJNYXVzIDogYSBzdXJ2aXZvcidzIHRhbGUgLyBieSBBcnQgU3BpZWdlbG1hbi4iLCJ0aXRsZV90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBQYW50aGVvbiBCb29rcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5ODYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk4NiwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIxNTkgcC4gOiBpbGwuIDsgMjMgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNTkgcC4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdfSIsImlzYm5fZGlzcGxheSI6WyIwMzk0NzQ3MjMyIDoiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDg2MDQyNjQyICJdLCJsY2NuX3MiOlsiODYwNDI2NDIiXSwiaXNibl9zIjpbIjk3ODAzOTQ3NDcyMzEiXSwiaXNibl90IjpbIjk3ODAzOTQ3NDcyMzEiXSwib2NsY19zIjpbIjEzNTI0MzE0Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwMzk0NzQ3MjMxIiwib2NtMTM1MjQzMTQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIzNjc4ODJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCJ9LFwiMzY3ODgzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJQcmluY2V0b24gY29weSAxXCJdfX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiIsImV4Il0sImxvY2F0aW9uIjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3MiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiZXgiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTcGllZ2VsbWFuLCBBcnQuIE1hdXMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJfdmVyc2lvbl8iOjE2MTE1OTAzODkyMzk2NDQxNjAsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTM6Mzk6MjIuNzQyWiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:13:08 GMT
 - request:
     method: get
@@ -10081,7 +10017,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQiLCJCb2huZXIsIEthdGUiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJCb2huZXIsIEthdGVcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiVHJ1bXAsIERvbmFsZFwifSIsImF1dGhvcl9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIiwiQm9obmVyLCBLYXRlIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiIsInRpdGxlX3QiOlsiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2siXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsieHgsIDI0NCBwLiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGluZGV4LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJfdmVyc2lvbl8iOjE2MTE1OTY0NDMyNzYwMTc2NjQsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTU6MTU6MzYuMjcwWiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:13:10 GMT
 - request:
     method: get
@@ -10135,7 +10071,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb3RvzIQsIE1laXNlaSwgMTkzMi0xOTk5Iiwi5b6M6Jek5piO55SfLCAxOTMyLTE5OTkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR290b8yELCBNZWlzZWkiLCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wi5b6M6Jek5piO55SfXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1XCIsXCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrlcIl0sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvzIQsIE1laXNlaVwifSIsImF1dGhvcl9zIjpbIkdvdG/MhCwgTWVpc2VpLCAxOTMyLTE5OTkiLCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1Iiwi5b6M6Jek5piO55SfLCAxOTMyLTE5OTkiLCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrkiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiSW50ZXJ2aWV3ZWUiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRhIGt1amlzaGlraSBHb3RvzIQgTWVpc2VpLiBaYWRhbiBoZW4gLyBHb3RvzIQgTWVpc2VpIDsgQcyEcmnMhCBCYcyEZG8gQnVra3VzdSBoZW4uIiwidGl0bGVfdmVybl9kaXNwbGF5Ijoi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744KkLiDluqfoq4fnr4cgLyDlvozol6TmmI7nlJ8gOyDjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrnnt6guIiwidGl0bGVfdCI6WyJBbWlkYSBrdWppc2hpa2kgR290b8yEIE1laXNlaS4gWmFkYW4gaGVuIC8gR290b8yEIE1laXNlaSA7IEHMhHJpzIQgQmHMhGRvIEJ1a2t1c3UgaGVuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkFtaWRhIGt1amlzaGlraSBHb3RvzIQgTWVpc2VpIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744KkLiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW1pZGEga3VqaXNoaWtpIEdvdG/MhCBNZWlzZWkuIFphZGFuIGhlbiAvIEdvdG/MhCBNZWlzZWkgOyBBzIRyacyEIEJhzIRkbyBCdWtrdXN1IGhlbi4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqQuIOW6p+irh+evhyAvIOW+jOiXpOaYjueUnyA7IOOCouODvOODquODvOODkOODvOODieODu+ODluODg+OCr+OCuee3qC4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIkRhaSAxLWhhbi4iLCLnrKwx54mILiJdLCJwdWJfY3JlYXRlZF92ZXJuX2Rpc3BsYXkiOlsi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlRvzIRreW/MhCA6IFRzdWthZGFtYSBTaG9ib8yELCAyMDE3LiIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNy4iXSwicHViX2NyZWF0ZWRfcyI6WyJUb8yEa3lvzIQgOiBUc3VrYWRhbWEgU2hvYm/MhCwgMjAxNy4iLCLmnbHkuqwgOiDjgaTjgYvjgaDjgb7mm7jmiL8sIDIwMTcuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRvzIRreW/MhDogVHN1a2FkYW1hIFNob2JvzIQiLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywicHViX2RhdGVfZW5kX3NvcnQiOjIwMTcsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTA4LTI0VDE3OjI2OjM3WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNDQ2IHBhZ2VzIDsgMjIgY20iXSwiZGVzY3JpcHRpb25fdCI6WyI0NDYgcGFnZXMgOyAyMiBjbSJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI0NDYgcGFnZXMiXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiamEiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJFZGl0b3JcIjpbXCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1XCIsXCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrlcIl19Iiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyLluqfoq4fnr4ciXSwiYWx0X3RpdGxlXzI0Nl9kaXNwbGF5IjpbIuW6p+irh+evhyJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCIsIjQ5MDg2MjQwMTEiXSwiaXNibl9zIjpbIjk3ODQ5MDg2MjQwMTgiXSwiaXNibl90IjpbIjk3ODQ5MDg2MjQwMTgiXSwib2NsY19zIjpbIjk4ODI1MzIwMyJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTg4MjUzMjAzIiwiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIlBMODUxLk84MyBBNjIyIDIwMTdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiUEw4NTEuTzgzIEE2MjIgMjAxN1wifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb3RvzIQsIE1laXNlaSwgMTkzMi0xOTk5LiBBbWlkYSBrdWppc2hpa2kgR290b8yEIE1laXNlaSIsIuW+jOiXpOaYjueUnywgMTkzMi0xOTk5LiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqQuIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUEw4NTEuTzgzIEE2MjIgMjAxNyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJQTDg1MS5PODMgQTYyMiAyMDE3Il0sIl92ZXJzaW9uXyI6MTYxMjA0ODE0MTk2MTM5NjIyNCwidGltZXN0YW1wIjoiMjAxOC0wOS0xOVQxNDo1NTowOS43MDRaIn19fQ==
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:13:12 GMT
 - request:
     method: get
@@ -10189,7 +10125,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5MyJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXNcIn0iLCJhdXRob3JfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwidGl0bGVfdCI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NyZWF0ZWRfcyI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGFyaXMiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTQzIl0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NDMsInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTQ1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0wNVQxODoxOToyMloiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjYxIHAuIDE3IGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjYxIHAuIDE3IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2MSBwLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiUHJlbWllzIByZSBlzIFkaXRpb24gcHVibGlxdWUuXCIiLCJBdXRob3IncyBwc2V1ZC4sIEFyZ29ubmUsIGF0IGhlYWQgb2YgdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkZyZW5jaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZnJlIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJmciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiR3JlYXQgQnJpdGFpbuKAlFJlbGF0aW9uc+KAlEZyYW5jZSIsIkZyYW5jZeKAlFJlbGF0aW9uc+KAlEdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWlu4oCUQ2l2aWxpemF0aW9u4oCUSGlzdG9yeSJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJFZGl0aW9ucyBkZSBNaW51aXRcIl19IiwibGNjbl9kaXNwbGF5IjpbIiAgIDQ3MDI4Nzk5ICAiXSwibGNjbl9zIjpbIjQ3MDI4Nzk5Il0sIm9jbGNfcyI6WyI2Njc4NjgxIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20wNjY3ODY4MSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjI0NTM2OTNcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFN5bHZpYSBCZWFjaCBDb2xsZWN0aW9uXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJiZWFjXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiREE0Ny4xIC5EMzUgMTk0NVwifSxcIjI0NTM2OTRcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3NcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImV4XCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIjMyMjkuMzE5LjI4XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjMyMjkuMzE5LjI4XCJ9LFwiMzUyMDU0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiMTQ1OS4yODdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTQ1OS4yODdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImJlYWMiLCJleCIsInJjcHBhIl0sImxvY2F0aW9uIjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvbiIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIiwiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5My4gQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJfdmVyc2lvbl8iOjE2MTE1OTc4NjEwNzEzNTU5MDQsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTU6Mzg6MDguMzc2WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:13:19 GMT
 - request:
     method: get
@@ -10253,7 +10189,7 @@ http_interactions:
         Books","Firestone Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone
         Library"],"call_number_display":["Oversize HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766
         .B53f","HQ766 .B53"],"_version_":1611598476842369024,"timestamp":"2018-09-14T15:47:55.672Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:13:21 GMT
 - request:
     method: get
@@ -10307,7 +10243,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJhdXRob3JfcyI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NyZWF0ZWRfcyI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2VuZWdhbDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNiJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE2LCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDktMjBUMTk6MzQ6MTRaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJBZnJpY2EiLCJTZW5lZ2FsIl0sImNvbnRpbnVlc19kaXNwbGF5IjpbIkXMgWNyaXZhaW4sIGpvdXJuYWwgY3VsdHVyZWwgcGFuYWZyaWNhaW4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbjogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pOyB0aXRsZSBmcm9tIGNvdmVyLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IEhvcnMgc2XMgXJpZSAocHVibGlzaGVkIGluIDIwMTY/KS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImZyIl0sInN1YmplY3RfZGlzcGxheSI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJfdmVyc2lvbl8iOjE2MTE2MTI4Njc3OTYxNDAwMzIsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTk6MzY6MzkuODk2WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:13:26 GMT
 - request:
     method: get
@@ -10361,7 +10297,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uIiwiU2Nocm9lZGVyLCBDYXJvbGluZSBULiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC5cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiQ2hpbiwgQ2F0aGVyaW5lIE0uXCJ9IiwiYXV0aG9yX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsInRpdGxlX3QiOlsiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5Il0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEgb25saW5lIHJlc291cmNlIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwicmVsYXRlZF9yZWNvcmRfaW5mb19kaXNwbGF5IjpbIlByaW50IHZlcnNpb246Il0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTWVsYW5pYSB0aGUgRWxkZXIgYW5kIGhlciBncmFuZGRhdWdodGVyIE1lbGFuaWEgdGhlIFlvdW5nZXIgd2VyZSBtYWpvciBmaWd1cmVzIGluIGVhcmx5IENocmlzdGlhbiBoaXN0b3J5LCB1c2luZyB0aGVpciB3ZWFsdGgsIHN0YXR1cywgYW5kIGZvcmNlZnVsIHBlcnNvbmFsaXRpZXMgdG8gc2hhcGUgdGhlIGRldmVsb3BtZW50IG9mIG5lYXJseSBldmVyeSBhc3BlY3Qgb2YgdGhlIHJlbGlnaW9uIHdlIG5vdyBrbm93IGFzIENocmlzdGlhbml0eS4gVGhpcyB2b2x1bWUgZXhhbWluZXMgdGhlIGluZmx1ZW5jZSB0aGF0IHRoZXNlIHR3byB3b21lbiBoYWQgb24gdGhlIGRldmVsb3BtZW50IG9mIENocmlzdGlhbml0eSBhbmQgcHJvdmlkZXMgYW4gaW5zaWdodGZ1bCBwb3J0cmFpdCBvZiB0aGUgdGhlaXIgbGVnYWNpZXMgaW4gdGhlIG1vZGVybiB3b3JsZC4gSW5zdGVhZCBvZiB0aGUgdHJhZGl0aW9uYWxseSBwYXRyaWFyY2hhbCB2aWV3LCB0aGlzIHBlcnNwZWN0aXZlIGdpdmVzIGEgcG9pZ25hbnQgYW5kIHNvbWV0aW1lcyBzdXJwcmlzaW5nIHZpZXcgb2YgaG93IHRoZSByaXNlIG9mIENocmlzdGlhbiBpbnN0aXR1dGlvbnMgaW4gdGhlIFJvbWFuIEVtcGlyZSBzaGFwZWQgdGhlIHVuZGVyc3RhbmRpbmcgb2Ygd29tZW4ncyByb2xlcyBpbiB0aGUgbGFyZ2VyIHdvcmxkLlwiLS1Qcm92aWRlZCBieSBwdWJsaXNoZXIuIl0sImJpYl9yZWZfbm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBiaWJsaW9ncmFwaGljYWwgcmVmZXJlbmNlcyBhbmQgaW5kZXguIl0sInNvdXJjZV9kZXNjX25vdGVzX2Rpc3BsYXkiOlsiRGVzY3JpcHRpb24gYmFzZWQgb24gcHJpbnQgdmVyc2lvbiByZWNvcmQgYW5kIENJUCBkYXRhIHByb3ZpZGVkIGJ5IHB1Ymxpc2hlcjsgcmVzb3VyY2Ugbm90IHZpZXdlZC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKChlbGVjdHJvbmljIGJrLikpIiwiMDUyMDk2NTYzOSAoKGVsZWN0cm9uaWMgYmsuKSkiLCIiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxNjAyMDM0MSJdLCJsY2NuX3MiOlsiMjAxNjAyMDM0MSJdLCJpc2JuX3MiOlsiOTc4MDUyMDk2NTYzOCJdLCJpc2JuX3QiOlsiOTc4MDUyMDk2NTYzOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDUyMDk2NTYzOCIsIjk3ODA1MjAyOTIwODYiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5ODAwOTEwXCI6e1wibG9jYXRpb25cIjpcIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXNcIixcImxpYnJhcnlcIjpcIk9ubGluZVwiLFwibG9jYXRpb25fY29kZVwiOlwiZWxmM1wiLFwiY2FsbF9udW1iZXJcIjpcIkVsZWN0cm9uaWMgUmVzb3VyY2VcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZWxmMyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXMiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJlbGYzIiwiT25saW5lIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLS4gTWVsYW5pYSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkVsZWN0cm9uaWMgUmVzb3VyY2UiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJfdmVyc2lvbl8iOjE2MTE2MjUwODk2MjY4MDAxMjgsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjI6NTA6NTUuNjQ4WiJ9fX0=
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:13:30 GMT
 - request:
     method: get
@@ -10437,7 +10373,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"_version_":1611608287253364736,"timestamp":"2018-09-14T18:23:51.638Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 00:13:32 GMT
 - request:
     method: get
@@ -10509,7 +10445,7 @@ http_interactions:
         Library"],"location_display":["Marquand Library"],"advanced_location_s":["sa","Marquand
         Library"],"name_title_browse_s":["Burrows, Roger. 3D THINKING IN DESIGN AND
         ARCHITECTURE: FROM ANTIQUITY TO THE FUTURE"],"_version_":1612048154518093824,"timestamp":"2018-09-19T14:55:21.689Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 14:00:10 GMT
 - request:
     method: get
@@ -10561,7 +10497,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"10672583":{"more_items":false,"location":"sa","status":"Pending Order","label":"Marquand
         Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 14:00:10 GMT
 - request:
     method: get
@@ -10633,7 +10569,7 @@ http_interactions:
         Library"],"location_display":["Marquand Library"],"advanced_location_s":["sa","Marquand
         Library"],"name_title_browse_s":["Burrows, Roger. 3D THINKING IN DESIGN AND
         ARCHITECTURE: FROM ANTIQUITY TO THE FUTURE"],"_version_":1612048154518093824,"timestamp":"2018-09-19T14:55:21.693Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 14:00:25 GMT
 - request:
     method: get
@@ -10685,7 +10621,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"10672583":{"more_items":false,"location":"sa","status":"Pending Order","label":"Marquand
         Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 14:00:25 GMT
 - request:
     method: get
@@ -10757,7 +10693,7 @@ http_interactions:
         Library"],"location_display":["Marquand Library"],"advanced_location_s":["sa","Marquand
         Library"],"name_title_browse_s":["Burrows, Roger. 3D THINKING IN DESIGN AND
         ARCHITECTURE: FROM ANTIQUITY TO THE FUTURE"],"_version_":1612048154518093824,"timestamp":"2018-09-19T14:55:21.693Z"}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 14:21:18 GMT
 - request:
     method: get
@@ -10809,7 +10745,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"10672583":{"more_items":false,"location":"sa","status":"Pending Order","label":"Marquand
         Library"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 14:21:18 GMT
 - request:
     method: get
@@ -10863,6 +10799,6 @@ http_interactions:
         Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand
         Library of Art and Archaeology","code":"marquand"},"delivery_locations":[{"label":"Marquand
         Library of Art and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 21 Sep 2018 14:21:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/request_models.yml
+++ b/spec/cassettes/request_models.yml
@@ -18237,4 +18237,162 @@ http_interactions:
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk3MzgxMzYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkd1zIhyY2FuLCBNZXRpbiJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJHdcyIcmNhbiwgTWV0aW4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHdcyIcmNhbiwgTWV0aW5cIn0iLCJhdXRob3JfcyI6WyJHdcyIcmNhbiwgTWV0aW4iXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJXaGF0IHdlbnQgd3JvbmcgaW4gQWZnaGFuaXN0YW4gOiB1bmRlcnN0YW5kaW5nIGNvdW50ZXJpbnN1cmdlbmN5IGVmZm9ydHMgaW4gdHJpYmFsaXplZCBydXJhbCBhbmQgTXVzbGltIGVudmlyb25tZW50cyAvIE1ldGluIEd1cmNhbi4iLCJ0aXRsZV90IjpbIldoYXQgd2VudCB3cm9uZyBpbiBBZmdoYW5pc3RhbiA6IHVuZGVyc3RhbmRpbmcgY291bnRlcmluc3VyZ2VuY3kgZWZmb3J0cyBpbiB0cmliYWxpemVkIHJ1cmFsIGFuZCBNdXNsaW0gZW52aXJvbm1lbnRzIC8gTWV0aW4gR3VyY2FuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIldoYXQgd2VudCB3cm9uZyBpbiBBZmdoYW5pc3RhbiA6IHVuZGVyc3RhbmRpbmcgY291bnRlcmluc3VyZ2VuY3kgZWZmb3J0cyBpbiB0cmliYWxpemVkIHJ1cmFsIGFuZCBNdXNsaW0gZW52aXJvbm1lbnRzIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJXaGF0IHdlbnQgd3JvbmcgaW4gQWZnaGFuaXN0YW4gOiB1bmRlcnN0YW5kaW5nIGNvdW50ZXJpbnN1cmdlbmN5IGVmZm9ydHMgaW4gdHJpYmFsaXplZCBydXJhbCBhbmQgTXVzbGltIGVudmlyb25tZW50cyAvIE1ldGluIEd1cmNhbi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTb2xpaHVsbCwgV2VzdCBNaWRsYW5kcywgRW5nbGFuZCA6IEhlbGlvbiBcdTAwMjYgQ29tcGFueSBMaW1pdGVkLCAyMDE2LiIsIsKpMjAxNiJdLCJwdWJfY3JlYXRlZF9zIjpbIlNvbGlodWxsLCBXZXN0IE1pZGxhbmRzLCBFbmdsYW5kIDogSGVsaW9uIFx1MDAyNiBDb21wYW55IExpbWl0ZWQsIDIwMTYuIiwiwqkyMDE2Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNvbGlodWxsLCBXZXN0IE1pZGxhbmRzLCBFbmdsYW5kOiBIZWxpb24gXHUwMDI2IENvbXBhbnkgTGltaXRlZCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTYsImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA3LTIzVDAxOjI5OjQ5WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTM3IHBhZ2VzIDogaWxsdXN0cmF0aW9ucywgbWFwcyA7IDI0IGNtIl0sImRlc2NyaXB0aW9uX3QiOlsiMTM3IHBhZ2VzIDogaWxsdXN0cmF0aW9ucywgbWFwcyA7IDI0IGNtIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEzNyBwYWdlcyJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiQWZnaGFuaXN0YW4iXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiQUZHSEFOIFdBUi4gU2luY2UgMjAgRGVjZW1iZXIgMjAwMSAtIHRoZSBkYXRlIHdoaWNoIG1hcmtlZCB0aGUgYXV0aG9yaXNhdGlvbiBvZiB0aGUgSW50ZXJuYXRpb25hbCBTZWN1cml0eSBBc3Npc3RhbmNlIEZvcmNlIChJU0FGKSB0byBhc3Npc3QgdGhlIEFmZ2hhbiBHb3Zlcm5tZW50IC0gaHVuZHJlZHMgb2YgdGhvdXNhbmRzIG9mIGNvYWxpdGlvbiBzb2xkaWVycyBmcm9tIGFyb3VuZCA1MCBkaWZmZXJlbnQgc3RhdGVzIGhhdmUgcGh5c2ljYWxseSBiZWVuIGFuZCBzZXJ2ZWQgaW4gQWZnaGFuaXN0YW4uIFJvdWdobHkgMjAgcm90YXRpb24gcGVyaW9kcyBoYXZlIGJlZW4gZXhwZXJpZW5jZWQ7IGJpbGxpb25zIG9mIFVTIGRvbGxhcnMgaGF2ZSBiZWVuIHNwZW50OyBhbmQgYWxtb3N0IDMsNTAwIGNvYWxpdGlvbiBzb2xkaWVycyBhbmQgNyw0MDAgQWZnaGFuaSBzZWN1cml0eSBwZXJzb25uZWwgaGF2ZSBmYWxsZW4gZm9yIEFmZ2hhbmlzdGFuLiBJbiB0aGlzIGJhZGx5LW1hbmFnZWQgc3VjY2VzcyBzdG9yeSwgdGhlIHRydWUgZGV0ZXJtaW5lciBvZiBib3RoIHRhY3RpY2FsIG91dGNvbWVzIG9uIHRoZSBncm91bmQgYW5kIHN0cmF0ZWdpYyByZXN1bHRzIHdhcyBhbHdheXMgdGhlIHRyaWJhbCBhbmQgcnVyYWwgcGFydHMgb2YgTXVzbGltLXBvcHVsYXRlZCBBZmdoYW5pc3Rhbi4gQWx0aG91Z2ggdGhlcmUgaGFzIGVtZXJnZWQgYSB2YXN0IGxpdGVyYXR1cmUgb24gY291bnRlcmluc3VyZ2VuY3kgdGhlb3JpZXMgYW5kIHRhY3RpY3MsIHdlIHN0aWxsIGxhY2sgcmVsaWFibGUgaW5mb3JtYXRpb24gYWJvdXQgdGhlIG1vdGl2YXRpb25zIGFuZCBhc3BpcmF0aW9ucyBvZiB0aGUgcmVzaWRlbnRzIG9mIFRyaWJhbGlzZWQgUnVyYWwgTXVzbGltIEVudmlyb25tZW50cyAoVFJNRXMpIHRoYXQgbWFrZSB1cCBtb3N0IG9mIEFmZ2hhbmlzdGFuLiJdLCJiaWJfcmVmX25vdGVzX2Rpc3BsYXkiOlsiSW5jbHVkZXMgYmlibGlvZ3JhcGhpY2FsIHJlZmVyZW5jZXMgKHBhZ2VzIDEzMi0xMzUpIGFuZCBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiUGVhY2UtYnVpbGRpbmfigJRBZmdoYW5pc3RhbiIsIk5hdGlvbmFsIHNlY3VyaXR54oCUQWZnaGFuaXN0YW4iLCJBZmdoYW5pc3RhbuKAlFBvbGl0aWNzIGFuZCBnb3Zlcm5tZW504oCUMjAwMS0iXSwic3ViamVjdF9mYWNldCI6WyJQZWFjZS1idWlsZGluZ+KAlEFmZ2hhbmlzdGFuIiwiTmF0aW9uYWwgc2VjdXJpdHnigJRBZmdoYW5pc3RhbiIsIkFmZ2hhbmlzdGFu4oCUUG9saXRpY3MgYW5kIGdvdmVybm1lbnTigJQyMDAxLSJdLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIldoYXQgd2VudCB3cm9uZyBpbiBBZmdoYW5pc3Rhbj8iXSwiYWx0X3RpdGxlXzI0Nl9kaXNwbGF5IjpbIldoYXQgd2VudCB3cm9uZyBpbiBBZmdoYW5pc3Rhbj8iXSwiaXNibl9kaXNwbGF5IjpbIjk3ODE5MTEwOTYwMDkiLCIxOTExMDk2MDAxIl0sImlzYm5fcyI6WyI5NzgxOTExMDk2MDA5Il0sImlzYm5fdCI6WyI5NzgxOTExMDk2MDA5Il0sIm9jbGNfcyI6WyI5NTM0NDMxMzYiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODE5MTEwOTYwMDkiLCJvY245NTM0NDMxMzYiXSwic3ViamVjdF9lcmFfZmFjZXQiOlsiMjAwMS0iXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5NTU4MDM4XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY2FsbF9udW1iZXJcIjpcIkpaNTU4NC5BMzMgRzg3IDIwMTZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSlo1NTg0LkEzMyBHODcgMjAxNlwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiZiIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiR3XMiHJjYW4sIE1ldGluLiBXaGF0IHdlbnQgd3JvbmcgaW4gQWZnaGFuaXN0YW4iXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJKWjU1ODQuQTMzIEc4NyAyMDE2Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkpaNTU4NC5BMzMgRzg3IDIwMTYiXSwiX3ZlcnNpb25fIjoxNjExNjI0MzE4NDUzNjc4MDgwLCJ0aW1lc3RhbXAiOiIyMDE4LTA5LTE0VDIyOjM4OjQwLjExN1oifX19
     http_version: 
   recorded_at: Thu, 20 Sep 2018 20:59:18 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/345682.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - c2386a4c-af49-4a80-86da-6de204cf97fc
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"5bc67061aa1c6ba73fbe42319357aa4a"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.015667'
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 27 Sep 2018 20:32:43 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.3.4
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjM0NTY4MiIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX2Rpc3BsYXkiOlsiV2hpdGUsIE1pY2hhZWwgTS4iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiV2hpdGUsIE1pY2hhZWwgTS4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJXaGl0ZSwgTWljaGFlbCBNLlwifSIsImF1dGhvcl9zIjpbIldoaXRlLCBNaWNoYWVsIE0uIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiT3Bwb3J0dW5pdHkgaW4gY3Jpc2lzIDogbW9uZXkgYW5kIHBvd2VyIGluIHdvcmxkIHBvbGl0aWNzIDE5ODYtODggLyBNaWNoYWVsIE0uIFdoaXRlLiIsInRpdGxlX3QiOlsiT3Bwb3J0dW5pdHkgaW4gY3Jpc2lzIDogbW9uZXkgYW5kIHBvd2VyIGluIHdvcmxkIHBvbGl0aWNzIDE5ODYtODggLyBNaWNoYWVsIE0uIFdoaXRlLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk9wcG9ydHVuaXR5IGluIGNyaXNpcyA6IG1vbmV5IGFuZCBwb3dlciBpbiB3b3JsZCBwb2xpdGljcyAxOTg2LTg4Il0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJPcHBvcnR1bml0eSBpbiBjcmlzaXMgOiBtb25leSBhbmQgcG93ZXIgaW4gd29ybGQgcG9saXRpY3MgMTk4Ni04OCAvIE1pY2hhZWwgTS4gV2hpdGUuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTG9uZG9uIDogRmlyZXRob3JuIFByZXNzLCAxOTg1LiJdLCJwdWJfY3JlYXRlZF9zIjpbIkxvbmRvbiA6IEZpcmV0aG9ybiBQcmVzcywgMTk4NS4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTG9uZG9uOiBGaXJldGhvcm4gUHJlc3MiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTg1Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5ODUsImNhdGFsb2dlZF90ZHQiOiIyMDAwLTA2LTEzVDA0OjAwOjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMzQxIHAuIDsgMjQgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMzQxIHAuIDsgMjQgY20uIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjM0MSBwLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJJbnRlcm5hdGlvbmFsIHJlbGF0aW9ucyIsIldvcmxkIHBvbGl0aWNz4oCUMTk4NS0xOTk1Il0sInN1YmplY3RfZmFjZXQiOlsiSW50ZXJuYXRpb25hbCByZWxhdGlvbnMiLCJXb3JsZCBwb2xpdGljc+KAlDE5ODUtMTk5NSJdLCJpc2JuX2Rpc3BsYXkiOlsiMDk0Nzc1MjE5NiJdLCJpc2JuX3MiOlsiOTc4MDk0Nzc1MjE5NCJdLCJpc2JuX3QiOlsiOTc4MDk0Nzc1MjE5NCJdLCJvY2xjX3MiOlsiMTMxNTQwNjciXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA5NDc3NTIxOTQiLCJvY20xMzE1NDA2NyJdLCJzdWJqZWN0X2VyYV9mYWNldCI6WyIxOTg1LTE5OTUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIzNzc2NzhcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJKWDEzOTUgLlc0NFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJKWDEzOTUgLlc0NFwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJXaGl0ZSwgTWljaGFlbCBNLi4gT3Bwb3J0dW5pdHkgaW4gY3Jpc2lzIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiSlgxMzk1IC5XNDQiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSlgxMzk1IC5XNDQiXSwiX3ZlcnNpb25fIjoxNjExNTkwNDc3MTU0MzUzMTUyLCJ0aW1lc3RhbXAiOiIyMDE4LTA5LTE0VDEzOjQwOjQ2LjYzM1oifX19
+    http_version: 
+  recorded_at: Thu, 27 Sep 2018 20:32:43 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?id=345682
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"a9350c43ffcf80cf2d5c3b4e00701dbf"
+      X-Runtime:
+      - '0.085697'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - '09587704-4a1e-4c42-a6cb-c9f31f27489b'
+      Date:
+      - Thu, 27 Sep 2018 20:32:42 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.3.4
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.4
+    body:
+      encoding: ASCII-8BIT
+      string: '{"377678":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":390955,"on_reserve":"N","status":"Not
+        Charged","label":"ReCAP"}}'
+    http_version: 
+  recorded_at: Thu, 27 Sep 2018 20:32:43 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=377678
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"ec5ba9ed644674fd89c257b54394209b"
+      X-Runtime:
+      - '0.054793'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 4a1d0134-ab0c-4db3-9c06-2dd01e730fd8
+      Date:
+      - Thu, 27 Sep 2018 20:32:43 GMT
+      X-Powered-By:
+      - Phusion Passenger 5.3.4
+      Server:
+      - nginx/1.14.0 + Phusion Passenger 5.3.4
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"barcode":"32101043718731","id":390955,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
+        Charged","on_reserve":"N","label":"ReCAP"}]'
+    http_version: 
+  recorded_at: Thu, 27 Sep 2018 20:32:44 GMT
+recorded_with: VCR 4.0.0

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -570,6 +570,9 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:firestone_circ) {
       { label: "Firestone Library", gfa_code: "PA" }
     }
+    let(:architecture) {
+      { label: "Architecture Library", gfa_code: "PW" }
+    }
     subject { request_with_on_order }
 
     describe "#requestable" do
@@ -595,6 +598,10 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
 
       it "should list Firestone as the first choice" do
         expect(subject.default_pickups.first).to eq(firestone_circ)
+      end
+
+      it "should alpha sort the pickups between Firestone and staff locations" do
+        expect(subject.default_pickups[1]).to eq(architecture)
       end
     end
   end

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -568,10 +568,10 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     }
     let(:request_with_on_order) { described_class.new(params) }
     let(:firestone_circ) {
-      { label: "Firestone Library", gfa_code: "PA" }
+      { label: "Firestone Library", gfa_code: "PA", staff_only: false }
     }
     let(:architecture) {
-      { label: "Architecture Library", gfa_code: "PW" }
+      { label: "Architecture Library", gfa_code: "PW", staff_only: false }
     }
     subject { request_with_on_order }
 


### PR DESCRIPTION
Supersedes #381. Fixes #264. Floats "Firestone" to the top of the list and staff only locations to the bottom, follows alpha sort outside of those exceptions.