### PR TITLE
Ensuring that cases where Requests::Requestable#location are nil (or location[:library] is missing the key :code) are handled

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,19 @@ Bundler/DuplicatedGem:
   Exclude:
     - 'Gemfile'
 
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'app/models/requests/requestable.rb'
+    - 'app/controllers/requests/request_controller.rb'
+    - 'app/helpers/requests/application_helper.rb'
+    - 'app/models/concerns/requests/aeon.rb'
+    - 'app/models/concerns/requests/ctx.rb'
+    - 'app/models/concerns/requests/illiad.rb'
+    - 'app/models/requests/recall.rb'
+    - 'app/models/requests/request.rb'
+    - 'app/models/requests/router.rb'
+    - 'app/models/requests/submission.rb'
+
 Metrics/LineLength:
   Exclude:
     - 'app/helpers/requests/application_helper.rb'
@@ -21,6 +34,19 @@ Metrics/LineLength:
     - 'spec/controllers/requests/request_controller_spec.rb'
     - 'spec/models/requests/pickup_lookup_spec.rb'
     - 'spec/models/requests/recall_spec.rb'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/models/requests/requestable.rb'
+    - 'app/controllers/requests/request_controller.rb'
+    - 'app/helpers/requests/application_helper.rb'
+    - 'app/models/concerns/requests/aeon.rb'
+    - 'app/models/concerns/requests/ctx.rb'
+    - 'app/models/concerns/requests/illiad.rb'
+    - 'app/models/requests/recall.rb'
+    - 'app/models/requests/request.rb'
+    - 'app/models/requests/router.rb'
+    - 'app/models/requests/submission.rb'
 
 RSpec/MultipleExpectations:
   Max: 5

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -52,6 +52,7 @@ module Requests
     end
 
     def recap?
+      return false unless location_valid?
       return true if location[:library][:code] == 'recap'
     end
 
@@ -78,11 +79,13 @@ module Requests
 
     # merge these two
     def annexa?
+      return false unless location_valid?
       return true if location[:library][:code] == 'annexa'
     end
 
     # locations temporarily moved to annex should work
     def annexb?
+      return false unless location_valid?
       return true if location[:library][:code] == 'annexb'
     end
 
@@ -173,6 +176,7 @@ module Requests
     end
 
     def pending?
+      return false unless location_valid?
       return false unless on_order? || in_process? || preservation?
       if location[:library][:code] == 'recap' && location[:holding_library].blank?
         false
@@ -203,6 +207,7 @@ module Requests
     end
 
     def online?
+      return false unless location_valid?
       return true if location[:library][:code] == 'online'
     end
 
@@ -329,6 +334,10 @@ module Requests
 
       def scsb_edd_cullection_codes
         %w[AR BR CA CH CJ CP CR CU EN EV GC GE GS HS JC JD LD LE ML SW UT NA NH NL NP NQ NS NW GN JN JO PA PB PN GP JP]
+      end
+
+      def location_valid?
+        location.key?(:library) && location[:library].key?(:code)
       end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/pulibrary/orangelight/issues/1413