### PR TITLE
adds method for lewis library paging

### DIFF
--- a/app/controllers/requests/request_controller.rb
+++ b/app/controllers/requests/request_controller.rb
@@ -139,7 +139,7 @@ module Requests
             unless @submission.service_types.include? 'bd'
               @submission.service_types.each do |type|
                 Requests::RequestMailer.send("#{type}_email", @submission).deliver_now
-                if ['on_order', 'in_process', 'pres', 'recap_no_items'].include? type
+                if ['on_order', 'in_process', 'pres', 'recap_no_items', 'lewis', 'ppl'].include? type
                   Requests::RequestMailer.send("#{type}_confirmation", @submission).deliver_now
                 end
                 if type == 'recall' && @submission.scsb?

--- a/app/controllers/requests/request_controller.rb
+++ b/app/controllers/requests/request_controller.rb
@@ -194,15 +194,6 @@ module Requests
         params.permit(:id, :system_id, :source, :mfhd, :user_name, :email, :user_barcode, :loc_code, :user, :requestable, :request, :barcode, :isbns).permit!
       end
 
-      # unused method
-      # def mail_services
-      #   ["paging", "annexa", "annexb", "trace", "on_order", "in_process"]
-      # end
-
-      # def recap_services
-      #   ["recap"]
-      # end
-
       def current_patron(uid)
         return false unless uid
         begin

--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -90,6 +90,8 @@ module Requests
         request_input('pres')
       elsif requestable.services.include? 'ppl'
         request_input('ppl')
+      elsif requestable.services.include? 'lewis'
+        request_input('lewis')
       elsif requestable.services.include? 'paging'
         request_input('paging')
       elsif requestable.services.include? 'in_process'
@@ -99,7 +101,6 @@ module Requests
       elsif requestable.services.include? 'recap_edd' and requestable.services.include? 'recap'
         recap_radio_button_group requestable
       elsif requestable.services.include? 'recap'
-        # request_input('recap')
         recap_print_only_input requestable
       elsif requestable.services.include? 'trace'
         request_input('trace')

--- a/app/mailers/requests/request_mailer.rb
+++ b/app/mailers/requests/request_mailer.rb
@@ -81,6 +81,22 @@ module Requests
            subject: subject_line(I18n.t('requests.ppl.email_subject'), @submission.user_barcode))
     end
 
+    def lewis_email(submission)
+      @submission = submission
+      destination_email = I18n.t('requests.lewis.email')
+      mail(to: destination_email,
+           from: I18n.t('requests.default.email_from'),
+           subject: subject_line(I18n.t('requests.lewis.email_subject'), @submission.user_barcode))
+    end
+
+    def lewis_confirmation(submission)
+      @submission = submission
+      destination_email = @submission.email
+      mail(to: destination_email,
+           from: I18n.t('requests.default.email_from'),
+           subject: subject_line(I18n.t('requests.lewis.email_subject'), @submission.user_barcode))
+    end
+
     def on_order_email(submission)
       @submission = submission
       destination_email = I18n.t('requests.default.email_destination')

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -69,6 +69,10 @@ module Requests
       return true if item[:status] == 'Missing'
     end
 
+    def lewis?
+      return true if ['sci', 'scith', 'sciref', 'sciefa', 'scinb'].include?(location[:code])
+    end
+
     def plasma?
       return true if location[:code] == 'ppl'
     end

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -70,7 +70,7 @@ module Requests
     end
 
     def lewis?
-      return true if ['sci', 'scith', 'sciref', 'sciefa', 'scinb'].include?(location[:code])
+      return true if ['sci', 'scith', 'sciref', 'sciefa'].include?(location[:code])
     end
 
     def plasma?

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -91,10 +91,8 @@ module Requests
               services << 'annexb'
             elsif requestable.plasma?
               services << 'ppl'
-            # elsif(requestable.in_process? && auth_user?)
-            #   services << 'in_process'
-            # elsif(requestable.on_order? && auth_user?)
-            #   services << 'on_order'
+            elsif requestable.lewis?
+              services << 'lewis'
             elsif requestable.recap?
               if requestable.has_item_data?
                 services << 'recap'

--- a/app/models/requests/submission.rb
+++ b/app/models/requests/submission.rb
@@ -3,7 +3,7 @@ require 'email_validator'
 module Requests
   class SelectedItemsValidator < ActiveModel::Validator
     def mail_services
-      ["paging", "pres", "annexa", "annexb", "trace", "on_order", "in_process", "ppl"]
+      ["paging", "pres", "annexa", "annexb", "trace", "on_order", "in_process", "ppl", "lewis"]
     end
 
     def validate(record)

--- a/app/views/requests/request_mailer/lewis_confirmation.text.erb
+++ b/app/views/requests/request_mailer/lewis_confirmation.text.erb
@@ -1,7 +1,7 @@
 ==============================================
-<%= I18n.t('requests.ppl.email_subject') %>
+<%= I18n.t('requests.lewis.email_subject') %>
 
-<%= I18n.t('requests.ppl.email_conf_msg') %>
+<%= I18n.t('requests.lewis.email_conf_msg') %>
 
 <%= render 'patron_info' %>
 <%= render 'bib_info' %>

--- a/app/views/requests/request_mailer/lewis_email.text.erb
+++ b/app/views/requests/request_mailer/lewis_email.text.erb
@@ -1,7 +1,7 @@
 ==============================================
-<%= I18n.t('requests.ppl.email_subject') %>
+<%= I18n.t('requests.lewis.email_subject') %>
 
-<%= I18n.t('requests.ppl.email_conf_msg') %>
+<%= I18n.t('requests.lewis.email_conf_msg') %>
 
 <%= render 'patron_info' %>
 <%= render 'bib_info' %>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -23,7 +23,8 @@ en:
       annex_success: "Request submitted. See confirmation email with details about when your item(s) will be available."
       annexa_success: "Request submitted. See confirmation email with details about when your item(s) will be available."
       annexb_success: "Request submitted. See confirmation email with details about when your item(s) will be available."
-      ppl_success: "Request submitted. See confirmation email with details about when your item(s) will be available."
+      ppl_success: ""
+      lewis_success: "Item has been paged"
       paging_success: "Item has been paged."
       trace_success: "Item is now being traced."
       error: "We were unable to process your request. Correct the highlighted errors."
@@ -51,6 +52,11 @@ en:
       email_subject: "Harold P. Furth Plasma Physics Library Request"
       brief_msg: "Pageable item at Plasma Physics Library. Request for delivery in 1-2 business days."
       email_conf_msg: "You will be notified via email when your item is ready for pickup. Most items are ready in 1 to 2 business days."
+    lewis:
+      email: "lewispaging@princeton.edu"
+      email_subject: "Lewis Library Paging Request"
+      brief_msg: "Pageable item at Lewis Library, will be delivered to Lewis Library Service desk on first floor."
+      email_conf_msg: "Items requested before 3:00 pm (weekdays and weekends) will be available for pickup, on the same day, at the Lewis Library Service desk on the first floor of the library. Items requested after 3:00 pm will be available the next day."
     pres:
       email: "fstcirc@princeton.edu"
       email_subject: "Preservation Office Request"

--- a/spec/mailers/requests/request_mailer_spec.rb
+++ b/spec/mailers/requests/request_mailer_spec.rb
@@ -912,7 +912,114 @@ describe Requests::RequestMailer, :type => :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to have_content I18n.t('requests.ppl.patron_conf_msg')
+      expect(mail.body.encoded).to have_content I18n.t('requests.ppl.email_conf_msg')
+    end
+  end
+  context "send lewis email request" do
+    let(:requestable) {
+      [
+        {
+          "selected" => "true",
+          "mfhd" => "10066344",
+          "call_number" => "QC92.U54 A36 2017",
+          "location_code" => "sci",
+          "item_id" => "7659317",
+          "barcode" => "32101101395745",
+          "copy_number" => "0",
+          "status" => "Not Charged",
+          "type" => "lewis",
+          "pickup" => "PN"
+        }.with_indifferent_access,
+        {
+          "selected" => "false"
+        }.with_indifferent_access
+      ]
+    }
+    let(:bib) {
+      {
+        "id" => "10292269",
+        "title" => "Adopting the International System of units for radiation measurements in the United States : proceedings of a workshop /",
+        "author" => "Kosti, Ourania"
+      }.with_indifferent_access
+    }
+    let(:params) {
+      {
+        request: user_info,
+        requestable: requestable,
+        bib: bib
+      }
+    }
+
+    let(:submission_for_lewis) {
+      Requests::Submission.new(params)
+    }
+
+    let(:mail) {
+      Requests::RequestMailer.send("lewis_email", submission_for_lewis).deliver_now
+    }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t('requests.lewis.email_subject'))
+      expect(mail.to).to eq([I18n.t('requests.lewis.email')])
+      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to have_content I18n.t('requests.lewis.email_conf_msg')
+    end
+  end
+
+  context "send lewis email patron confirmation" do
+    let(:requestable) {
+      [
+        {
+          "selected" => "true",
+          "mfhd" => "10066344",
+          "call_number" => "QC92.U54 A36 2017",
+          "location_code" => "sci",
+          "item_id" => "7659317",
+          "barcode" => "32101101395745",
+          "copy_number" => "0",
+          "status" => "Not Charged",
+          "type" => "lewis",
+          "pickup" => "PN"
+        }.with_indifferent_access,
+        {
+          "selected" => "false"
+        }.with_indifferent_access
+      ]
+    }
+    let(:bib) {
+      {
+        "id" => "10292269",
+        "title" => "Adopting the International System of units for radiation measurements in the United States : proceedings of a workshop /",
+        "author" => "Kosti, Ourania"
+      }.with_indifferent_access
+    }
+    let(:params) {
+      {
+        request: user_info,
+        requestable: requestable,
+        bib: bib
+      }
+    }
+
+    let(:submission_for_lewis) {
+      Requests::Submission.new(params)
+    }
+
+    let(:mail) {
+      Requests::RequestMailer.send("lewis_confirmation", submission_for_lewis).deliver_now
+    }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq(I18n.t('requests.lewis.email_subject'))
+      expect(mail.to).to eq([submission_for_lewis.email])
+      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to have_content I18n.t('requests.lewis.email_conf_msg')
     end
   end
 end


### PR DESCRIPTION
Closes #428. Closes #427.
 - Also adds scinb and sciefa to the pageable location codes
 - Empties "ppl_success" config because it duplicates the info in the "success" locale
 - Updates ppl confirmation email template to remove unconfigured "patron_conf_msg" locale