### PR TITLE
catches language code being nil

### DIFF
--- a/app/models/requests/request.rb
+++ b/app/models/requests/request.rb
@@ -343,7 +343,7 @@ module Requests
     end
 
     def get_language
-      doc["language_iana_s"].first
+      doc["language_iana_s"]&.first
     end
 
     def pickups


### PR DESCRIPTION
This record errors when displaying the request form because the `language_iana_s` field is nil: https://catalog.princeton.edu/catalog/1346010