### PR TITLE
Allow on the shelf items to be requestable from all libraries

### DIFF
--- a/app/mailers/requests/request_mailer.rb
+++ b/app/mailers/requests/request_mailer.rb
@@ -1,5 +1,8 @@
 module Requests
   class RequestMailer < ApplicationMailer
+    # temporary changes issue 438
+    include Requests::Bibdata
+
     def paging_email(submission)
       @submission = submission
       pickups = []
@@ -43,7 +46,10 @@ module Requests
           destination_email.push(I18n.t('requests.annexa.email'))
         end
       end
-      cc_email = [@submission.email]
+
+      # temporary changes issue 438
+      # cc_email = [@submission.email]
+      cc_email = [@submission.email, I18n.t('requests.on_shelf.email')]
       mail(to: destination_email,
            cc: cc_email,
            from: I18n.t('requests.default.email_from'),
@@ -69,6 +75,8 @@ module Requests
       @submission = submission
       destination_email = I18n.t('requests.ppl.email')
       mail(to: destination_email,
+           # temporary changes issue 438
+           cc: [I18n.t('requests.on_shelf.email')],
            from: I18n.t('requests.default.email_from'),
            subject: subject_line(I18n.t('requests.ppl.email_subject'), @submission.user_barcode))
     end
@@ -85,6 +93,8 @@ module Requests
       @submission = submission
       destination_email = I18n.t('requests.lewis.email')
       mail(to: destination_email,
+           # temporary changes issue 438
+           cc: [I18n.t('requests.on_shelf.email')],
            from: I18n.t('requests.default.email_from'),
            subject: subject_line(I18n.t('requests.lewis.email_subject'), @submission.user_barcode))
     end
@@ -95,6 +105,26 @@ module Requests
       mail(to: destination_email,
            from: I18n.t('requests.default.email_from'),
            subject: subject_line(I18n.t('requests.lewis.email_subject'), @submission.user_barcode))
+    end
+
+    # temporary changes issue 438
+    def on_shelf_email(submission)
+      location_email = get_location_contact_email(submission.items.first[:location_code])
+      @submission = submission
+      destination_email = I18n.t('requests.on_shelf.email')
+      mail(to: location_email,
+           cc: destination_email,
+           from: I18n.t('requests.default.email_from'),
+           subject: subject_line(I18n.t('requests.on_shelf.email_subject'), @submission.user_barcode))
+    end
+
+    # temporary changes issue 438
+    def on_shelf_confirmation(submission)
+      @submission = submission
+      destination_email = @submission.email
+      mail(to: destination_email,
+           from: I18n.t('requests.default.email_from'),
+           subject: subject_line(I18n.t('requests.on_shelf.email_subject'), @submission.user_barcode))
     end
 
     def on_order_email(submission)

--- a/app/models/concerns/requests/bibdata.rb
+++ b/app/models/concerns/requests/bibdata.rb
@@ -67,5 +67,14 @@ module Requests
       end
       public_locs + staff_locs
     end
+
+    # get the location contact email from thr delivery locations via the library code
+    def get_location_contact_email(location_code)
+      code = get_location(location_code)
+      library_code = code[:library]["code"]
+      return I18n.t('requests.on_shelf.email') if library_code == "firestone"
+      delivery_location = Requests::BibdataService.delivery_locations.select { |_key, value| value[:library][:code] == library_code }
+      delivery_location.values.first[:contact_email]
+    end
   end
 end

--- a/app/models/requests/submission.rb
+++ b/app/models/requests/submission.rb
@@ -3,7 +3,9 @@ require 'email_validator'
 module Requests
   class SelectedItemsValidator < ActiveModel::Validator
     def mail_services
-      ["paging", "pres", "annexa", "annexb", "trace", "on_order", "in_process", "ppl", "lewis"]
+      # temporary changes issue 438
+      # ["paging", "pres", "annexa", "annexb", "trace", "on_order", "in_process", "ppl", "lewis"]
+      ["paging", "pres", "annexa", "annexb", "trace", "on_order", "in_process", "ppl", "lewis", "on_shelf"]
     end
 
     def validate(record)

--- a/app/views/requests/request_mailer/on_shelf_confirmation.text.erb
+++ b/app/views/requests/request_mailer/on_shelf_confirmation.text.erb
@@ -1,0 +1,9 @@
+<% # temporary changes issue 438 %>
+==============================================
+<%= I18n.t('requests.on_shelf.email_subject') %>
+
+<%= I18n.t('requests.on_shelf.email_conf_msg') %>
+
+<%= render 'patron_info' %>
+<%= render 'bib_info' %>
+<%= render 'item_info' %>

--- a/app/views/requests/request_mailer/on_shelf_email.text.erb
+++ b/app/views/requests/request_mailer/on_shelf_email.text.erb
@@ -1,0 +1,9 @@
+<% # temporary changes issue 438 %>
+==============================================
+<%= I18n.t('requests.on_shelf.email_subject') %>
+
+<%= I18n.t('requests.on_shelf.email_conf_msg') %>
+
+<%= render 'patron_info' %>
+<%= render 'bib_info' %>
+<%= render 'item_info' %>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -24,8 +24,10 @@ en:
       annexa_success: "Request submitted. See confirmation email with details about when your item(s) will be available."
       annexb_success: "Request submitted. See confirmation email with details about when your item(s) will be available."
       ppl_success: ""
-      lewis_success: "Item has been paged"
+      lewis_success: "Item has been paged."
       paging_success: "Item has been paged."
+      # temporary changes issue 438
+      on_shelf_success: "Item has been paged."
       trace_success: "Item is now being traced."
       error: "We were unable to process your request. Correct the highlighted errors."
       service_error: "There was a problem with this request which Library staff need to investigate. You'll be notified once it's resolved and requested for you."
@@ -39,24 +41,33 @@ en:
       email: "forranx@princeton.edu"
       email_subject: "Annex Request"
       brief_msg: "Item offsite at Forrestal Annex. Request for delivery in 1-2 business days"
-      email_conf_msg: "You will be notified via email when your item is ready for pickup. Most items are ready in 1 to 2 business days."
+      # temporary changes issue 438
+      #email_conf_msg: "You will be notified via email when your item is ready for pickup. Most items are ready in 1 to 2 business days."
+      email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email the day prior telling you the item will be available for pickup in Firestone Lobby between the hours of 12-2."
     anxadoc:
       email: "docstor@princeton.edu"
     annexb:
       email: "fineanx@princeton.edu"
       email_subject: "Annex Request"
       brief_msg: "Item offsite at Fine Annex. Request for delivery in 1-2 business days."
-      email_conf_msg: "You will be notified via email when your item is ready for pickup. Most items are ready in 1 to 2 business days."
+      # temporary changes issue 438
+      #email_conf_msg: "You will be notified via email when your item is ready for pickup. Most items are ready in 1 to 2 business days."
+      email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email the day prior telling you the item will be available for pickup in Firestone Lobby between the hours of 12-2."
     ppl:
       email: "ppllib@princeton.edu"
       email_subject: "Harold P. Furth Plasma Physics Library Request"
       brief_msg: "Pageable item at Plasma Physics Library. Request for delivery in 1-2 business days."
-      email_conf_msg: "You will be notified via email when your item is ready for pickup. Most items are ready in 1 to 2 business days."
+      # temporary changes issue 438
+      #email_conf_msg: "You will be notified via email when your item is ready for pickup. Most items are ready in 1 to 2 business days."
+      email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email the day prior telling you the item will be available for pickup in Firestone Lobby between the hours of 12-2."
     lewis:
       email: "lewispaging@princeton.edu"
       email_subject: "Lewis Library Paging Request"
-      brief_msg: "Pageable item at Lewis Library, will be delivered to Lewis Library Service desk on first floor."
-      email_conf_msg: "Items requested before 3:00 pm (weekdays and weekends) will be available for pickup, on the same day, at the Lewis Library Service desk on the first floor of the library. Items requested after 3:00 pm will be available the next day."
+      # temporary changes issue 438
+      #brief_msg: "Pageable item at Lewis Library, will be delivered to Lewis Library Service desk on first floor."
+      brief_msg: "Pageable item at Lewis Library. Request for delivery in 1-2 business days."
+      #email_conf_msg: "Items requested before 3:00 pm (weekdays and weekends) will be available for pickup, on the same day, at the Lewis Library Service desk on the first floor of the library. Items requested after 3:00 pm will be available the next day."
+      email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email the day prior telling you the item will be available for pickup in Firestone Lobby between the hours of 12-2."
     pres:
       email: "fstcirc@princeton.edu"
       email_subject: "Preservation Office Request"
@@ -64,7 +75,12 @@ en:
       email_conf_msg: "The following Preservation item has been requested:"
       patron_conf_msg: "You will be notified via email when your item is ready for pickup from the Preservation Office."
     on_shelf:
-      brief_msg: "Item on Shelf. Consult shelf location map."
+      # temporary changes issue 438
+      # brief_msg: "Item on Shelf. Consult shelf location map."
+      email: "fstcirc@princeton.edu"
+      email_subject: "On the Shelf Paging Request"
+      brief_msg: "Pageable item at %{location}. Request for delivery in 1-2 business days."
+      email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email the day prior telling you the item will be available for pickup in Firestone Lobby between the hours of 12-2."
       access_msg: 'Access Users must obtain a pass to enter the Library.'
     on_order:
       email: "fstcirc@princeton.edu"
@@ -79,7 +95,9 @@ en:
       message: "If you have not picked up a requested book by the end of the same day, you will receive an email reminder that your book is available for you at Circulation."
       brief_msg: "Paging Request, will be delivered to Firestone Circulation."
       success: "Request submitted. Please visit Firsestone Circulation at the next scheduled paging delivery time."
-      email_conf_msg: "Items requested anytime before 3:00pm (weekdays) will be available for you to pick up at Circulation no later than 5:00pm the same day (and often much sooner)."
+      # temporary changes issue 438
+      #email_conf_msg: "Items requested anytime before 3:00pm (weekdays) will be available for you to pick up at Circulation no later than 5:00pm the same day (and often much sooner)."
+      email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email the day prior telling you the item will be available for pickup in Firestone Lobby between the hours of 12-2."
     recap_guest:
       email_subject: "Patron Initiated Catalog Request - ReCAP Access Only Request"
       brief_msg: "Item off-site at ReCAP facility."

--- a/spec/cassettes/mailer.yml
+++ b/spec/cassettes/mailer.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/locations/holding_locations/f.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Wed, 18 Mar 2020 20:13:46 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"250b12294d5b9710e9827751c996ca99"
+      X-Runtime:
+      - '0.009157'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 69ddd055-f269-4b59-bca9-dca83585e2b0
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"label":"","code":"f","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Firestone
+        Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
+        Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
+        Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
+    http_version: null
+  recorded_at: Wed, 18 Mar 2020 20:13:46 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/locations/holding_locations/c.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Wed, 18 Mar 2020 20:13:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"36424b67bf9d8cf7afbd86fc55d51a7b"
+      X-Runtime:
+      - '0.008475'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 7cefac71-e04e-4c68-8e91-63496fa803ab
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"label":"","code":"c","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"East
+        Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East
+        Asian Library","code":"eastasian"},"delivery_locations":[]}'
+    http_version: null
+  recorded_at: Wed, 18 Mar 2020 20:13:47 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/request_features.yml
+++ b/spec/cassettes/request_features.yml
@@ -52,7 +52,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk0OTMzMTgiLCJhdXRob3JfZGlzcGxheSI6WyJTYW1ozKNhzIRuLCBOYWphzIR0Iiwi2LPZhdit2KfZhtiMINmG2KzYp9ip2IwiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FtaMyjYcyEbiwgTmFqYcyEdCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcItiz2YXYrdin2YbYjCDZhtis2KfYqdiMXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNhbWjMo2HMhG4sIE5hamHMhHRcIn0iLCJhdXRob3JfcyI6WyJTYW1ozKNhzIRuLCBOYWphzIR0Iiwi2LPZhdit2KfZhtiMINmG2KzYp9ip2IwiXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIlNhbWjMo2HMhG4sIE5hamHMhHQiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjCIsIsq7QXdhzIR0zKNpZiBtYWRmdcyEbmFoIC8gTmFqYcyEdCBhbC1TYW1ozKNhzIRuLiIsIlNob3J0IHN0b3JpZXMsIEFyYWJpYyJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Isq7QXdhzIR0zKNpZiBtYWRmdcyEbmFoIC8gTmFqYcyEdCBhbC1TYW1ozKNhzIRuLiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6Iti52YjYp9i32YEg2YXYr9mB2YjZhtipIC8g2YbYrNin2Kkg2KfZhNiz2YXYrdin2YYuIiwidGl0bGVfdCI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIE5hamHMhHQgYWwtU2FtaMyjYcyEbi4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIiwi2LnZiNin2LfZgSDZhdiv2YHZiNmG2KkgLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiyrtBd2HMhHTMo2lmIG1hZGZ1zIRuYWggLyBOYWphzIR0IGFsLVNhbWjMo2HMhG4uIiwi2LnZiNin2LfZgSDZhdiv2YHZiNmG2KkgLyDZhtis2KfYqSDYp9mE2LPZhdit2KfZhi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJhbC1RYcyEaGlyYWggOiBEYcyEciBhbC1LaXRhzIRiIGFsLUjMo2FkacyEdGgsIDIwMTYuIiwi2KfZhNmC2KfZh9ix2KkgOiDYr9in2LEg2KfZhNmD2KrYp9ioINin2YTYrdiv2YrYq9iMIDIwMTYuIl0sInB1Yl9jcmVhdGVkX3MiOlsiYWwtUWHMhGhpcmFoIDogRGHMhHIgYWwtS2l0YcyEYiBhbC1IzKNhZGnMhHRoLCAyMDE2LiIsItin2YTZgtin2YfYsdipIDog2K/Yp9ixINin2YTZg9iq2KfYqCDYp9mE2K3Yr9mK2KvYjCAyMDE2LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJhbC1RYcyEaGlyYWg6IERhzIRyIGFsLUtpdGHMhGIgYWwtSMyjYWRpzIR0aCIsItin2YTZgtin2YfYsdipOiDYr9in2LEg2KfZhNmD2KrYp9ioINin2YTYrdiv2YrYq9iMIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNiJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE2LCJjYXRhbG9nZWRfdGR0IjoiMjAxNi0wMS0xOVQxMzo0OTozN1oiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjIzMCBwYWdlcyA7IDIwIGNtIl0sImRlc2NyaXB0aW9uX3QiOlsiMjMwIHBhZ2VzIDsgMjAgY20iXSwibm90ZXNfZGlzcGxheSI6WyJTaG9ydCBzdG9yaWVzLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJBcmFiaWMiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImFyYSJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU2hvcnQgc3RvcmllcywgQXJhYmlj4oCUMjFzdCBjZW50dXJ5Il0sInN1YmplY3RfdCI6WyJTaG9ydCBzdG9yaWVzLCBBcmFiaWPigJQyMXN0IGNlbnR1cnkiXSwic3ViamVjdF9mYWNldCI6WyJTaG9ydCBzdG9yaWVzLCBBcmFiaWPigJQyMXN0IGNlbnR1cnkiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODk3NzM1MDY4MjciLCI5NzczNTA2ODI3Il0sImlzYm5fcyI6WyI5Nzg5NzczNTA2ODI3Il0sImlzYm5fdCI6WyI5Nzg5NzczNTA2ODI3Il0sIm9jbGNfcyI6WyI5MzUyMTkzMTAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjkzNTIxOTMxMCIsIjk3ODk3NzM1MDY4MjciXSwic3ViamVjdF9lcmFfZmFjZXQiOlsiMjFzdCBjZW50dXJ5Il0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTM1MTk2N1wiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiUEo3OTYyLkE1NDk1IEE5NSAyMDE2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIlBKNzk2Mi5BNTQ5NSBBOTUgMjAxNlwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJsb2NhdGlvbiI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTYW1ozKNhzIRuLCBOYWphzIR0LiDKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCIsItiz2YXYrdin2YbYjCDZhtis2KfYqdiMLiDYudmI2KfYt9mBINmF2K/ZgdmI2YbYqSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIlBKNzk2Mi5BNTQ5NSBBOTUgMjAxNiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJQSjc5NjIuQTU0OTUgQTk1IDIwMTYiXSwidGltZXN0YW1wIjoiMjAxNy0wMy0yM1QyMToxMDowNi42ODdaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 01:52:23 GMT
 - request:
     method: get
@@ -102,7 +102,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9351967":{"more_items":false,"location":"rcppa","copy_number":0,"item_id":7303228,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 01:52:23 GMT
 - request:
     method: get
@@ -152,7 +152,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101095798938","id":7303228,"location":"rcppa","copy_number":0,"item_sequence_number":0,"status":"Not
         Charged","label":"ReCAP"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 01:52:23 GMT
 - request:
     method: get
@@ -222,7 +222,7 @@ http_interactions:
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services, Holdings Management","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 01:52:23 GMT
 - request:
     method: get
@@ -276,7 +276,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwiYXV0aG9yX3MiOlsiQXNzb2NpYXRpb24gZGVzIGXMgWNyaXZhaW5zIGR1IFNlzIFuZcyBZ2FsIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiLCJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIiwiQXV0aG9ycywgQWZyaWNhbiIsIlNlbmVnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jcmVhdGVkX3MiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlbmVnYWw6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA5LTIwVDE5OjM0OjE0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsidm9sdW1lcyJdLCJkZXNjcmlwdGlvbl90IjpbInZvbHVtZXMiXSwiY29udGludWVzX2Rpc3BsYXkiOlsiRcyBY3JpdmFpbiwgam91cm5hbCBjdWx0dXJlbCBwYW5hZnJpY2FpbiJdLCJzb3VyY2VfZGVzY19ub3Rlc19kaXNwbGF5IjpbIkRlc2NyaXB0aW9uIGJhc2VkIG9uOiBIb3JzIHNlzIFyaWUgKHB1Ymxpc2hlZCBpbiAyMDE2Pyk7IHRpdGxlIGZyb20gY292ZXIuIiwiTGF0ZXN0IGlzc3VlIGNvbnN1bHRlZDogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJGcmVuY2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImZyZSJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiQXV0aG9ycywgQWZyaWNhbuKAlFBlcmlvZGljYWxzIiwiU2VuZWdhbOKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfdCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTIzVDE4OjIzOjMyLjE0N1oifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:29 GMT
 - request:
     method: get
@@ -326,7 +326,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9757511":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":7467161,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:30 GMT
 - request:
     method: get
@@ -376,7 +376,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098722844","id":7467161,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"2016","label":"ReCAP"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:30 GMT
 - request:
     method: get
@@ -430,7 +430,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwiYXV0aG9yX3MiOlsiQXNzb2NpYXRpb24gZGVzIGXMgWNyaXZhaW5zIGR1IFNlzIFuZcyBZ2FsIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiLCJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIiwiQXV0aG9ycywgQWZyaWNhbiIsIlNlbmVnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jcmVhdGVkX3MiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlbmVnYWw6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA5LTIwVDE5OjM0OjE0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsidm9sdW1lcyJdLCJkZXNjcmlwdGlvbl90IjpbInZvbHVtZXMiXSwiY29udGludWVzX2Rpc3BsYXkiOlsiRcyBY3JpdmFpbiwgam91cm5hbCBjdWx0dXJlbCBwYW5hZnJpY2FpbiJdLCJzb3VyY2VfZGVzY19ub3Rlc19kaXNwbGF5IjpbIkRlc2NyaXB0aW9uIGJhc2VkIG9uOiBIb3JzIHNlzIFyaWUgKHB1Ymxpc2hlZCBpbiAyMDE2Pyk7IHRpdGxlIGZyb20gY292ZXIuIiwiTGF0ZXN0IGlzc3VlIGNvbnN1bHRlZDogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJGcmVuY2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImZyZSJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiQXV0aG9ycywgQWZyaWNhbuKAlFBlcmlvZGljYWxzIiwiU2VuZWdhbOKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfdCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTIzVDE4OjIzOjMyLjE0N1oifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:31 GMT
 - request:
     method: get
@@ -480,7 +480,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9757511":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":7467161,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:31 GMT
 - request:
     method: get
@@ -530,7 +530,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098722844","id":7467161,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"2016","label":"ReCAP"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:31 GMT
 - request:
     method: get
@@ -600,7 +600,7 @@ http_interactions:
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services, Holdings Management","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:31 GMT
 - request:
     method: get
@@ -654,7 +654,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwiYXV0aG9yX3MiOlsiQXNzb2NpYXRpb24gZGVzIGXMgWNyaXZhaW5zIGR1IFNlzIFuZcyBZ2FsIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiLCJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIiwiQXV0aG9ycywgQWZyaWNhbiIsIlNlbmVnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jcmVhdGVkX3MiOlsiU2VuZWdhbCA6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCwgW2RhdGUgb2YgcHVibGljYXRpb24gbm90IGlkZW50aWZpZWRdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlbmVnYWw6IENhaXNzZSBkZSBTZWN1cml0ZSBTb2NpYWwgZHUgU2VuZWdhbCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA5LTIwVDE5OjM0OjE0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsidm9sdW1lcyJdLCJkZXNjcmlwdGlvbl90IjpbInZvbHVtZXMiXSwiY29udGludWVzX2Rpc3BsYXkiOlsiRcyBY3JpdmFpbiwgam91cm5hbCBjdWx0dXJlbCBwYW5hZnJpY2FpbiJdLCJzb3VyY2VfZGVzY19ub3Rlc19kaXNwbGF5IjpbIkRlc2NyaXB0aW9uIGJhc2VkIG9uOiBIb3JzIHNlzIFyaWUgKHB1Ymxpc2hlZCBpbiAyMDE2Pyk7IHRpdGxlIGZyb20gY292ZXIuIiwiTGF0ZXN0IGlzc3VlIGNvbnN1bHRlZDogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJGcmVuY2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImZyZSJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiQXV0aG9ycywgQWZyaWNhbuKAlFBlcmlvZGljYWxzIiwiU2VuZWdhbOKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfdCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTIzVDE4OjIzOjMyLjE0N1oifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:32 GMT
 - request:
     method: get
@@ -704,7 +704,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9757511":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":7467161,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:32 GMT
 - request:
     method: get
@@ -754,7 +754,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098722844","id":7467161,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"2016","label":"ReCAP"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:32 GMT
 - request:
     method: get
@@ -824,7 +824,7 @@ http_interactions:
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services, Holdings Management","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:32 GMT
 - request:
     method: get
@@ -878,7 +878,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk2NDYwOTkiLCJhdXRob3JfZGlzcGxheSI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlcnJhbm8gZGVsIFBvem8sIElnbmFjaW8iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvXCJ9IiwiYXV0aG9yX3MiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyIsIkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsIkNoaWxlYW4gbGl0ZXJhdHVyZSIsIkNoaWxlIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsInRpdGxlX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2FydGFzIHJvbWFuYXMgLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sImVkaXRpb25fZGlzcGxheSI6WyJQcmltZXJhIGVkaWNpb8yBbi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NyZWF0ZWRfcyI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FudGlhZ28gZGUgQ2hpbGU6IFJpTCBlZGl0b3JlcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTUiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNSwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTUsImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA1LTEzVDE4OjUzOjM5WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiOTEgcGFnZXMgOyAyMyBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjkxIHBhZ2VzIDsgMjMgY20iXSwic2VyaWVzX2Rpc3BsYXkiOlsiQ29sZWNjaW/MgW4gODAgbXVuZG9zLiIsIkNvbGVjY2lvbiA4MCBtdW5kb3MuIl0sIm1vcmVfaW5fdGhpc19zZXJpZXNfdCI6WyJDb2xlY2Npb8yBbiA4MCBtdW5kb3MuIl0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTGEgbm92ZWxhIGVwaXN0b2xhciBlbmNhcm5hIHNpZW1wcmUgdW4gZGVzYWZpzIFvOiBhc3VtaXIgbGEgdm96IGRlIGxvcyBwZXJzb25hamVzIGRlIG1hbmVyYSB2ZXJvc2nMgW1pbCBwYXJhIHF1ZSwgZW4gZWwgaW50ZXJjYW1iaW8sIHNlIGNvbnN0cnV5YSB1bmEgaGlzdG9yaWEuIElnbmFjaW8gU2VycmFubyBkZWwgUG96byBsbyBhc3VtZSB5IGxsZXZhIHVuIHBvY28gbWHMgXMgYWxsYcyBIHVuIGdlzIFuZXJvIHF1ZSwgYWwgbWVub3MgZGVzZGUgZWwgc2lnbG8gWFZJSSwgaGEgdGVuaWRvIGN1bHRvcmVzIGRlIHBlc28uIFRyYXNsYWRhIGEgbGEgdmllamEgUm9tYSBsYSByZWxhY2lvzIFuIGRlIGRvcyBoZXJtYW5vcyBxdWUgdmVuIGF0cmF2ZXNhZGFzIHN1cyB2aWRhcyBwb3IgbGEgZ3VlcnJhLCBsYSBwZcyBcmRpZGEgZGUgbG9zIHNlcmVzIGFtYWRvcywgbGEgYXBhcmljaW/MgW4gZGVsIGNyaXN0aWFuaXNtbywgbGEgY3Jpc2lzIGRlbCBJbXBlcmlvIHkgY2lyY3Vuc3RhbmNpYXMgdGFuIGNvbXVuZXMgY29tbyBsYSBlbmZlcm1lZGFkIHkgbGEgaW5jb21wcmVuc2lvzIFuLiBDb24gdW4gdG9ubyBlamVtcGxhciwgcXVlIGxvZ3JhIGNvbiBtYWVzdHJpzIFhIGVsIGVmZWN0byBkZSB0cmFzbGFkYXIgYWwgbGVjdG9yIGEgdW5hIHJlYWxpZGFkIGxlamFuYSwgU2VycmFubyBkZWwgUG96byBub3MgY29udmllcnRlIGVuIHRlc3RpZ29zIGRlIHVuIG11bmRvIHF1ZSBtdWVyZSB5IHJlbmFjZSBqdW50byBjb24gc3VzIHByb3RhZ29uaXN0YXMuXCItLVBhZ2UgNCBvZiBjb3Zlci4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiU3BhbmlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsic3BhIl0sInN1YmplY3RfZGlzcGxheSI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfdCI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfZmFjZXQiOlsiQ2hpbGVhbiBsaXRlcmF0dXJlIiwiQ2hpbGXigJRIaXN0b3J54oCURmljdGlvbiJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmljdGlvbi4iLCJIaXN0b3J5LiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4OTU2MDEwMjMxNyIsIjk1NjAxMDIzMTEiXSwiaXNibl9zIjpbIjk3ODk1NjAxMDIzMTciXSwiaXNibl90IjpbIjk3ODk1NjAxMDIzMTciXSwib2NsY19zIjpbIjk1NjUxNjQ1MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTU2NTE2NDUxIiwiOTc4OTU2MDEwMjMxNyJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk0NzkwNjRcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiRmlyZXN0b25lIExpYnJhcnkiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvLiBDYXJ0YXMgcm9tYW5hcyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI4VDA0OjQyOjMwLjEzMloifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:33 GMT
 - request:
     method: get
@@ -928,7 +928,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9479064":{"more_items":false,"location":"f","copy_number":0,"item_id":7384386,"on_reserve":"N","status":"In
         Process","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:33 GMT
 - request:
     method: get
@@ -978,7 +978,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098590092","id":7384386,"location":"f","copy_number":0,"item_sequence_number":1,"status":"In
         Process","label":"Firestone Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:33 GMT
 - request:
     method: get
@@ -1030,7 +1030,7 @@ http_interactions:
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
         Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:33 GMT
 - request:
     method: get
@@ -1084,7 +1084,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk2NDYwOTkiLCJhdXRob3JfZGlzcGxheSI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlcnJhbm8gZGVsIFBvem8sIElnbmFjaW8iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvXCJ9IiwiYXV0aG9yX3MiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyIsIkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsIkNoaWxlYW4gbGl0ZXJhdHVyZSIsIkNoaWxlIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsInRpdGxlX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2FydGFzIHJvbWFuYXMgLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sImVkaXRpb25fZGlzcGxheSI6WyJQcmltZXJhIGVkaWNpb8yBbi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NyZWF0ZWRfcyI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FudGlhZ28gZGUgQ2hpbGU6IFJpTCBlZGl0b3JlcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTUiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNSwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTUsImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA1LTEzVDE4OjUzOjM5WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiOTEgcGFnZXMgOyAyMyBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjkxIHBhZ2VzIDsgMjMgY20iXSwic2VyaWVzX2Rpc3BsYXkiOlsiQ29sZWNjaW/MgW4gODAgbXVuZG9zLiIsIkNvbGVjY2lvbiA4MCBtdW5kb3MuIl0sIm1vcmVfaW5fdGhpc19zZXJpZXNfdCI6WyJDb2xlY2Npb8yBbiA4MCBtdW5kb3MuIl0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTGEgbm92ZWxhIGVwaXN0b2xhciBlbmNhcm5hIHNpZW1wcmUgdW4gZGVzYWZpzIFvOiBhc3VtaXIgbGEgdm96IGRlIGxvcyBwZXJzb25hamVzIGRlIG1hbmVyYSB2ZXJvc2nMgW1pbCBwYXJhIHF1ZSwgZW4gZWwgaW50ZXJjYW1iaW8sIHNlIGNvbnN0cnV5YSB1bmEgaGlzdG9yaWEuIElnbmFjaW8gU2VycmFubyBkZWwgUG96byBsbyBhc3VtZSB5IGxsZXZhIHVuIHBvY28gbWHMgXMgYWxsYcyBIHVuIGdlzIFuZXJvIHF1ZSwgYWwgbWVub3MgZGVzZGUgZWwgc2lnbG8gWFZJSSwgaGEgdGVuaWRvIGN1bHRvcmVzIGRlIHBlc28uIFRyYXNsYWRhIGEgbGEgdmllamEgUm9tYSBsYSByZWxhY2lvzIFuIGRlIGRvcyBoZXJtYW5vcyBxdWUgdmVuIGF0cmF2ZXNhZGFzIHN1cyB2aWRhcyBwb3IgbGEgZ3VlcnJhLCBsYSBwZcyBcmRpZGEgZGUgbG9zIHNlcmVzIGFtYWRvcywgbGEgYXBhcmljaW/MgW4gZGVsIGNyaXN0aWFuaXNtbywgbGEgY3Jpc2lzIGRlbCBJbXBlcmlvIHkgY2lyY3Vuc3RhbmNpYXMgdGFuIGNvbXVuZXMgY29tbyBsYSBlbmZlcm1lZGFkIHkgbGEgaW5jb21wcmVuc2lvzIFuLiBDb24gdW4gdG9ubyBlamVtcGxhciwgcXVlIGxvZ3JhIGNvbiBtYWVzdHJpzIFhIGVsIGVmZWN0byBkZSB0cmFzbGFkYXIgYWwgbGVjdG9yIGEgdW5hIHJlYWxpZGFkIGxlamFuYSwgU2VycmFubyBkZWwgUG96byBub3MgY29udmllcnRlIGVuIHRlc3RpZ29zIGRlIHVuIG11bmRvIHF1ZSBtdWVyZSB5IHJlbmFjZSBqdW50byBjb24gc3VzIHByb3RhZ29uaXN0YXMuXCItLVBhZ2UgNCBvZiBjb3Zlci4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiU3BhbmlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsic3BhIl0sInN1YmplY3RfZGlzcGxheSI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfdCI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfZmFjZXQiOlsiQ2hpbGVhbiBsaXRlcmF0dXJlIiwiQ2hpbGXigJRIaXN0b3J54oCURmljdGlvbiJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmljdGlvbi4iLCJIaXN0b3J5LiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4OTU2MDEwMjMxNyIsIjk1NjAxMDIzMTEiXSwiaXNibl9zIjpbIjk3ODk1NjAxMDIzMTciXSwiaXNibl90IjpbIjk3ODk1NjAxMDIzMTciXSwib2NsY19zIjpbIjk1NjUxNjQ1MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTU2NTE2NDUxIiwiOTc4OTU2MDEwMjMxNyJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk0NzkwNjRcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiRmlyZXN0b25lIExpYnJhcnkiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvLiBDYXJ0YXMgcm9tYW5hcyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI4VDA0OjQyOjMwLjEzMloifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1134,7 +1134,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9479064":{"more_items":false,"location":"f","copy_number":0,"item_id":7384386,"on_reserve":"N","status":"In
         Process","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1184,7 +1184,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098590092","id":7384386,"location":"f","copy_number":0,"item_sequence_number":1,"status":"In
         Process","label":"Firestone Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1236,7 +1236,7 @@ http_interactions:
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
         Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1290,7 +1290,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk2NDYwOTkiLCJhdXRob3JfZGlzcGxheSI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNlcnJhbm8gZGVsIFBvem8sIElnbmFjaW8iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvXCJ9IiwiYXV0aG9yX3MiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiU2VycmFubyBkZWwgUG96bywgSWduYWNpbyIsIkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsIkNoaWxlYW4gbGl0ZXJhdHVyZSIsIkNoaWxlIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkNhcnRhcyByb21hbmFzIC8gSWduYWNpbyBTZXJyYW5vIGRlbCBQb3pvLiIsInRpdGxlX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2FydGFzIHJvbWFuYXMgLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQ2FydGFzIHJvbWFuYXMgLyBJZ25hY2lvIFNlcnJhbm8gZGVsIFBvem8uIl0sImVkaXRpb25fZGlzcGxheSI6WyJQcmltZXJhIGVkaWNpb8yBbi4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NyZWF0ZWRfcyI6WyJTYW50aWFnbyBkZSBDaGlsZSA6IFJpTCBlZGl0b3JlcywgMjAxNS4iLCLCqTIwMTUiXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FudGlhZ28gZGUgQ2hpbGU6IFJpTCBlZGl0b3JlcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTUiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNSwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTUsImNhdGFsb2dlZF90ZHQiOiIyMDE2LTA1LTEzVDE4OjUzOjM5WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiOTEgcGFnZXMgOyAyMyBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjkxIHBhZ2VzIDsgMjMgY20iXSwic2VyaWVzX2Rpc3BsYXkiOlsiQ29sZWNjaW/MgW4gODAgbXVuZG9zLiIsIkNvbGVjY2lvbiA4MCBtdW5kb3MuIl0sIm1vcmVfaW5fdGhpc19zZXJpZXNfdCI6WyJDb2xlY2Npb8yBbiA4MCBtdW5kb3MuIl0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTGEgbm92ZWxhIGVwaXN0b2xhciBlbmNhcm5hIHNpZW1wcmUgdW4gZGVzYWZpzIFvOiBhc3VtaXIgbGEgdm96IGRlIGxvcyBwZXJzb25hamVzIGRlIG1hbmVyYSB2ZXJvc2nMgW1pbCBwYXJhIHF1ZSwgZW4gZWwgaW50ZXJjYW1iaW8sIHNlIGNvbnN0cnV5YSB1bmEgaGlzdG9yaWEuIElnbmFjaW8gU2VycmFubyBkZWwgUG96byBsbyBhc3VtZSB5IGxsZXZhIHVuIHBvY28gbWHMgXMgYWxsYcyBIHVuIGdlzIFuZXJvIHF1ZSwgYWwgbWVub3MgZGVzZGUgZWwgc2lnbG8gWFZJSSwgaGEgdGVuaWRvIGN1bHRvcmVzIGRlIHBlc28uIFRyYXNsYWRhIGEgbGEgdmllamEgUm9tYSBsYSByZWxhY2lvzIFuIGRlIGRvcyBoZXJtYW5vcyBxdWUgdmVuIGF0cmF2ZXNhZGFzIHN1cyB2aWRhcyBwb3IgbGEgZ3VlcnJhLCBsYSBwZcyBcmRpZGEgZGUgbG9zIHNlcmVzIGFtYWRvcywgbGEgYXBhcmljaW/MgW4gZGVsIGNyaXN0aWFuaXNtbywgbGEgY3Jpc2lzIGRlbCBJbXBlcmlvIHkgY2lyY3Vuc3RhbmNpYXMgdGFuIGNvbXVuZXMgY29tbyBsYSBlbmZlcm1lZGFkIHkgbGEgaW5jb21wcmVuc2lvzIFuLiBDb24gdW4gdG9ubyBlamVtcGxhciwgcXVlIGxvZ3JhIGNvbiBtYWVzdHJpzIFhIGVsIGVmZWN0byBkZSB0cmFzbGFkYXIgYWwgbGVjdG9yIGEgdW5hIHJlYWxpZGFkIGxlamFuYSwgU2VycmFubyBkZWwgUG96byBub3MgY29udmllcnRlIGVuIHRlc3RpZ29zIGRlIHVuIG11bmRvIHF1ZSBtdWVyZSB5IHJlbmFjZSBqdW50byBjb24gc3VzIHByb3RhZ29uaXN0YXMuXCItLVBhZ2UgNCBvZiBjb3Zlci4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiU3BhbmlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsic3BhIl0sInN1YmplY3RfZGlzcGxheSI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfdCI6WyJDaGlsZWFuIGxpdGVyYXR1cmUiLCJDaGlsZeKAlEhpc3RvcnnigJRGaWN0aW9uIl0sInN1YmplY3RfZmFjZXQiOlsiQ2hpbGVhbiBsaXRlcmF0dXJlIiwiQ2hpbGXigJRIaXN0b3J54oCURmljdGlvbiJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmljdGlvbi4iLCJIaXN0b3J5LiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4OTU2MDEwMjMxNyIsIjk1NjAxMDIzMTEiXSwiaXNibl9zIjpbIjk3ODk1NjAxMDIzMTciXSwiaXNibl90IjpbIjk3ODk1NjAxMDIzMTciXSwib2NsY19zIjpbIjk1NjUxNjQ1MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTU2NTE2NDUxIiwiOTc4OTU2MDEwMjMxNyJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk0NzkwNjRcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiRmlyZXN0b25lIExpYnJhcnkiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTZXJyYW5vIGRlbCBQb3pvLCBJZ25hY2lvLiBDYXJ0YXMgcm9tYW5hcyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI4VDA0OjQyOjMwLjEzMloifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1340,7 +1340,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9479064":{"more_items":false,"location":"f","copy_number":0,"item_id":7384386,"on_reserve":"N","status":"In
         Process","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1390,7 +1390,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101098590092","id":7384386,"location":"f","copy_number":0,"item_sequence_number":1,"status":"In
         Process","label":"Firestone Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:34 GMT
 - request:
     method: get
@@ -1442,7 +1442,7 @@ http_interactions:
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
         Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1496,7 +1496,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwiYXV0aG9yX2Rpc3BsYXkiOlsiR290bywgU2VpbWVpIiwi5b6M6Jek5piO55SfIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIuW+jOiXpOaYjueUn1wiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvLCBTZWltZWlcIn0iLCJhdXRob3JfcyI6WyJHb3RvLCBTZWltZWkiLCLlvozol6TmmI7nlJ8iXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSIsIuW+jOiXpOaYjueUnyIsIkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6IuOCouODn+ODgOOCr+OCuOW8j+OCtOODiOOCpuODoeOCpOOCu+OCpOOAkOOCt+ODs+ODneOCuOOCpuODoO+8neW6p+irh+evh+OAkSIsInRpdGxlX3QiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744Kk44CQ44K344Oz44Od44K444Km44Og77yd5bqn6KuH56+H44CRIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJBbWlkYWt1amlzaGlraSBHb3RvIFNlaW1laSBzaGlucG9qaXVtdT16YWRhbiBoZW4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJUb2t5byA6IFRzdWthZGFtYSBTaG9ibywgMjAxNyIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNyJdLCJwdWJfY3JlYXRlZF9zIjpbIlRva3lvIDogVHN1a2FkYW1hIFNob2JvLCAyMDE3Iiwi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRva3lvOiBUc3VrYWRhbWEgU2hvYm8iLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywiZm9ybWF0IjpbIkJvb2siXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3QiOlsiOTc4NDkwODYyNDAxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiRWFzdCBBc2lhbiBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJFYXN0IEFzaWFuIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImpcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImoiXSwibG9jYXRpb25fZGlzcGxheSI6WyJFYXN0IEFzaWFuIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRWFzdCBBc2lhbiBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiaiIsIkVhc3QgQXNpYW4gTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkdvdG8sIFNlaW1laS4gQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi5b6M6Jek5piO55SfLiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwidGltZXN0YW1wIjoiMjAxNy0wMy0yM1QyMToyODo0Ni41NTdaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1546,7 +1546,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9878235":{"more_items":false,"location":"j","status":"On-Order","label":"East
         Asian Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1597,7 +1597,7 @@ http_interactions:
       string: '{"label":"","code":"j","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"East
         Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East
         Asian Library","code":"eastasian"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1651,7 +1651,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwiYXV0aG9yX2Rpc3BsYXkiOlsiR290bywgU2VpbWVpIiwi5b6M6Jek5piO55SfIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIuW+jOiXpOaYjueUn1wiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvLCBTZWltZWlcIn0iLCJhdXRob3JfcyI6WyJHb3RvLCBTZWltZWkiLCLlvozol6TmmI7nlJ8iXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSIsIuW+jOiXpOaYjueUnyIsIkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6IuOCouODn+ODgOOCr+OCuOW8j+OCtOODiOOCpuODoeOCpOOCu+OCpOOAkOOCt+ODs+ODneOCuOOCpuODoO+8neW6p+irh+evh+OAkSIsInRpdGxlX3QiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744Kk44CQ44K344Oz44Od44K444Km44Og77yd5bqn6KuH56+H44CRIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJBbWlkYWt1amlzaGlraSBHb3RvIFNlaW1laSBzaGlucG9qaXVtdT16YWRhbiBoZW4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJUb2t5byA6IFRzdWthZGFtYSBTaG9ibywgMjAxNyIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNyJdLCJwdWJfY3JlYXRlZF9zIjpbIlRva3lvIDogVHN1a2FkYW1hIFNob2JvLCAyMDE3Iiwi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRva3lvOiBUc3VrYWRhbWEgU2hvYm8iLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywiZm9ybWF0IjpbIkJvb2siXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3QiOlsiOTc4NDkwODYyNDAxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiRWFzdCBBc2lhbiBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJFYXN0IEFzaWFuIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImpcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImoiXSwibG9jYXRpb25fZGlzcGxheSI6WyJFYXN0IEFzaWFuIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRWFzdCBBc2lhbiBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiaiIsIkVhc3QgQXNpYW4gTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkdvdG8sIFNlaW1laS4gQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi5b6M6Jek5piO55SfLiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwidGltZXN0YW1wIjoiMjAxNy0wMy0yM1QyMToyODo0Ni41NTdaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1701,7 +1701,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9878235":{"more_items":false,"location":"j","status":"On-Order","label":"East
         Asian Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1752,7 +1752,7 @@ http_interactions:
       string: '{"label":"","code":"j","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"East
         Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East
         Asian Library","code":"eastasian"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1806,7 +1806,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwiYXV0aG9yX2Rpc3BsYXkiOlsiR290bywgU2VpbWVpIiwi5b6M6Jek5piO55SfIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIuW+jOiXpOaYjueUn1wiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvLCBTZWltZWlcIn0iLCJhdXRob3JfcyI6WyJHb3RvLCBTZWltZWkiLCLlvozol6TmmI7nlJ8iXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIkdvdG8sIFNlaW1laSIsIuW+jOiXpOaYjueUnyIsIkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRha3VqaXNoaWtpIEdvdG8gU2VpbWVpIHNoaW5wb2ppdW11PXphZGFuIGhlbiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6IuOCouODn+ODgOOCr+OCuOW8j+OCtOODiOOCpuODoeOCpOOCu+OCpOOAkOOCt+ODs+ODneOCuOOCpuODoO+8neW6p+irh+evh+OAkSIsInRpdGxlX3QiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744Kk44CQ44K344Oz44Od44K444Km44Og77yd5bqn6KuH56+H44CRIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJBbWlkYWt1amlzaGlraSBHb3RvIFNlaW1laSBzaGlucG9qaXVtdT16YWRhbiBoZW4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJUb2t5byA6IFRzdWthZGFtYSBTaG9ibywgMjAxNyIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNyJdLCJwdWJfY3JlYXRlZF9zIjpbIlRva3lvIDogVHN1a2FkYW1hIFNob2JvLCAyMDE3Iiwi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRva3lvOiBUc3VrYWRhbWEgU2hvYm8iLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywiZm9ybWF0IjpbIkJvb2siXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJpc2JuX3QiOlsiOTc4NDkwODYyNDAxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiRWFzdCBBc2lhbiBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJFYXN0IEFzaWFuIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImpcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImoiXSwibG9jYXRpb25fZGlzcGxheSI6WyJFYXN0IEFzaWFuIExpYnJhcnkiXSwibG9jYXRpb24iOlsiRWFzdCBBc2lhbiBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiaiIsIkVhc3QgQXNpYW4gTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkdvdG8sIFNlaW1laS4gQW1pZGFrdWppc2hpa2kgR290byBTZWltZWkgc2hpbnBvaml1bXU9emFkYW4gaGVuIiwi5b6M6Jek5piO55SfLiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqTjgJDjgrfjg7Pjg53jgrjjgqbjg6DvvJ3luqfoq4fnr4fjgJEiXSwidGltZXN0YW1wIjoiMjAxNy0wMy0yM1QyMToyODo0Ni41NTdaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:35 GMT
 - request:
     method: get
@@ -1856,7 +1856,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9878235":{"more_items":false,"location":"j","status":"On-Order","label":"East
         Asian Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:36 GMT
 - request:
     method: get
@@ -1907,7 +1907,7 @@ http_interactions:
       string: '{"label":"","code":"j","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"East
         Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East
         Asian Library","code":"eastasian"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:36 GMT
 - request:
     method: get
@@ -1961,7 +1961,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJhdXRob3JfZGlzcGxheSI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJTY2hyb2VkZXIsIENhcm9saW5lIFQuXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkNoaW4sIENhdGhlcmluZSBNLlwifSIsImF1dGhvcl9zIjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iLCJTY2hyb2VkZXIsIENhcm9saW5lIFQuLCAxOTcxLSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIiwiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR5IiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iLCJ0aXRsZV90IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiXCJNZWxhbmlhIHRoZSBFbGRlciBhbmQgaGVyIGdyYW5kZGF1Z2h0ZXIgTWVsYW5pYSB0aGUgWW91bmdlciB3ZXJlIG1ham9yIGZpZ3VyZXMgaW4gZWFybHkgQ2hyaXN0aWFuIGhpc3RvcnksIHVzaW5nIHRoZWlyIHdlYWx0aCwgc3RhdHVzLCBhbmQgZm9yY2VmdWwgcGVyc29uYWxpdGllcyB0byBzaGFwZSB0aGUgZGV2ZWxvcG1lbnQgb2YgbmVhcmx5IGV2ZXJ5IGFzcGVjdCBvZiB0aGUgcmVsaWdpb24gd2Ugbm93IGtub3cgYXMgQ2hyaXN0aWFuaXR5LiBUaGlzIHZvbHVtZSBleGFtaW5lcyB0aGUgaW5mbHVlbmNlIHRoYXQgdGhlc2UgdHdvIHdvbWVuIGhhZCBvbiB0aGUgZGV2ZWxvcG1lbnQgb2YgQ2hyaXN0aWFuaXR5IGFuZCBwcm92aWRlcyBhbiBpbnNpZ2h0ZnVsIHBvcnRyYWl0IG9mIHRoZSB0aGVpciBsZWdhY2llcyBpbiB0aGUgbW9kZXJuIHdvcmxkLiBJbnN0ZWFkIG9mIHRoZSB0cmFkaXRpb25hbGx5IHBhdHJpYXJjaGFsIHZpZXcsIHRoaXMgcGVyc3BlY3RpdmUgZ2l2ZXMgYSBwb2lnbmFudCBhbmQgc29tZXRpbWVzIHN1cnByaXNpbmcgdmlldyBvZiBob3cgdGhlIHJpc2Ugb2YgQ2hyaXN0aWFuIGluc3RpdHV0aW9ucyBpbiB0aGUgUm9tYW4gRW1waXJlIHNoYXBlZCB0aGUgdW5kZXJzdGFuZGluZyBvZiB3b21lbidzIHJvbGVzIGluIHRoZSBsYXJnZXIgd29ybGQuXCItLVByb3ZpZGVkIGJ5IHB1Ymxpc2hlci4iXSwiYmliX3JlZl9ub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGJpYmxpb2dyYXBoaWNhbCByZWZlcmVuY2VzIGFuZCBpbmRleC4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbiBwcmludCB2ZXJzaW9uIHJlY29yZCBhbmQgQ0lQIGRhdGEgcHJvdmlkZWQgYnkgcHVibGlzaGVyOyByZXNvdXJjZSBub3Qgdmlld2VkLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwic3ViamVjdF9kaXNwbGF5IjpbIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR54oCUSGlzdG9yeSJdLCJzdWJqZWN0X3QiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKGVsZWN0cm9uaWMgYmsuKSIsIjA1MjA5NjU2MzkgKGVsZWN0cm9uaWMgYmsuKSJdLCJsY2NuX2Rpc3BsYXkiOlsiICAyMDE2MDIwMzQxIl0sImxjY25fcyI6WyIyMDE2MDIwMzQxIl0sImlzYm5fcyI6WyI5NzgwNTIwOTY1NjM4Il0sImlzYm5fdCI6WyI5NzgwNTIwOTY1NjM4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwNTIwOTY1NjM4IiwiOTc4MDUyMDI5MjA4NiJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4MDA5MTBcIjp7XCJsb2NhdGlvblwiOlwiT25saW5lIC0gT25saW5lIFJlc291cmNlc1wiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYzXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJlbGYzIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiT25saW5lIC0gT25saW5lIFJlc291cmNlcyJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImVsZjMiLCJPbmxpbmUiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItLiBNZWxhbmlhIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJFbGVjdHJvbmljIFJlc291cmNlIl0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMjE6MzI6NTguMzU0WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:36 GMT
 - request:
     method: get
@@ -2011,7 +2011,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9800910":{"more_items":false,"location":"elf3","status":"Order Received","label":"Online
         - Online Resources"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:36 GMT
 - request:
     method: get
@@ -2058,7 +2058,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 9800910 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:37 GMT
 - request:
     method: get
@@ -2107,7 +2107,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"label":"Online Resources","code":"elf3","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:37 GMT
 - request:
     method: get
@@ -2161,7 +2161,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJhdXRob3JfZGlzcGxheSI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJTY2hyb2VkZXIsIENhcm9saW5lIFQuXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkNoaW4sIENhdGhlcmluZSBNLlwifSIsImF1dGhvcl9zIjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iLCJTY2hyb2VkZXIsIENhcm9saW5lIFQuLCAxOTcxLSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIiwiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR5IiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iLCJ0aXRsZV90IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiXCJNZWxhbmlhIHRoZSBFbGRlciBhbmQgaGVyIGdyYW5kZGF1Z2h0ZXIgTWVsYW5pYSB0aGUgWW91bmdlciB3ZXJlIG1ham9yIGZpZ3VyZXMgaW4gZWFybHkgQ2hyaXN0aWFuIGhpc3RvcnksIHVzaW5nIHRoZWlyIHdlYWx0aCwgc3RhdHVzLCBhbmQgZm9yY2VmdWwgcGVyc29uYWxpdGllcyB0byBzaGFwZSB0aGUgZGV2ZWxvcG1lbnQgb2YgbmVhcmx5IGV2ZXJ5IGFzcGVjdCBvZiB0aGUgcmVsaWdpb24gd2Ugbm93IGtub3cgYXMgQ2hyaXN0aWFuaXR5LiBUaGlzIHZvbHVtZSBleGFtaW5lcyB0aGUgaW5mbHVlbmNlIHRoYXQgdGhlc2UgdHdvIHdvbWVuIGhhZCBvbiB0aGUgZGV2ZWxvcG1lbnQgb2YgQ2hyaXN0aWFuaXR5IGFuZCBwcm92aWRlcyBhbiBpbnNpZ2h0ZnVsIHBvcnRyYWl0IG9mIHRoZSB0aGVpciBsZWdhY2llcyBpbiB0aGUgbW9kZXJuIHdvcmxkLiBJbnN0ZWFkIG9mIHRoZSB0cmFkaXRpb25hbGx5IHBhdHJpYXJjaGFsIHZpZXcsIHRoaXMgcGVyc3BlY3RpdmUgZ2l2ZXMgYSBwb2lnbmFudCBhbmQgc29tZXRpbWVzIHN1cnByaXNpbmcgdmlldyBvZiBob3cgdGhlIHJpc2Ugb2YgQ2hyaXN0aWFuIGluc3RpdHV0aW9ucyBpbiB0aGUgUm9tYW4gRW1waXJlIHNoYXBlZCB0aGUgdW5kZXJzdGFuZGluZyBvZiB3b21lbidzIHJvbGVzIGluIHRoZSBsYXJnZXIgd29ybGQuXCItLVByb3ZpZGVkIGJ5IHB1Ymxpc2hlci4iXSwiYmliX3JlZl9ub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGJpYmxpb2dyYXBoaWNhbCByZWZlcmVuY2VzIGFuZCBpbmRleC4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbiBwcmludCB2ZXJzaW9uIHJlY29yZCBhbmQgQ0lQIGRhdGEgcHJvdmlkZWQgYnkgcHVibGlzaGVyOyByZXNvdXJjZSBub3Qgdmlld2VkLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwic3ViamVjdF9kaXNwbGF5IjpbIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR54oCUSGlzdG9yeSJdLCJzdWJqZWN0X3QiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKGVsZWN0cm9uaWMgYmsuKSIsIjA1MjA5NjU2MzkgKGVsZWN0cm9uaWMgYmsuKSJdLCJsY2NuX2Rpc3BsYXkiOlsiICAyMDE2MDIwMzQxIl0sImxjY25fcyI6WyIyMDE2MDIwMzQxIl0sImlzYm5fcyI6WyI5NzgwNTIwOTY1NjM4Il0sImlzYm5fdCI6WyI5NzgwNTIwOTY1NjM4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwNTIwOTY1NjM4IiwiOTc4MDUyMDI5MjA4NiJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4MDA5MTBcIjp7XCJsb2NhdGlvblwiOlwiT25saW5lIC0gT25saW5lIFJlc291cmNlc1wiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYzXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJlbGYzIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiT25saW5lIC0gT25saW5lIFJlc291cmNlcyJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImVsZjMiLCJPbmxpbmUiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItLiBNZWxhbmlhIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJFbGVjdHJvbmljIFJlc291cmNlIl0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMjE6MzI6NTguMzU0WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:37 GMT
 - request:
     method: get
@@ -2211,7 +2211,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9800910":{"more_items":false,"location":"elf3","status":"Order Received","label":"Online
         - Online Resources"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:43 GMT
 - request:
     method: get
@@ -2258,7 +2258,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 9800910 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:43 GMT
 - request:
     method: get
@@ -2307,7 +2307,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"label":"Online Resources","code":"elf3","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:43 GMT
 - request:
     method: get
@@ -2361,7 +2361,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJhdXRob3JfZGlzcGxheSI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJTY2hyb2VkZXIsIENhcm9saW5lIFQuXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkNoaW4sIENhdGhlcmluZSBNLlwifSIsImF1dGhvcl9zIjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iLCJTY2hyb2VkZXIsIENhcm9saW5lIFQuLCAxOTcxLSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIiwiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR5IiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iLCJ0aXRsZV90IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5IC8gQ2F0aGVyaW5lIE0uIENoaW4gYW5kIENhcm9saW5lIFQuIFNjaHJvZWRlci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiXCJNZWxhbmlhIHRoZSBFbGRlciBhbmQgaGVyIGdyYW5kZGF1Z2h0ZXIgTWVsYW5pYSB0aGUgWW91bmdlciB3ZXJlIG1ham9yIGZpZ3VyZXMgaW4gZWFybHkgQ2hyaXN0aWFuIGhpc3RvcnksIHVzaW5nIHRoZWlyIHdlYWx0aCwgc3RhdHVzLCBhbmQgZm9yY2VmdWwgcGVyc29uYWxpdGllcyB0byBzaGFwZSB0aGUgZGV2ZWxvcG1lbnQgb2YgbmVhcmx5IGV2ZXJ5IGFzcGVjdCBvZiB0aGUgcmVsaWdpb24gd2Ugbm93IGtub3cgYXMgQ2hyaXN0aWFuaXR5LiBUaGlzIHZvbHVtZSBleGFtaW5lcyB0aGUgaW5mbHVlbmNlIHRoYXQgdGhlc2UgdHdvIHdvbWVuIGhhZCBvbiB0aGUgZGV2ZWxvcG1lbnQgb2YgQ2hyaXN0aWFuaXR5IGFuZCBwcm92aWRlcyBhbiBpbnNpZ2h0ZnVsIHBvcnRyYWl0IG9mIHRoZSB0aGVpciBsZWdhY2llcyBpbiB0aGUgbW9kZXJuIHdvcmxkLiBJbnN0ZWFkIG9mIHRoZSB0cmFkaXRpb25hbGx5IHBhdHJpYXJjaGFsIHZpZXcsIHRoaXMgcGVyc3BlY3RpdmUgZ2l2ZXMgYSBwb2lnbmFudCBhbmQgc29tZXRpbWVzIHN1cnByaXNpbmcgdmlldyBvZiBob3cgdGhlIHJpc2Ugb2YgQ2hyaXN0aWFuIGluc3RpdHV0aW9ucyBpbiB0aGUgUm9tYW4gRW1waXJlIHNoYXBlZCB0aGUgdW5kZXJzdGFuZGluZyBvZiB3b21lbidzIHJvbGVzIGluIHRoZSBsYXJnZXIgd29ybGQuXCItLVByb3ZpZGVkIGJ5IHB1Ymxpc2hlci4iXSwiYmliX3JlZl9ub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGJpYmxpb2dyYXBoaWNhbCByZWZlcmVuY2VzIGFuZCBpbmRleC4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbiBwcmludCB2ZXJzaW9uIHJlY29yZCBhbmQgQ0lQIGRhdGEgcHJvdmlkZWQgYnkgcHVibGlzaGVyOyByZXNvdXJjZSBub3Qgdmlld2VkLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwic3ViamVjdF9kaXNwbGF5IjpbIk1lbGFuaWEsIHRoZSBFbGRlciwgU2FpbnQsIDM0MT8tNDEwPyIsIk1lbGFuaWEsIHRoZSBZb3VuZ2VyLCBTYWludCwgMzg1Py00MzkiLCJDaHJpc3RpYW4gd29tZW4gc2FpbnRzIiwiV29tZW4gaW4gQ2hyaXN0aWFuaXR54oCUSGlzdG9yeSJdLCJzdWJqZWN0X3QiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKGVsZWN0cm9uaWMgYmsuKSIsIjA1MjA5NjU2MzkgKGVsZWN0cm9uaWMgYmsuKSJdLCJsY2NuX2Rpc3BsYXkiOlsiICAyMDE2MDIwMzQxIl0sImxjY25fcyI6WyIyMDE2MDIwMzQxIl0sImlzYm5fcyI6WyI5NzgwNTIwOTY1NjM4Il0sImlzYm5fdCI6WyI5NzgwNTIwOTY1NjM4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwNTIwOTY1NjM4IiwiOTc4MDUyMDI5MjA4NiJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4MDA5MTBcIjp7XCJsb2NhdGlvblwiOlwiT25saW5lIC0gT25saW5lIFJlc291cmNlc1wiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYzXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJlbGYzIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiT25saW5lIC0gT25saW5lIFJlc291cmNlcyJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImVsZjMiLCJPbmxpbmUiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJDaGluLCBDYXRoZXJpbmUgTS4sIDE5NzItLiBNZWxhbmlhIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJFbGVjdHJvbmljIFJlc291cmNlIl0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMjE6MzI6NTguMzU0WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:43 GMT
 - request:
     method: get
@@ -2411,7 +2411,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9800910":{"more_items":false,"location":"elf3","status":"Order Received","label":"Online
         - Online Resources"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2458,7 +2458,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 9800910 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2507,7 +2507,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"label":"Online Resources","code":"elf3","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2561,7 +2561,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjU2MTc3NCIsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZVwiLFwiTmF0aW9uYWwgQWZmYWlycywgSW5jXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdfSIsImF1dGhvcl9zIjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlIiwiTmF0aW9uYWwgQWZmYWlycywgSW5jIiwiRm9yZWlnbiBwb2xpY3kuIiwiVW5pdGVkIFN0YXRlcyIsIkZvcmVpZ24gcmVsYXRpb25zIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJGb3JlaWduIHBvbGljeSAoTmV3IFlvcmssIE4uWS4pIl0sInRpdGxlX2Rpc3BsYXkiOiJGb3JlaWduIHBvbGljeS4iLCJ0aXRsZV90IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRm9yZWlnbiBwb2xpY3kuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBOYXRpb25hbCBBZmZhaXJzLCBJbmMuLCBjMTk3MC0iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IE5hdGlvbmFsIEFmZmFpcnMsIEluYy4sIGMxOTcwLSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogTmF0aW9uYWwgQWZmYWlycywgSW5jIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk3MSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTcxLCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2LiA6IGlsbC4gOyAxMXgyNiAtIDI4IGNtLiIsIk5vLiAxICh3aW50ZXIgMTk3MC83MSktIl0sImRlc2NyaXB0aW9uX3QiOlsidi4gOiBpbGwuIDsgMTF4MjYgLSAyOCBjbS4iLCJOby4gMSAod2ludGVyIDE5NzAvNzEpLSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJCaW1vbnRobHksIFNlcHQuL09jdC4gMjAwMC1cdTAwM2MyMDEwXHUwMDNlIl0sImZvcm1lcl9mcmVxdWVuY3lfZGlzcGxheSI6WyJRdWFydGVybHksIDE5NzAvNzEtXHUwMDNjZmFsbCAxOTk5XHUwMDNlIl0sIm5vdGVzX2Rpc3BsYXkiOlsiUGxhY2Ugb2YgcHVibGljYXRpb24gdmFyaWVzOiBcdTAwM2MyMDAzLTIwMTBcdTAwM2UsIFdhc2hpbmd0b24sIERDLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IDEzOSAoTm92Li9EZWMuIDIwMDMpLiJdLCJpc3N1aW5nX2JvZHlfbm90ZXNfZGlzcGxheSI6WyJQdWJsaXNoZWQgc3ByaW5nIDE5Nzctc3ByaW5nIDE5NzggaW4gYXNzb2NpYXRpb24gd2l0aDogQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlOyBzdW1tZXIgMTk3OC1cdTAwM2MyMDA3XHUwMDNlLCBieSB0aGUgRW5kb3dtZW50LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwiaW5kZXhlc19kaXNwbGF5IjpbIk5vLiAxICh3aW50ZXIgMTk3MC83MSktOCAoZmFsbCAxOTcyKS4gMSB2LiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF90IjpbIlVuaXRlZCBTdGF0ZXPigJRGb3JlaWduIHJlbGF0aW9uc+KAlDE5NDUtMTk4OeKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJDYXJuZWdpZSBFbmRvd21lbnQgZm9yIEludGVybmF0aW9uYWwgUGVhY2VcIixcIk5hdGlvbmFsIEFmZmFpcnMsIEluY1wiXX0iLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5IiwiRlAgU2VwdC4vT2N0LiAyMDAwLVx1MDAzYzIwMTBcdTAwM2UiXSwiaXNzbl9kaXNwbGF5IjpbIjAwMTUtNzIyOCJdLCJsY2NuX2Rpc3BsYXkiOlsiICAgNzM2NDE4MjUgICJdLCJsY2NuX3MiOlsiNzM2NDE4MjUiXSwiaXNzbl9zIjpbIjAwMTU3MjI4Il0sIm9jbGNfcyI6WyIxNzg1NDg5Il0sIm90aGVyX3ZlcnNpb25fcyI6WyIwMDE1NzIyOCIsIm9jbTAxNzg1NDg5Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjE5NDUtMTk4OSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjYxMjc0MFwiOntcImxvY2F0aW9uXCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjY3NDNcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRTc0NCAuRjY3NDNcIixcImxvY2F0aW9uX2hhc1wiOltcIk5vLiAxMjAgKFNlcHQuL09jdC4gMjAwMCktbm8uIDIxNSAoTm92L0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTM0LCAxNTgsIDE2MCwgMTYyLCAxNjksIDE3MiwgMTczLDE3NVwiLFwiQ1VSUkVOVCBJU1NVRVMgSU46IFBlcmlvZGljYWxzIENvbGxlY3Rpb24gKFBSKS4gRmlyZXN0b25lXCJdfSxcIjYxMjc0MVwiOntcImxvY2F0aW9uXCI6XCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzXCIsXCJsaWJyYXJ5XCI6XCJTdG9rZXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic3BpYXBzXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDEgKHdpbnRlciAxOTcwLzcxKS1uby4gMjE1IChOb3YuL0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTE2LCAxMTgsIDEyOCwgMTM0LTEzNSwgMTU0LTE1OCwgMTYxLTE2MiwgMTcyLTE3NSwgMTc3XCIsXCJDVVJSRU5UIElTU1VFUyBJTjogRG9uYWxkIEUuIFN0b2tlcyBMaWJyYXJ5IChTUElBKS4gV2FsbGFjZSBIYWxsXCJdLFwiaW5kZXhlc1wiOltcIkluZGV4LCBuby4gMS84XCJdfSxcIjYxMjc0MlwiOntcImxvY2F0aW9uXCI6XCJNdWRkIE1hbnVzY3JpcHQgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcIm11ZGRcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTk8gQk9VTkQgSE9MRElOR1NcIixcIkNVUlJFTlQgSVNTVUVTIElOOiBTZWVsZXkgRy4gTXVkZCBMaWJyYXJ5IChNdWRkKVwiXX0sXCI0NzM2NzM1XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIixcImNhbGxfbnVtYmVyXCI6XCIxMDk2LjM1MjVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTA5Ni4zNTI1XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMSAod2ludGVyIDE5NzAvNzEpLW5vLiAxMTYgKGZhbGwgMTk5OSlcIl19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIiwic3BpYXBzIiwibXVkZCIsInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiLCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzIiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJzcGlhcHMiLCJtdWRkIiwicmNwcGEiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMTY6NDQ6NDAuNDQ0WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2608,7 +2608,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 612742 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:48 GMT
 - request:
     method: get
@@ -2661,7 +2661,7 @@ http_interactions:
         Charged","label":"Stokes Library - Periodicals"},"612742":{"more_items":false,"location":"mudd","status":"On-Site","label":"Mudd
         Manuscript Library"},"4736735":{"more_items":true,"location":"rcppa","copy_number":1,"item_id":703398,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2712,7 +2712,7 @@ http_interactions:
       string: '{"label":"Periodicals","code":"spiaps","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2764,7 +2764,7 @@ http_interactions:
         Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd
         Manuscript Library and University Archives","code":"mudd"},"delivery_locations":[{"label":"Mudd
         Manuscript Library","address":"65 Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2818,7 +2818,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjU2MTc3NCIsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZVwiLFwiTmF0aW9uYWwgQWZmYWlycywgSW5jXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdfSIsImF1dGhvcl9zIjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlIiwiTmF0aW9uYWwgQWZmYWlycywgSW5jIiwiRm9yZWlnbiBwb2xpY3kuIiwiVW5pdGVkIFN0YXRlcyIsIkZvcmVpZ24gcmVsYXRpb25zIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJGb3JlaWduIHBvbGljeSAoTmV3IFlvcmssIE4uWS4pIl0sInRpdGxlX2Rpc3BsYXkiOiJGb3JlaWduIHBvbGljeS4iLCJ0aXRsZV90IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRm9yZWlnbiBwb2xpY3kuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBOYXRpb25hbCBBZmZhaXJzLCBJbmMuLCBjMTk3MC0iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IE5hdGlvbmFsIEFmZmFpcnMsIEluYy4sIGMxOTcwLSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogTmF0aW9uYWwgQWZmYWlycywgSW5jIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk3MSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTcxLCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2LiA6IGlsbC4gOyAxMXgyNiAtIDI4IGNtLiIsIk5vLiAxICh3aW50ZXIgMTk3MC83MSktIl0sImRlc2NyaXB0aW9uX3QiOlsidi4gOiBpbGwuIDsgMTF4MjYgLSAyOCBjbS4iLCJOby4gMSAod2ludGVyIDE5NzAvNzEpLSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJCaW1vbnRobHksIFNlcHQuL09jdC4gMjAwMC1cdTAwM2MyMDEwXHUwMDNlIl0sImZvcm1lcl9mcmVxdWVuY3lfZGlzcGxheSI6WyJRdWFydGVybHksIDE5NzAvNzEtXHUwMDNjZmFsbCAxOTk5XHUwMDNlIl0sIm5vdGVzX2Rpc3BsYXkiOlsiUGxhY2Ugb2YgcHVibGljYXRpb24gdmFyaWVzOiBcdTAwM2MyMDAzLTIwMTBcdTAwM2UsIFdhc2hpbmd0b24sIERDLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IDEzOSAoTm92Li9EZWMuIDIwMDMpLiJdLCJpc3N1aW5nX2JvZHlfbm90ZXNfZGlzcGxheSI6WyJQdWJsaXNoZWQgc3ByaW5nIDE5Nzctc3ByaW5nIDE5NzggaW4gYXNzb2NpYXRpb24gd2l0aDogQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlOyBzdW1tZXIgMTk3OC1cdTAwM2MyMDA3XHUwMDNlLCBieSB0aGUgRW5kb3dtZW50LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwiaW5kZXhlc19kaXNwbGF5IjpbIk5vLiAxICh3aW50ZXIgMTk3MC83MSktOCAoZmFsbCAxOTcyKS4gMSB2LiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF90IjpbIlVuaXRlZCBTdGF0ZXPigJRGb3JlaWduIHJlbGF0aW9uc+KAlDE5NDUtMTk4OeKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJDYXJuZWdpZSBFbmRvd21lbnQgZm9yIEludGVybmF0aW9uYWwgUGVhY2VcIixcIk5hdGlvbmFsIEFmZmFpcnMsIEluY1wiXX0iLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5IiwiRlAgU2VwdC4vT2N0LiAyMDAwLVx1MDAzYzIwMTBcdTAwM2UiXSwiaXNzbl9kaXNwbGF5IjpbIjAwMTUtNzIyOCJdLCJsY2NuX2Rpc3BsYXkiOlsiICAgNzM2NDE4MjUgICJdLCJsY2NuX3MiOlsiNzM2NDE4MjUiXSwiaXNzbl9zIjpbIjAwMTU3MjI4Il0sIm9jbGNfcyI6WyIxNzg1NDg5Il0sIm90aGVyX3ZlcnNpb25fcyI6WyIwMDE1NzIyOCIsIm9jbTAxNzg1NDg5Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjE5NDUtMTk4OSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjYxMjc0MFwiOntcImxvY2F0aW9uXCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjY3NDNcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRTc0NCAuRjY3NDNcIixcImxvY2F0aW9uX2hhc1wiOltcIk5vLiAxMjAgKFNlcHQuL09jdC4gMjAwMCktbm8uIDIxNSAoTm92L0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTM0LCAxNTgsIDE2MCwgMTYyLCAxNjksIDE3MiwgMTczLDE3NVwiLFwiQ1VSUkVOVCBJU1NVRVMgSU46IFBlcmlvZGljYWxzIENvbGxlY3Rpb24gKFBSKS4gRmlyZXN0b25lXCJdfSxcIjYxMjc0MVwiOntcImxvY2F0aW9uXCI6XCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzXCIsXCJsaWJyYXJ5XCI6XCJTdG9rZXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic3BpYXBzXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDEgKHdpbnRlciAxOTcwLzcxKS1uby4gMjE1IChOb3YuL0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTE2LCAxMTgsIDEyOCwgMTM0LTEzNSwgMTU0LTE1OCwgMTYxLTE2MiwgMTcyLTE3NSwgMTc3XCIsXCJDVVJSRU5UIElTU1VFUyBJTjogRG9uYWxkIEUuIFN0b2tlcyBMaWJyYXJ5IChTUElBKS4gV2FsbGFjZSBIYWxsXCJdLFwiaW5kZXhlc1wiOltcIkluZGV4LCBuby4gMS84XCJdfSxcIjYxMjc0MlwiOntcImxvY2F0aW9uXCI6XCJNdWRkIE1hbnVzY3JpcHQgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcIm11ZGRcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTk8gQk9VTkQgSE9MRElOR1NcIixcIkNVUlJFTlQgSVNTVUVTIElOOiBTZWVsZXkgRy4gTXVkZCBMaWJyYXJ5IChNdWRkKVwiXX0sXCI0NzM2NzM1XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIixcImNhbGxfbnVtYmVyXCI6XCIxMDk2LjM1MjVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTA5Ni4zNTI1XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMSAod2ludGVyIDE5NzAvNzEpLW5vLiAxMTYgKGZhbGwgMTk5OSlcIl19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIiwic3BpYXBzIiwibXVkZCIsInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiLCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzIiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJzcGlhcHMiLCJtdWRkIiwicmNwcGEiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMTY6NDQ6NDAuNDQ0WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2865,7 +2865,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 612742 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2918,7 +2918,7 @@ http_interactions:
         Charged","label":"Stokes Library - Periodicals"},"612742":{"more_items":false,"location":"mudd","status":"On-Site","label":"Mudd
         Manuscript Library"},"4736735":{"more_items":true,"location":"rcppa","copy_number":1,"item_id":703398,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -2969,7 +2969,7 @@ http_interactions:
       string: '{"label":"Periodicals","code":"spiaps","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -3021,7 +3021,7 @@ http_interactions:
         Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd
         Manuscript Library and University Archives","code":"mudd"},"delivery_locations":[{"label":"Mudd
         Manuscript Library","address":"65 Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:49 GMT
 - request:
     method: get
@@ -3075,7 +3075,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjU2MTc3NCIsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZVwiLFwiTmF0aW9uYWwgQWZmYWlycywgSW5jXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdfSIsImF1dGhvcl9zIjpbIkNhcm5lZ2llIEVuZG93bWVudCBmb3IgSW50ZXJuYXRpb25hbCBQZWFjZSIsIk5hdGlvbmFsIEFmZmFpcnMsIEluYyJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlIiwiTmF0aW9uYWwgQWZmYWlycywgSW5jIiwiRm9yZWlnbiBwb2xpY3kuIiwiVW5pdGVkIFN0YXRlcyIsIkZvcmVpZ24gcmVsYXRpb25zIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJGb3JlaWduIHBvbGljeSAoTmV3IFlvcmssIE4uWS4pIl0sInRpdGxlX2Rpc3BsYXkiOiJGb3JlaWduIHBvbGljeS4iLCJ0aXRsZV90IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5LiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRm9yZWlnbiBwb2xpY3kuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBOYXRpb25hbCBBZmZhaXJzLCBJbmMuLCBjMTk3MC0iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IE5hdGlvbmFsIEFmZmFpcnMsIEluYy4sIGMxOTcwLSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogTmF0aW9uYWwgQWZmYWlycywgSW5jIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk3MSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTcxLCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2LiA6IGlsbC4gOyAxMXgyNiAtIDI4IGNtLiIsIk5vLiAxICh3aW50ZXIgMTk3MC83MSktIl0sImRlc2NyaXB0aW9uX3QiOlsidi4gOiBpbGwuIDsgMTF4MjYgLSAyOCBjbS4iLCJOby4gMSAod2ludGVyIDE5NzAvNzEpLSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJCaW1vbnRobHksIFNlcHQuL09jdC4gMjAwMC1cdTAwM2MyMDEwXHUwMDNlIl0sImZvcm1lcl9mcmVxdWVuY3lfZGlzcGxheSI6WyJRdWFydGVybHksIDE5NzAvNzEtXHUwMDNjZmFsbCAxOTk5XHUwMDNlIl0sIm5vdGVzX2Rpc3BsYXkiOlsiUGxhY2Ugb2YgcHVibGljYXRpb24gdmFyaWVzOiBcdTAwM2MyMDAzLTIwMTBcdTAwM2UsIFdhc2hpbmd0b24sIERDLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IDEzOSAoTm92Li9EZWMuIDIwMDMpLiJdLCJpc3N1aW5nX2JvZHlfbm90ZXNfZGlzcGxheSI6WyJQdWJsaXNoZWQgc3ByaW5nIDE5Nzctc3ByaW5nIDE5NzggaW4gYXNzb2NpYXRpb24gd2l0aDogQ2FybmVnaWUgRW5kb3dtZW50IGZvciBJbnRlcm5hdGlvbmFsIFBlYWNlOyBzdW1tZXIgMTk3OC1cdTAwM2MyMDA3XHUwMDNlLCBieSB0aGUgRW5kb3dtZW50LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwiaW5kZXhlc19kaXNwbGF5IjpbIk5vLiAxICh3aW50ZXIgMTk3MC83MSktOCAoZmFsbCAxOTcyKS4gMSB2LiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF90IjpbIlVuaXRlZCBTdGF0ZXPigJRGb3JlaWduIHJlbGF0aW9uc+KAlDE5NDUtMTk4OeKAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiVW5pdGVkIFN0YXRlc+KAlEZvcmVpZ24gcmVsYXRpb25z4oCUMTk0NS0xOTg54oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJDYXJuZWdpZSBFbmRvd21lbnQgZm9yIEludGVybmF0aW9uYWwgUGVhY2VcIixcIk5hdGlvbmFsIEFmZmFpcnMsIEluY1wiXX0iLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIkZvcmVpZ24gcG9saWN5IiwiRlAgU2VwdC4vT2N0LiAyMDAwLVx1MDAzYzIwMTBcdTAwM2UiXSwiaXNzbl9kaXNwbGF5IjpbIjAwMTUtNzIyOCJdLCJsY2NuX2Rpc3BsYXkiOlsiICAgNzM2NDE4MjUgICJdLCJsY2NuX3MiOlsiNzM2NDE4MjUiXSwiaXNzbl9zIjpbIjAwMTU3MjI4Il0sIm9jbGNfcyI6WyIxNzg1NDg5Il0sIm90aGVyX3ZlcnNpb25fcyI6WyIwMDE1NzIyOCIsIm9jbTAxNzg1NDg5Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjE5NDUtMTk4OSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjYxMjc0MFwiOntcImxvY2F0aW9uXCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjY3NDNcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRTc0NCAuRjY3NDNcIixcImxvY2F0aW9uX2hhc1wiOltcIk5vLiAxMjAgKFNlcHQuL09jdC4gMjAwMCktbm8uIDIxNSAoTm92L0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTM0LCAxNTgsIDE2MCwgMTYyLCAxNjksIDE3MiwgMTczLDE3NVwiLFwiQ1VSUkVOVCBJU1NVRVMgSU46IFBlcmlvZGljYWxzIENvbGxlY3Rpb24gKFBSKS4gRmlyZXN0b25lXCJdfSxcIjYxMjc0MVwiOntcImxvY2F0aW9uXCI6XCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzXCIsXCJsaWJyYXJ5XCI6XCJTdG9rZXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic3BpYXBzXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDEgKHdpbnRlciAxOTcwLzcxKS1uby4gMjE1IChOb3YuL0RlYy4gMjAxNSlcIixcIkxBQ0tTOiBuby4gMTE2LCAxMTgsIDEyOCwgMTM0LTEzNSwgMTU0LTE1OCwgMTYxLTE2MiwgMTcyLTE3NSwgMTc3XCIsXCJDVVJSRU5UIElTU1VFUyBJTjogRG9uYWxkIEUuIFN0b2tlcyBMaWJyYXJ5IChTUElBKS4gV2FsbGFjZSBIYWxsXCJdLFwiaW5kZXhlc1wiOltcIkluZGV4LCBuby4gMS84XCJdfSxcIjYxMjc0MlwiOntcImxvY2F0aW9uXCI6XCJNdWRkIE1hbnVzY3JpcHQgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcIm11ZGRcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRTc0NCAuRjc1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkU3NDQgLkY3NVwiLFwibG9jYXRpb25faGFzXCI6W1wiTk8gQk9VTkQgSE9MRElOR1NcIixcIkNVUlJFTlQgSVNTVUVTIElOOiBTZWVsZXkgRy4gTXVkZCBMaWJyYXJ5IChNdWRkKVwiXX0sXCI0NzM2NzM1XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIixcImNhbGxfbnVtYmVyXCI6XCIxMDk2LjM1MjVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTA5Ni4zNTI1XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMSAod2ludGVyIDE5NzAvNzEpLW5vLiAxMTYgKGZhbGwgMTk5OSlcIl19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJmIiwic3BpYXBzIiwibXVkZCIsInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiLCJTdG9rZXMgTGlicmFyeSAtIFBlcmlvZGljYWxzIiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJzcGlhcHMiLCJtdWRkIiwicmNwcGEiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlN0b2tlcyBMaWJyYXJ5IiwiTXVkZCBNYW51c2NyaXB0IExpYnJhcnkiLCJSZUNBUCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkU3NDQgLkY2NzQzIiwiRTc0NCAuRjc1IiwiMTA5Ni4zNTI1Il0sInRpbWVzdGFtcCI6IjIwMTctMDMtMjNUMTY6NDQ6NDAuNDQ0WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3122,7 +3122,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 612742 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3175,7 +3175,7 @@ http_interactions:
         Charged","label":"Stokes Library - Periodicals"},"612742":{"more_items":false,"location":"mudd","status":"On-Site","label":"Mudd
         Manuscript Library"},"4736735":{"more_items":true,"location":"rcppa","copy_number":1,"item_id":703398,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3226,7 +3226,7 @@ http_interactions:
       string: '{"label":"Periodicals","code":"spiaps","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3278,7 +3278,7 @@ http_interactions:
         Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd
         Manuscript Library and University Archives","code":"mudd"},"delivery_locations":[{"label":"Mudd
         Manuscript Library","address":"65 Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:50 GMT
 - request:
     method: get
@@ -3332,7 +3332,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJhdXRob3JfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkIiwiQm9obmVyLCBLYXRlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiQm9obmVyLCBLYXRlXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlRydW1wLCBEb25hbGRcIn0iLCJhdXRob3JfcyI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJvaG5lciwgS2F0ZSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCb2huZXIsIEthdGUiLCJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8gRG9uYWxkIEouIFRydW1wIHdpdGggS2F0ZSBCb2huZXIuIiwiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbiIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iLCJ0aXRsZV90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfdCI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI0VDE1OjQwOjM0LjE0M1oifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:53 GMT
 - request:
     method: get
@@ -3382,7 +3382,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101032361436","id":2114223,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Charged","due_date":"4/13/2017","label":"Firestone
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:53 GMT
 - request:
     method: get
@@ -3436,7 +3436,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJhdXRob3JfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkIiwiQm9obmVyLCBLYXRlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiQm9obmVyLCBLYXRlXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlRydW1wLCBEb25hbGRcIn0iLCJhdXRob3JfcyI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJvaG5lciwgS2F0ZSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCb2huZXIsIEthdGUiLCJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8gRG9uYWxkIEouIFRydW1wIHdpdGggS2F0ZSBCb2huZXIuIiwiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbiIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iLCJ0aXRsZV90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfdCI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI0VDE1OjQwOjM0LjE0M1oifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:53 GMT
 - request:
     method: get
@@ -3486,7 +3486,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101032361436","id":2114223,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Charged","due_date":"4/13/2017","label":"Firestone
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:53 GMT
 - request:
     method: get
@@ -3540,7 +3540,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJhdXRob3JfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkIiwiQm9obmVyLCBLYXRlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiQm9obmVyLCBLYXRlXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlRydW1wLCBEb25hbGRcIn0iLCJhdXRob3JfcyI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJvaG5lciwgS2F0ZSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCb2huZXIsIEthdGUiLCJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8gRG9uYWxkIEouIFRydW1wIHdpdGggS2F0ZSBCb2huZXIuIiwiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbiIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iLCJ0aXRsZV90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJUcnVtcCA6IHRoZSBhcnQgb2YgdGhlIGNvbWViYWNrIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfdCI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJ0aW1lc3RhbXAiOiIyMDE3LTAzLTI0VDE1OjQwOjM0LjE0M1oifX19
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:54 GMT
 - request:
     method: get
@@ -3590,7 +3590,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101032361436","id":2114223,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Charged","due_date":"4/13/2017","label":"Firestone
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:54 GMT
 - request:
     method: get
@@ -3641,7 +3641,7 @@ http_interactions:
       string: '{"2576882":{"more_items":false,"location":"l","status":"On Shelf","label":"Forrestal
         Annex - Locked Books"},"2576883":{"more_items":true,"location":"f","copy_number":1,"item_id":4288427,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:54 GMT
 - request:
     method: get
@@ -3688,7 +3688,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2576882 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3745,7 +3745,7 @@ http_interactions:
         Charged","enum":"v. 10 (1931-32)","label":"Firestone Library"},{"barcode":"32101100259587","id":7079626,"location":"f","copy_number":1,"item_sequence_number":2,"status":"Not
         Charged","enum":"v. 9 (1930-31)","label":"Firestone Library"},{"barcode":"32101100259561","id":4288428,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"v. 8 (1929-30)","label":"Firestone Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3795,7 +3795,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"label":"Locked Books","code":"l","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Forrestal
         Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3859,7 +3859,7 @@ http_interactions:
         Annex - Locked Books","Firestone Library"],"location":["Forrestal Annex","Firestone
         Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone Library"],"call_number_display":["Oversize
         HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766 .B53f","HQ766 .B53"],"timestamp":"2017-03-23T15:10:21.059Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3910,7 +3910,7 @@ http_interactions:
       string: '{"2576882":{"more_items":false,"location":"l","status":"On Shelf","label":"Forrestal
         Annex - Locked Books"},"2576883":{"more_items":true,"location":"f","copy_number":1,"item_id":4288427,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -3957,7 +3957,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2576882 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -4014,7 +4014,7 @@ http_interactions:
         Charged","enum":"v. 10 (1931-32)","label":"Firestone Library"},{"barcode":"32101100259587","id":7079626,"location":"f","copy_number":1,"item_sequence_number":2,"status":"Not
         Charged","enum":"v. 9 (1930-31)","label":"Firestone Library"},{"barcode":"32101100259561","id":4288428,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"v. 8 (1929-30)","label":"Firestone Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:55 GMT
 - request:
     method: get
@@ -4064,7 +4064,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"label":"Locked Books","code":"l","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Forrestal
         Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4128,7 +4128,7 @@ http_interactions:
         Annex - Locked Books","Firestone Library"],"location":["Forrestal Annex","Firestone
         Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone Library"],"call_number_display":["Oversize
         HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766 .B53f","HQ766 .B53"],"timestamp":"2017-03-23T15:10:21.059Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4179,7 +4179,7 @@ http_interactions:
       string: '{"2576882":{"more_items":false,"location":"l","status":"On Shelf","label":"Forrestal
         Annex - Locked Books"},"2576883":{"more_items":true,"location":"f","copy_number":1,"item_id":4288427,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4226,7 +4226,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2576882 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4283,7 +4283,7 @@ http_interactions:
         Charged","enum":"v. 10 (1931-32)","label":"Firestone Library"},{"barcode":"32101100259587","id":7079626,"location":"f","copy_number":1,"item_sequence_number":2,"status":"Not
         Charged","enum":"v. 9 (1930-31)","label":"Firestone Library"},{"barcode":"32101100259561","id":4288428,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","enum":"v. 8 (1929-30)","label":"Firestone Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:56 GMT
 - request:
     method: get
@@ -4333,7 +4333,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"label":"Locked Books","code":"l","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Forrestal
         Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 29 Mar 2017 16:52:57 GMT
 - request:
     method: get
@@ -4403,7 +4403,7 @@ http_interactions:
         - Marquand Library use only\",\"library\":\"ReCAP\",\"location_code\":\"rcppj\"}}","location_code_s":["rcppj"],"location_display":["ReCAP
         - Marquand Library use only"],"location":["ReCAP"],"advanced_location_s":["rcppj","ReCAP"],"name_title_browse_s":["Dyk,
         Janna. ADAM GOLFER: A HOUSE WITHOUT A ROOF"],"timestamp":"2017-03-31T04:41:46.037Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:12 GMT
 - request:
     method: get
@@ -4453,7 +4453,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9933878":{"more_items":false,"location":"rcppj","copy_number":0,"item_id":7584750,"on_reserve":"N","status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:12 GMT
 - request:
     method: get
@@ -4503,7 +4503,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101099207571","id":7584750,"location":"rcppj","copy_number":0,"item_sequence_number":1,"status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4558,7 +4558,7 @@ http_interactions:
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Preservation","address":"One
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4628,7 +4628,7 @@ http_interactions:
         - Marquand Library use only\",\"library\":\"ReCAP\",\"location_code\":\"rcppj\"}}","location_code_s":["rcppj"],"location_display":["ReCAP
         - Marquand Library use only"],"location":["ReCAP"],"advanced_location_s":["rcppj","ReCAP"],"name_title_browse_s":["Dyk,
         Janna. ADAM GOLFER: A HOUSE WITHOUT A ROOF"],"timestamp":"2017-03-31T04:41:46.037Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4678,7 +4678,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9933878":{"more_items":false,"location":"rcppj","copy_number":0,"item_id":7584750,"on_reserve":"N","status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4728,7 +4728,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101099207571","id":7584750,"location":"rcppj","copy_number":0,"item_sequence_number":1,"status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:13 GMT
 - request:
     method: get
@@ -4783,7 +4783,7 @@ http_interactions:
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Preservation","address":"One
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:14 GMT
 - request:
     method: get
@@ -4853,7 +4853,7 @@ http_interactions:
         - Marquand Library use only\",\"library\":\"ReCAP\",\"location_code\":\"rcppj\"}}","location_code_s":["rcppj"],"location_display":["ReCAP
         - Marquand Library use only"],"location":["ReCAP"],"advanced_location_s":["rcppj","ReCAP"],"name_title_browse_s":["Dyk,
         Janna. ADAM GOLFER: A HOUSE WITHOUT A ROOF"],"timestamp":"2017-03-31T04:41:46.037Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:14 GMT
 - request:
     method: get
@@ -4903,7 +4903,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"9933878":{"more_items":false,"location":"rcppj","copy_number":0,"item_id":7584750,"on_reserve":"N","status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:15 GMT
 - request:
     method: get
@@ -4953,7 +4953,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101099207571","id":7584750,"location":"rcppj","copy_number":0,"item_sequence_number":1,"status":"On-Site
         - In Process","label":"ReCAP - Marquand Library use only"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:15 GMT
 - request:
     method: get
@@ -5008,7 +5008,7 @@ http_interactions:
         08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Preservation","address":"One
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 31 Mar 2017 19:24:15 GMT
 - request:
     method: get
@@ -5085,7 +5085,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"timestamp":"2017-03-23T17:22:00.830Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:43 GMT
 - request:
     method: get
@@ -5135,7 +5135,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101059892883","id":4397582,"location":"spia","temp_loc":"strr","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"Engineering Library - Reserve"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:47 GMT
 - request:
     method: get
@@ -5186,7 +5186,7 @@ http_interactions:
       string: '{"label":"","code":"sci","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Lewis
         Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis
         Library","code":"lewis"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:48 GMT
 - request:
     method: get
@@ -5237,7 +5237,7 @@ http_interactions:
       string: '{"label":"SPIA","code":"spia","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:48 GMT
 - request:
     method: get
@@ -5289,7 +5289,7 @@ http_interactions:
         Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand
         Library of Art and Archaeology","code":"marquand"},"delivery_locations":[{"label":"Marquand
         Library of Art and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:48 GMT
 - request:
     method: get
@@ -5340,7 +5340,7 @@ http_interactions:
       string: '{"label":"Reserve","code":"strr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Engineering
         Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering
         Library","code":"engineering"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:49 GMT
 - request:
     method: get
@@ -5417,7 +5417,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"timestamp":"2017-03-23T17:22:00.830Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:50 GMT
 - request:
     method: get
@@ -5467,7 +5467,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101059892883","id":4397582,"location":"spia","temp_loc":"strr","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"Engineering Library - Reserve"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:50 GMT
 - request:
     method: get
@@ -5518,7 +5518,7 @@ http_interactions:
       string: '{"label":"","code":"sci","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Lewis
         Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis
         Library","code":"lewis"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:51 GMT
 - request:
     method: get
@@ -5569,7 +5569,7 @@ http_interactions:
       string: '{"label":"SPIA","code":"spia","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Stokes
         Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes
         Library","code":"stokes"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:51 GMT
 - request:
     method: get
@@ -5621,7 +5621,7 @@ http_interactions:
         Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand
         Library of Art and Archaeology","code":"marquand"},"delivery_locations":[{"label":"Marquand
         Library of Art and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:51 GMT
 - request:
     method: get
@@ -5672,7 +5672,7 @@ http_interactions:
       string: '{"label":"Reserve","code":"strr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Engineering
         Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering
         Library","code":"engineering"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 13 Apr 2017 05:38:52 GMT
 - request:
     method: get
@@ -5727,7 +5727,7 @@ http_interactions:
         Charged","label":"Engineering Library - Reserve"},"5039570":{"more_items":false,"location":"f","copy_number":1,"item_id":4428451,"on_reserve":"N","due_date":"6/15/2017","status":"Renewed","label":"Firestone
         Library"},"5674398":{"more_items":false,"location":"sa","copy_number":1,"item_id":5084627,"on_reserve":"N","status":"On-Site","label":"Marquand
         Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5777,7 +5777,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101059938264","id":4380458,"location":"sci","copy_number":1,"item_sequence_number":1,"status":"Renewed","due_date":"5/22/2017","label":"Lewis
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5827,7 +5827,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101061133466","id":4428451,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Renewed","due_date":"6/15/2017","label":"Firestone
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5877,7 +5877,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101067508992","id":5084627,"location":"sa","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Marquand
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5932,7 +5932,7 @@ http_interactions:
         Charged","label":"Engineering Library - Reserve"},"5039570":{"more_items":false,"location":"f","copy_number":1,"item_id":4428451,"on_reserve":"N","due_date":"6/15/2017","status":"Renewed","label":"Firestone
         Library"},"5674398":{"more_items":false,"location":"sa","copy_number":1,"item_id":5084627,"on_reserve":"N","status":"On-Site","label":"Marquand
         Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:32 GMT
 - request:
     method: get
@@ -5982,7 +5982,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101059938264","id":4380458,"location":"sci","copy_number":1,"item_sequence_number":1,"status":"Renewed","due_date":"5/22/2017","label":"Lewis
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:33 GMT
 - request:
     method: get
@@ -6032,7 +6032,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101061133466","id":4428451,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Renewed","due_date":"6/15/2017","label":"Firestone
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:33 GMT
 - request:
     method: get
@@ -6082,7 +6082,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101067508992","id":5084627,"location":"sa","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Marquand
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:33 GMT
 - request:
     method: get
@@ -6132,7 +6132,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"2053005":{"more_items":false,"location":"f","copy_number":1,"item_id":2114223,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:37 GMT
 - request:
     method: get
@@ -6182,7 +6182,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"2053005":{"more_items":false,"location":"f","copy_number":1,"item_id":2114223,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:37 GMT
 - request:
     method: get
@@ -6232,7 +6232,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"2053005":{"more_items":false,"location":"f","copy_number":1,"item_id":2114223,"on_reserve":"N","status":"Not
         Charged","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Apr 2017 21:22:37 GMT
 - request:
     method: get
@@ -6286,7 +6286,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJhdXRob3JfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcyIsIkVkaXRpb25zIGRlIE1pbnVpdCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkVkaXRpb25zIGRlIE1pbnVpdFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzXCJ9IiwiYXV0aG9yX3MiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcywgMTkwMi0xOTkzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiLCJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwiR3JlYXQgQnJpdGFpbiIsIlJlbGF0aW9ucyIsIkZyYW5jZSIsIkZyYW5jZSIsIlJlbGF0aW9ucyIsIkdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWluIiwiQ2l2aWxpemF0aW9uIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iLCJ0aXRsZV90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkgW3Bhcl0gQXJnb25uZSBbcHNldWQuXSJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQYXJpcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5NDMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk0MywicHViX2RhdGVfZW5kX3NvcnQiOjE5NDUsImNhdGFsb2dlZF90ZHQiOiIyMDA2LTEwLTA1VDE4OjE5OjIyWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNjEgcC4gMTcgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiNjEgcC4gMTcgY20uIl0sIm5vdGVzX2Rpc3BsYXkiOlsiXCJQcmVtaWXMgHJlIGXMgWRpdGlvbiBwdWJsaXF1ZS5cIiIsIkF1dGhvcidzIHBzZXVkLiwgQXJnb25uZSwgYXQgaGVhZCBvZiB0aXRsZS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF90IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF9mYWNldCI6WyJHcmVhdCBCcml0YWlu4oCUUmVsYXRpb25z4oCURnJhbmNlIiwiRnJhbmNl4oCUUmVsYXRpb25z4oCUR3JlYXQgQnJpdGFpbiIsIkdyZWF0IEJyaXRhaW7igJRDaXZpbGl6YXRpb27igJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiUmVsYXRlZCBuYW1lXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdfSIsImxjY25fZGlzcGxheSI6WyIgICA0NzAyODc5OSAgIl0sImxjY25fcyI6WyI0NzAyODc5OSJdLCJvY2xjX3MiOlsiNjY3ODY4MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NtMDY2Nzg2ODEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyNDUzNjkzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvblwiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiYmVhY1wiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEQTQ3LjEgLkQzNSAxOTQ1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIn0sXCIyNDUzNjk0XCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCIzMjI5LjMxOS4yOFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIzMjI5LjMxOS4yOFwifSxcIjM1MjA1NDFcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIjE0NTkuMjg3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjE0NTkuMjg3XCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSJdLCJsb2NhdGlvbiI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gU3lsdmlhIEJlYWNoIENvbGxlY3Rpb24iLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rcyIsIlJlQ0FQIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiYmVhYyIsImV4IiwicmNwcGEiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMuIEFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwidGltZXN0YW1wIjoiMjAxNy0wNC0yNFQwNjoyNjo1NC40NTZaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:53 GMT
 - request:
     method: get
@@ -6338,7 +6338,7 @@ http_interactions:
         Books and Special Collections - Sylvia Beach Collection"},"2453694":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"},"3520541":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":4410328,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6388,7 +6388,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101091596450","id":6924622,"location":"beac","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Rare
         Books and Special Collections - Sylvia Beach Collection"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6435,7 +6435,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2453694 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6485,7 +6485,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101062195498","id":4410328,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"ReCAP"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6536,7 +6536,7 @@ http_interactions:
       string: '{"label":"Sylvia Beach Collection","code":"beac","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"library":{"label":"Rare
         Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6589,7 +6589,7 @@ http_interactions:
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[{"label":"Rare
         Books and Special Collections","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6643,7 +6643,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJhdXRob3JfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcyIsIkVkaXRpb25zIGRlIE1pbnVpdCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkVkaXRpb25zIGRlIE1pbnVpdFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzXCJ9IiwiYXV0aG9yX3MiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcywgMTkwMi0xOTkzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiLCJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwiR3JlYXQgQnJpdGFpbiIsIlJlbGF0aW9ucyIsIkZyYW5jZSIsIkZyYW5jZSIsIlJlbGF0aW9ucyIsIkdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWluIiwiQ2l2aWxpemF0aW9uIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iLCJ0aXRsZV90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkgW3Bhcl0gQXJnb25uZSBbcHNldWQuXSJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQYXJpcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5NDMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk0MywicHViX2RhdGVfZW5kX3NvcnQiOjE5NDUsImNhdGFsb2dlZF90ZHQiOiIyMDA2LTEwLTA1VDE4OjE5OjIyWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNjEgcC4gMTcgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiNjEgcC4gMTcgY20uIl0sIm5vdGVzX2Rpc3BsYXkiOlsiXCJQcmVtaWXMgHJlIGXMgWRpdGlvbiBwdWJsaXF1ZS5cIiIsIkF1dGhvcidzIHBzZXVkLiwgQXJnb25uZSwgYXQgaGVhZCBvZiB0aXRsZS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF90IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF9mYWNldCI6WyJHcmVhdCBCcml0YWlu4oCUUmVsYXRpb25z4oCURnJhbmNlIiwiRnJhbmNl4oCUUmVsYXRpb25z4oCUR3JlYXQgQnJpdGFpbiIsIkdyZWF0IEJyaXRhaW7igJRDaXZpbGl6YXRpb27igJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiUmVsYXRlZCBuYW1lXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdfSIsImxjY25fZGlzcGxheSI6WyIgICA0NzAyODc5OSAgIl0sImxjY25fcyI6WyI0NzAyODc5OSJdLCJvY2xjX3MiOlsiNjY3ODY4MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NtMDY2Nzg2ODEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyNDUzNjkzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvblwiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiYmVhY1wiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEQTQ3LjEgLkQzNSAxOTQ1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIn0sXCIyNDUzNjk0XCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCIzMjI5LjMxOS4yOFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIzMjI5LjMxOS4yOFwifSxcIjM1MjA1NDFcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIjE0NTkuMjg3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjE0NTkuMjg3XCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSJdLCJsb2NhdGlvbiI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gU3lsdmlhIEJlYWNoIENvbGxlY3Rpb24iLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rcyIsIlJlQ0FQIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiYmVhYyIsImV4IiwicmNwcGEiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMuIEFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwidGltZXN0YW1wIjoiMjAxNy0wNC0yNFQwNjoyNjo1NC40NTZaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:54 GMT
 - request:
     method: get
@@ -6695,7 +6695,7 @@ http_interactions:
         Books and Special Collections - Sylvia Beach Collection"},"2453694":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"},"3520541":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":4410328,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6745,7 +6745,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101091596450","id":6924622,"location":"beac","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Rare
         Books and Special Collections - Sylvia Beach Collection"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6792,7 +6792,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2453694 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6842,7 +6842,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101062195498","id":4410328,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"ReCAP"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6893,7 +6893,7 @@ http_interactions:
       string: '{"label":"Sylvia Beach Collection","code":"beac","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"library":{"label":"Rare
         Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -6946,7 +6946,7 @@ http_interactions:
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[{"label":"Rare
         Books and Special Collections","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -7000,7 +7000,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJhdXRob3JfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcyIsIkVkaXRpb25zIGRlIE1pbnVpdCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkVkaXRpb25zIGRlIE1pbnVpdFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzXCJ9IiwiYXV0aG9yX3MiOlsiRGVidcyCLUJyaWRlbCwgSmFjcXVlcywgMTkwMi0xOTkzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiLCJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwiR3JlYXQgQnJpdGFpbiIsIlJlbGF0aW9ucyIsIkZyYW5jZSIsIkZyYW5jZSIsIlJlbGF0aW9ucyIsIkdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWluIiwiQ2l2aWxpemF0aW9uIiwiSGlzdG9yeSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iLCJ0aXRsZV90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkgW3Bhcl0gQXJnb25uZSBbcHNldWQuXSJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBhcmlzLCBFzIFkaXRpb25zIGRlIG1pbnVpdCwgMTk0MyBbaS5lLiAxOTQ1XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQYXJpcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5NDMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk0MywicHViX2RhdGVfZW5kX3NvcnQiOjE5NDUsImNhdGFsb2dlZF90ZHQiOiIyMDA2LTEwLTA1VDE4OjE5OjIyWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNjEgcC4gMTcgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiNjEgcC4gMTcgY20uIl0sIm5vdGVzX2Rpc3BsYXkiOlsiXCJQcmVtaWXMgHJlIGXMgWRpdGlvbiBwdWJsaXF1ZS5cIiIsIkF1dGhvcidzIHBzZXVkLiwgQXJnb25uZSwgYXQgaGVhZCBvZiB0aXRsZS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF90IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwic3ViamVjdF9mYWNldCI6WyJHcmVhdCBCcml0YWlu4oCUUmVsYXRpb25z4oCURnJhbmNlIiwiRnJhbmNl4oCUUmVsYXRpb25z4oCUR3JlYXQgQnJpdGFpbiIsIkdyZWF0IEJyaXRhaW7igJRDaXZpbGl6YXRpb27igJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiUmVsYXRlZCBuYW1lXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdfSIsImxjY25fZGlzcGxheSI6WyIgICA0NzAyODc5OSAgIl0sImxjY25fcyI6WyI0NzAyODc5OSJdLCJvY2xjX3MiOlsiNjY3ODY4MSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NtMDY2Nzg2ODEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyNDUzNjkzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvblwiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiYmVhY1wiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEQTQ3LjEgLkQzNSAxOTQ1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIn0sXCIyNDUzNjk0XCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCIzMjI5LjMxOS4yOFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIzMjI5LjMxOS4yOFwifSxcIjM1MjA1NDFcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIjE0NTkuMjg3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjE0NTkuMjg3XCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSJdLCJsb2NhdGlvbiI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gU3lsdmlhIEJlYWNoIENvbGxlY3Rpb24iLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rcyIsIlJlQ0FQIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiYmVhYyIsImV4IiwicmNwcGEiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMuIEFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiREE0Ny4xIC5EMzUgMTk0NSIsIjMyMjkuMzE5LjI4IiwiMTQ1OS4yODciXSwidGltZXN0YW1wIjoiMjAxNy0wNC0yNFQwNjoyNjo1NC40NTZaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:01:55 GMT
 - request:
     method: get
@@ -7052,7 +7052,7 @@ http_interactions:
         Books and Special Collections - Sylvia Beach Collection"},"2453694":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"},"3520541":{"more_items":false,"location":"rcppa","copy_number":1,"item_id":4410328,"on_reserve":"N","status":"Not
         Charged","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:02:00 GMT
 - request:
     method: get
@@ -7102,7 +7102,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101091596450","id":6924622,"location":"beac","copy_number":1,"item_sequence_number":1,"status":"On-Site","label":"Rare
         Books and Special Collections - Sylvia Beach Collection"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:02:00 GMT
 - request:
     method: get
@@ -7149,7 +7149,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 2453694 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:02:00 GMT
 - request:
     method: get
@@ -7199,7 +7199,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101062195498","id":4410328,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","label":"ReCAP"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:02:01 GMT
 - request:
     method: get
@@ -7250,7 +7250,7 @@ http_interactions:
       string: '{"label":"Sylvia Beach Collection","code":"beac","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"library":{"label":"Rare
         Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:02:01 GMT
 - request:
     method: get
@@ -7303,7 +7303,7 @@ http_interactions:
         Library - Rare Books and Special Collections","code":"rbsc"},"delivery_locations":[{"label":"Rare
         Books and Special Collections","address":"One Washington Rd. Princeton, NJ
         08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 27 Apr 2017 19:02:01 GMT
 - request:
     method: get
@@ -7387,7 +7387,7 @@ http_interactions:
         Library","Online"],"name_title_browse_s":["Gray, Brayton, 1940-. Abelian Properties
         of Anick Spaces"],"call_number_display":["QA3 .A57 no.1162","Electronic Resource"],"call_number_browse_s":["QA3
         .A57 no.1162","Electronic Resource"],"timestamp":"2017-04-22T07:14:25.173Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 01 Jun 2017 23:05:00 GMT
 - request:
     method: get
@@ -7438,7 +7438,7 @@ http_interactions:
       string: '{"9939337":{"more_items":false,"location":"sci","copy_number":0,"item_id":7572217,"on_reserve":"N","status":"Inaccessible","label":"Lewis
         Library"},"9956499":{"more_items":false,"location":"elf1","status":"Online","label":"Online
         - *ONLINE*"}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 01 Jun 2017 23:05:01 GMT
 - request:
     method: get
@@ -7488,7 +7488,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101097688129","id":7572217,"location":"sci","copy_number":0,"item_sequence_number":1,"status":"Inaccessible","on_reserve":"N","label":"Lewis
         Library"}]'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 01 Jun 2017 23:05:02 GMT
 - request:
     method: get
@@ -7537,7 +7537,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"label":"*ONLINE*","code":"elf1","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 01 Jun 2017 23:05:03 GMT
 - request:
     method: get
@@ -7591,7 +7591,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMjQ3ODA2IiwiYXV0aG9yX2Rpc3BsYXkiOlsiRGluY8ynYXNsYW4sIE0uIEJhaGFkxLFyaGFuIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhblwifSIsImF1dGhvcl9zIjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiRGluY8ynYXNsYW4sIE0uIEJhaGFkxLFyaGFuIiwiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyBCaXIgVHXMiHJrIG1pbGxpeWV0Y8ynaXNpbmluIG1pdG9sb2ppIGRlZnRlcmluZGVuIC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyBCaXIgVHXMiHJrIG1pbGxpeWV0Y8ynaXNpbmluIG1pdG9sb2ppIGRlZnRlcmluZGVuIC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIiwidGl0bGVfdCI6WyJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IEJpciBUdcyIcmsgbWlsbGl5ZXRjzKdpc2luaW4gbWl0b2xvamkgZGVmdGVyaW5kZW4gLyBNLiBCYWhhZMSxcmhhbiBEaW5jzKdhc2xhbi4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IEJpciBUdcyIcmsgbWlsbGl5ZXRjzKdpc2luaW4gbWl0b2xvamkgZGVmdGVyaW5kZW4gLyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyBCaXIgVHXMiHJrIG1pbGxpeWV0Y8ynaXNpbmluIG1pdG9sb2ppIGRlZnRlcmluZGVuIC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiSXN0YW5idWwgOiBBeWdhbiBZYXnEsW5jxLFsxLFrLCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9zIjpbIklzdGFuYnVsIDogQXlnYW4gWWF5xLFuY8SxbMSxaywgMjAxNy4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiSXN0YW5idWw6IEF5Z2FuIFlhecSxbmPEsWzEsWsiXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE3Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTcsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTA2LTA1VDE2OjA0OjQwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTY5IHAuIl0sImRlc2NyaXB0aW9uX3QiOlsiMTY5IHAuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIlR1cmtpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbInR1ciJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NjA1OTcwNzI0NCJdLCJpc2JuX3MiOlsiOTc4NjA1OTcwNzI0NCJdLCJpc2JuX3QiOlsiOTc4NjA1OTcwNzI0NCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4NjA1OTcwNzI0NCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjEwMDI4MTAyXCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiRGluY8ynYXNsYW4sIE0uIEJhaGFkxLFyaGFuLiBLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIl0sInRpbWVzdGFtcCI6IjIwMTctMDYtMDZUMDQ6NDQ6MDAuNTEyWiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Wed, 21 Jun 2017 18:32:52 GMT
 - request:
     method: get
@@ -7641,7 +7641,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"10028102":{"more_items":false,"location":"rcppa","copy_number":0,"item_id":7626545,"on_reserve":"N","status":"In
         Process","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 21 Jun 2017 18:32:52 GMT
 - request:
     method: get
@@ -7691,7 +7691,7 @@ http_interactions:
       encoding: UTF-8
       string: '[{"barcode":"32101101305488","id":7626545,"location":"rcppa","copy_number":0,"item_sequence_number":1,"status":"In
         Process","on_reserve":"N","label":"ReCAP"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 21 Jun 2017 18:32:52 GMT
 - request:
     method: get
@@ -7758,7 +7758,7 @@ http_interactions:
         p. HC."],"description_t":["343 p. HC."],"language_code_s":["und"],"holdings_1display":"{\"9929080\":{\"location\":\"ReCAP\",\"library\":\"ReCAP\",\"location_code\":\"rcppa\"}}","location_code_s":["rcppa"],"location":["ReCAP"],"location_display":["ReCAP"],"advanced_location_s":["rcppa","ReCAP"],"name_title_browse_s":["Jab
         al-Khayr, Sa''id. Abhath fi al-tasawwuf wa al-turuq al-sufiyah: al-zawayah
         wa al-marja''iyah al-diniyah.."],"timestamp":"2017-09-24T05:26:53.165Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Tue, 17 Oct 2017 14:02:14 GMT
 - request:
     method: get
@@ -7807,7 +7807,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"9929080":{"more_items":false,"location":"rcppa","status":"On Shelf","label":"ReCAP"}}'
-    http_version: null
+    http_version: 
   recorded_at: Tue, 17 Oct 2017 14:02:14 GMT
 - request:
     method: get
@@ -7854,7 +7854,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 9929080 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Tue, 17 Oct 2017 14:02:15 GMT
 - request:
     method: get
@@ -7908,7 +7908,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMwOCIsImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W10sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwidW5pZm9ybV90aXRsZV9zIjpbIkhhcmQgdGltZXMgKFdhc2hpbmd0b24sIEQuQy4pIl0sInRpdGxlX2Rpc3BsYXkiOiJIYXJkIHRpbWVzLiIsInRpdGxlX3QiOlsiSGFyZCB0aW1lcy4iXSwib3BlbnNlYXJjaF9kaXNwbGF5IjpbIkhhcmQgdGltZXMuIiwiUmFkaWNhbGlzbSIsIlVuaXRlZCBTdGF0ZXMiLCJQZXJpb2RpY2FscyJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkhhcmQgdGltZXMuIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJIYXJkIHRpbWVzLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIldhc2hpbmd0b24sIEQuQy4gOiBOZXcgV2Vla2x5IFByb2plY3QsIl0sInB1Yl9jcmVhdGVkX3MiOlsiV2FzaGluZ3RvbiwgRC5DLiA6IE5ldyBXZWVrbHkgUHJvamVjdCwiXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiV2FzaGluZ3RvbiwgRC5DLjogTmV3IFdlZWtseSBQcm9qZWN0Il0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk2OSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTY5LCJwdWJfZGF0ZV9lbmRfc29ydCI6MTk3MCwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyI2NiB2LiA7IDI4IGNtLiIsIk5vLiAyMiAoTWFyLiAxMC8xNyAxOTY5KS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKS4iXSwiZGVzY3JpcHRpb25fdCI6WyI2NiB2LiA7IDI4IGNtLiIsIk5vLiAyMiAoTWFyLiAxMC8xNyAxOTY5KS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKS4iXSwiZ2VvY29kZV9kaXNwbGF5IjpbIlVuaXRlZCBTdGF0ZXMiXSwiY29udGludWVzX2Rpc3BsYXkiOlsiTWF5ZGF5IChXYXNoaW5ndG9uLCBELiBDLikiXSwiYWJzb3JiZWRfYnlfZGlzcGxheSI6WyJSYW1wYXJ0cyAoQmVya2VsZXksIENhbGlmLikiXSwiZnJlcXVlbmN5X2Rpc3BsYXkiOlsiV2Vla2x5IChiaXdlZWtseSBkdXJpbmcgSnVseSBhbmQgQXVnLikiXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sInN1YmplY3RfZGlzcGxheSI6WyJSYWRpY2FsaXNt4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfdCI6WyJSYWRpY2FsaXNt4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiUmFkaWNhbGlzbeKAlFVuaXRlZCBTdGF0ZXPigJRQZXJpb2RpY2FscyJdLCJpc3NuX2Rpc3BsYXkiOlsiMDAyNS02MTQ1Il0sImlzc25fcyI6WyIwMDI1NjE0NSJdLCJvY2xjX3MiOlsiMjI0NDYxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiMDAyNTYxNDUiLCJvY20wMjI0NDYxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjM0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIFVzZSBpbiBGaXJlc3RvbmUgTWljcm9mb3JtcyBvbmx5XCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiTUlDUk9GSUxNIFMwMDUzNFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJNSUNST0ZJTE0gUzAwNTM0XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMjIgKE1hci4gMTAvMTcgMTk2OSktbm8uIDQ3IChPY3QuIDYsIDE5NjkpXCIsXCJOby4gMjItNDcgb24gcmVlbCB3aXRoIG5vLiAxLTIxIG9mIHRoZSBlYXJsaWVyIHRpdGxlLlwiXX0sXCIzNDJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIk92ZXJzaXplIEhYMSAuSDM3M3FcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSFgxIC5IMzczcVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDgyIChKdW5lIDI5LCAxOTcwKS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKVwiLFwiTEFDS1M6IG5vLiA4M1wiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBmIiwiZiJdLCJsb2NhdGlvbiI6WyJSZUNBUCIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBVc2UgaW4gRmlyZXN0b25lIE1pY3JvZm9ybXMgb25seSIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsicmNwcGYiLCJmIiwiUmVDQVAiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJPdmVyc2l6ZSBIWDEgLkgzNzNxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJIWDEgLkgzNzNxIl0sInRpbWVzdGFtcCI6IjIwMTctMDktMjNUMjA6MTM6MjcuODAxWiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Tue, 24 Oct 2017 19:41:32 GMT
 - request:
     method: get
@@ -7959,7 +7959,7 @@ http_interactions:
       string: '{"341":{"more_items":false,"location":"rcppf","status":"On Shelf","label":"ReCAP
         - Use in Firestone Microforms only"},"342":{"more_items":false,"location":"f","status":"On
         Shelf","label":"Firestone Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Tue, 24 Oct 2017 19:41:32 GMT
 - request:
     method: get
@@ -8006,7 +8006,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 341 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Tue, 24 Oct 2017 19:41:33 GMT
 - request:
     method: get
@@ -8053,7 +8053,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 342 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Tue, 24 Oct 2017 19:41:33 GMT
 - request:
     method: get
@@ -8109,7 +8109,7 @@ http_interactions:
         Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
         Services HMT","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"ReCAP
         ILL","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false}]}'
-    http_version: null
+    http_version: 
   recorded_at: Tue, 24 Oct 2017 19:41:33 GMT
 - request:
     method: get
@@ -8163,7 +8163,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMzNjUyNSIsImF1dGhvcl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJTcGllZ2VsbWFuLCBBcnQiLCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVycyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNwaWVnZWxtYW4sIEFydFwifSIsImF1dGhvcl9zIjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJTcGllZ2VsbWFuLCBBcnQiLCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVycyIsIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiIsIlNwaWVnZWxtYW4sIFZsYWRlayIsIkNvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUpIiwiUG9sYW5kIiwiQmlvZ3JhcGh5IiwiQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9ycyIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnQiLCJDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3JzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSIsIkNvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiIsInRpdGxlX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIk5ldyBZb3JrIDogUGFudGhlb24gQm9va3MsIGMxOTg2LiJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogUGFudGhlb24gQm9va3MsIGMxOTg2LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogUGFudGhlb24gQm9va3MiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTg2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5ODYsImNhdGFsb2dlZF90ZHQiOiIyMDAwLTA2LTEzVDA0OjAwOjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjE1OSBwLiA6IGlsbC4gOyAyMyBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgVmxhZGVr4oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0LCBKZXdpc2ggKDE5MzktMTk0NSnigJRQb2xhbmTigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIlNwaWVnZWxtYW4sIEFydOKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkNoaWxkcmVuIG9mIEhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIl0sInN1YmplY3RfdCI6WyJTcGllZ2VsbWFuLCBWbGFkZWvigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3QsIEpld2lzaCAoMTkzOS0xOTQ1KeKAlFBvbGFuZOKAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiU3BpZWdlbG1hbiwgQXJ04oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiQ2hpbGRyZW4gb2YgSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiXSwic3ViamVjdF9mYWNldCI6WyJTcGllZ2VsbWFuLCBWbGFkZWvigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3QsIEpld2lzaCAoMTkzOS0xOTQ1KeKAlFBvbGFuZOKAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiU3BpZWdlbG1hbiwgQXJ04oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiQ2hpbGRyZW4gb2YgSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVyc1wiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDM5NDc0NzIzMiA6Il0sImxjY25fZGlzcGxheSI6WyIgICA4NjA0MjY0MiAiXSwibGNjbl9zIjpbIjg2MDQyNjQyIl0sImlzYm5fcyI6WyI5NzgwMzk0NzQ3MjMxIl0sImlzYm5fdCI6WyI5NzgwMzk0NzQ3MjMxIl0sIm9jbGNfcyI6WyIxMzUyNDMxNCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDM5NDc0NzIzMSIsIm9jbTEzNTI0MzE0Il0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiMzY3ODgyXCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJEODEwLko0IFM2NDMgMTk4NlwifSxcIjM2Nzg4M1wiOntcImxvY2F0aW9uXCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rc1wiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiZXhcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtV1wiLFwibG9jYXRpb25faGFzXCI6W1wiUHJpbmNldG9uIGNvcHkgMVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbImYiLCJleCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiZiIsImV4IiwiRmlyZXN0b25lIExpYnJhcnkiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiU3BpZWdlbG1hbiwgQXJ0LiBNYXVzIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRDgxMC5KNCBTNjQzIDE5ODYiLCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRDgxMC5KNCBTNjQzIDE5ODYiLCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVciXSwidGltZXN0YW1wIjoiMjAxNy0xMC0wNFQwNDo0MjoxOS40NDhaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:53 GMT
 - request:
     method: get
@@ -8215,7 +8215,7 @@ http_interactions:
         Trauma, Accountability","course_number":"ANT 432","section_id":0,"instructor_first_name":"John","instructor_last_name":"Borneman"}],"copy_number":1,"item_id":381096,"on_reserve":"Y","status":"Not
         Charged","label":"Firestone Library - Circulation Desk (3 Hour Reserve)"},"367883":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:54 GMT
 - request:
     method: get
@@ -8266,7 +8266,7 @@ http_interactions:
       string: '[{"barcode":"32101011317193","id":381096,"location":"f","temp_loc":"resc","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","on_reserve":"Y","label":"Firestone Library - Circulation Desk (3
         Hour Reserve)"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:55 GMT
 - request:
     method: get
@@ -8313,7 +8313,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 367883 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:55 GMT
 - request:
     method: get
@@ -8364,7 +8364,7 @@ http_interactions:
       string: '{"label":"Circulation Desk (3 Hour Reserve)","code":"resc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Firestone
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:56 GMT
 - request:
     method: get
@@ -8418,7 +8418,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMzNjUyNSIsImF1dGhvcl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJTcGllZ2VsbWFuLCBBcnQiLCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVycyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNwaWVnZWxtYW4sIEFydFwifSIsImF1dGhvcl9zIjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJTcGllZ2VsbWFuLCBBcnQiLCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVycyIsIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiIsIlNwaWVnZWxtYW4sIFZsYWRlayIsIkNvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUpIiwiUG9sYW5kIiwiQmlvZ3JhcGh5IiwiQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9ycyIsIlVuaXRlZCBTdGF0ZXMiLCJCaW9ncmFwaHkiLCJDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnQiLCJDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3JzIiwiVW5pdGVkIFN0YXRlcyIsIkJpb2dyYXBoeSIsIkNvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Ik1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiIsInRpdGxlX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIk5ldyBZb3JrIDogUGFudGhlb24gQm9va3MsIGMxOTg2LiJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogUGFudGhlb24gQm9va3MsIGMxOTg2LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogUGFudGhlb24gQm9va3MiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTg2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5ODYsImNhdGFsb2dlZF90ZHQiOiIyMDAwLTA2LTEzVDA0OjAwOjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjE1OSBwLiA6IGlsbC4gOyAyMyBjbS4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgVmxhZGVr4oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0LCBKZXdpc2ggKDE5MzktMTk0NSnigJRQb2xhbmTigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIlNwaWVnZWxtYW4sIEFydOKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkNoaWxkcmVuIG9mIEhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIl0sInN1YmplY3RfdCI6WyJTcGllZ2VsbWFuLCBWbGFkZWvigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3QsIEpld2lzaCAoMTkzOS0xOTQ1KeKAlFBvbGFuZOKAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiU3BpZWdlbG1hbiwgQXJ04oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiQ2hpbGRyZW4gb2YgSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiXSwic3ViamVjdF9mYWNldCI6WyJTcGllZ2VsbWFuLCBWbGFkZWvigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJIb2xvY2F1c3QsIEpld2lzaCAoMTkzOS0xOTQ1KeKAlFBvbGFuZOKAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCBzdXJ2aXZvcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiU3BpZWdlbG1hbiwgQXJ04oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiQ2hpbGRyZW4gb2YgSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJMZW9uYXJkIEwuIE1pbGJlcmcgQ29sbGVjdGlvbiBvZiBKZXdpc2ggQW1lcmljYW4gV3JpdGVyc1wiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDM5NDc0NzIzMiA6Il0sImxjY25fZGlzcGxheSI6WyIgICA4NjA0MjY0MiAiXSwibGNjbl9zIjpbIjg2MDQyNjQyIl0sImlzYm5fcyI6WyI5NzgwMzk0NzQ3MjMxIl0sImlzYm5fdCI6WyI5NzgwMzk0NzQ3MjMxIl0sIm9jbGNfcyI6WyIxMzUyNDMxNCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDM5NDc0NzIzMSIsIm9jbTEzNTI0MzE0Il0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiMzY3ODgyXCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJEODEwLko0IFM2NDMgMTk4NlwifSxcIjM2Nzg4M1wiOntcImxvY2F0aW9uXCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gUmFyZSBCb29rc1wiLFwibGlicmFyeVwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiZXhcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtV1wiLFwibG9jYXRpb25faGFzXCI6W1wiUHJpbmNldG9uIGNvcHkgMVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbImYiLCJleCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiZiIsImV4IiwiRmlyZXN0b25lIExpYnJhcnkiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiU3BpZWdlbG1hbiwgQXJ0LiBNYXVzIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiRDgxMC5KNCBTNjQzIDE5ODYiLCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRDgxMC5KNCBTNjQzIDE5ODYiLCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVciXSwidGltZXN0YW1wIjoiMjAxNy0xMC0wNFQwNDo0MjoxOS40NDhaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:56 GMT
 - request:
     method: get
@@ -8470,7 +8470,7 @@ http_interactions:
         Trauma, Accountability","course_number":"ANT 432","section_id":0,"instructor_first_name":"John","instructor_last_name":"Borneman"}],"copy_number":1,"item_id":381096,"on_reserve":"Y","status":"Not
         Charged","label":"Firestone Library - Circulation Desk (3 Hour Reserve)"},"367883":{"more_items":false,"location":"ex","status":"On-Site","label":"Rare
         Books and Special Collections - Rare Books"}}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:57 GMT
 - request:
     method: get
@@ -8521,7 +8521,7 @@ http_interactions:
       string: '[{"barcode":"32101011317193","id":381096,"location":"f","temp_loc":"resc","copy_number":1,"item_sequence_number":1,"status":"Not
         Charged","on_reserve":"Y","label":"Firestone Library - Circulation Desk (3
         Hour Reserve)"}]'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:57 GMT
 - request:
     method: get
@@ -8568,7 +8568,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'Record: 367883 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:58 GMT
 - request:
     method: get
@@ -8619,7 +8619,7 @@ http_interactions:
       string: '{"label":"Circulation Desk (3 Hour Reserve)","code":"resc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Firestone
         Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
         Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Wed, 08 Nov 2017 23:29:58 GMT
 - request:
     method: get
@@ -8673,7 +8673,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjQ4ODg0OTQiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlNhbmJvcm4gTWFwIENvbXBhbnkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FuYm9ybiBNYXAgQ29tcGFueSIsIkxpYnJhcnkgb2YgQ29uZ3Jlc3MiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJMaWJyYXJ5IG9mIENvbmdyZXNzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNhbmJvcm4gTWFwIENvbXBhbnlcIn0iLCJhdXRob3JfcyI6WyJTYW5ib3JuIE1hcCBDb21wYW55IiwiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJTYW5ib3JuIE1hcCBDb21wYW55IiwiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uIiwiRnJlZWhvbGQsIE4uIEouIFttYXBdLiIsIlJlYWwgcHJvcGVydHkiLCJOZXcgSmVyc2V5IiwiRnJlZWhvbGQiLCJGcmVlaG9sZCAoTi5KLikiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJGcmVlaG9sZCwgTi4gSi4gW21hcF0uIiwidGl0bGVfdCI6WyJGcmVlaG9sZCwgTi4gSi4gW21hcF0uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRnJlZWhvbGQsIE4uIEouIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJGcmVlaG9sZCwgTi4gSi4gW21hcF0uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiW05ldyBZb3JrOiBTYW5ib3JuIE1hcCBcdTAwMjYgUHVibGlzaGluZyBDby4sIExpbWl0ZWQsIDE4ODVdIl0sInB1Yl9jcmVhdGVkX3MiOlsiW05ldyBZb3JrOiBTYW5ib3JuIE1hcCBcdTAwMjYgUHVibGlzaGluZyBDby4sIExpbWl0ZWQsIDE4ODVdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBTYW5ib3JuIE1hcCBcdTAwMjYgUHVibGlzaGluZyBDby4sIExpbWl0ZWQiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxODg1Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE4ODUsImNhdGFsb2dlZF90ZHQiOiIyMDA2LTEwLTE4VDE4OjU5OjAwWiIsImZvcm1hdCI6WyJNYXAiXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwczovL3B1bHNlYXJjaC5wcmluY2V0b24uZWR1L2NhdGFsb2cvNDg4ODQ5NCN2aWV3XCI6W1wiYXJrcy5wcmluY2V0b24uZWR1XCJdLFwiaWlpZl9tYW5pZmVzdF9wYXRoc1wiOntcImh0dHA6Ly9hcmtzLnByaW5jZXRvbi5lZHUvYXJrOi84ODQzNS9uNTgzeHg5MXhcIjpcImh0dHBzOi8vZmlnZ3kucHJpbmNldG9uLmVkdS9jb25jZXJuL21hcF9zZXRzL3BjcjU2cW0wOG0vbWFuaWZlc3RcIn19IiwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJTY2FsZSBbY2EuIDE6NjAwXS4gNTAgZnQuIHRvIGFuIGluY2guIiwiMSBtYXAgb24gMyBzaGVldHMgOiBjb2wuIDsgZWFjaCA2NCB4IDU0IGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIlNjYWxlIFtjYS4gMTo2MDBdLiA1MCBmdC4gdG8gYW4gaW5jaC4iLCIxIG1hcCBvbiAzIHNoZWV0cyA6IGNvbC4gOyBlYWNoIDY0IHggNTQgY20uIl0sImdlb2NvZGVfZGlzcGxheSI6WyJOZXcgSmVyc2V5Il0sInNjYWxlX2Rpc3BsYXkiOlsiU2NhbGUgW2NhLiAxOjYwMF0uIDUwIGZ0LiB0byBhbiBpbmNoLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiSmFuLiAxODg1LlwiIiwiSW5jbHVkZXMga2V5IGFuZCB0ZXh0LiIsIk5vcnRoIG9yaWVudGVkIHRvd2FyZCB1cHBlciBsZWZ0LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwicHJvdmVuYW5jZV9kaXNwbGF5IjpbIkhpc3RvcmljIE1hcHMgY29weSBoYXMgc3RhbXAgb2YgTWFwIERpdmlzaW9uLCBMaWJyYXJ5IG9mIENvbmdyZXNzLCBkYXRlZCBNYXIuIDYsIDE4ODUuIl0sInN1YmplY3RfZGlzcGxheSI6WyJSZWFsIHByb3BlcnR54oCUTmV3IEplcnNleeKAlEZyZWVob2xk4oCUTWFwcyIsIkZyZWVob2xkIChOLkouKeKAlE1hcHMiXSwic3ViamVjdF90IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmlyZSBpbnN1cmFuY2UgbWFwcyBOZXcgSmVyc2V5IEZyZWVob2xkIDE4ODUuIiwiTWFwcyBOZXcgSmVyc2V5IEZyZWVob2xkIDE4ODUuIl0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiRm9ybWVyIG93bmVyXCI6W1wiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uXCJdfSIsImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiNTA4NTQ5M1wiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIEhpc3RvcmljIE1hcHMgT2ZmLVNpdGUgU3RvcmFnZVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHhwXCIsXCJjYWxsX251bWJlclwiOlwiSE1DMDQgKEZyZWVob2xkKVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJITUMwNCAoRnJlZWhvbGQpXCJ9LFwiNzQyNjI3MlwiOntcImxvY2F0aW9uXCI6XCJPbmxpbmUgLSAqT05MSU5FKlwiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYxXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJyY3B4cCIsImVsZjEiXSwibG9jYXRpb24iOlsiUmVDQVAiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBIaXN0b3JpYyBNYXBzIE9mZi1TaXRlIFN0b3JhZ2UiLCJPbmxpbmUgLSAqT05MSU5FKiJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHhwIiwiZWxmMSIsIlJlQ0FQIiwiT25saW5lIiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlNhbmJvcm4gTWFwIENvbXBhbnkuIEZyZWVob2xkLCBOLiBKLiJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhNQzA0IChGcmVlaG9sZCkiLCJFbGVjdHJvbmljIFJlc291cmNlIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkhNQzA0IChGcmVlaG9sZCkiLCJFbGVjdHJvbmljIFJlc291cmNlIl0sInRpbWVzdGFtcCI6IjIwMTgtMDEtMjRUMjE6MTE6MDcuNzA4WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Sat, 27 Jan 2018 21:24:21 GMT
 - request:
     method: get
@@ -8726,7 +8726,7 @@ http_interactions:
       string: '{"5085493":{"more_items":true,"location":"rcpxp","copy_number":1,"item_id":4420352,"on_reserve":"N","status":"On-Site","label":"ReCAP
         - Historic Maps Off-Site Storage"},"7426272":{"more_items":false,"location":"elf1","status":"Online","label":"Online
         - *ONLINE*"}}'
-    http_version: null
+    http_version: 
   recorded_at: Sat, 27 Jan 2018 21:24:22 GMT
 - request:
     method: get
@@ -8780,7 +8780,7 @@ http_interactions:
         3","enum_display":"Sheet 3","label":"ReCAP - Historic Maps Off-Site Storage"},{"barcode":"32101054078603","id":4420354,"location":"rcpxp","copy_number":1,"item_sequence_number":2,"status":"On-Site","on_reserve":"N","enum":"Sheet
         2","enum_display":"Sheet 2","label":"ReCAP - Historic Maps Off-Site Storage"},{"barcode":"32101054078595","id":4420352,"location":"rcpxp","copy_number":1,"item_sequence_number":1,"status":"On-Site","on_reserve":"N","enum":"Sheet
         1","enum_display":"Sheet 1","label":"ReCAP - Historic Maps Off-Site Storage"}]'
-    http_version: null
+    http_version: 
   recorded_at: Sat, 27 Jan 2018 21:24:22 GMT
 - request:
     method: get
@@ -8833,7 +8833,7 @@ http_interactions:
       string: '{"label":"Historic Maps Off-Site Storage","code":"rcpxp","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare
         Books and Special Collections","code":"rare","order":2},"hours_location":null,"delivery_locations":[{"label":"Firestone,
         Historic Maps","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":false}]}'
-    http_version: null
+    http_version: 
   recorded_at: Sat, 27 Jan 2018 21:24:22 GMT
 - request:
     method: get
@@ -8885,7 +8885,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"3334792":{"more_items":false,"location":"p","status":"On Shelf","label":"Forrestal
         Annex - Princeton Collection"}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 17 May 2018 00:07:44 GMT
 - request:
     method: get
@@ -8934,7 +8934,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: 'Record: 3334792 not found.'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 17 May 2018 00:07:44 GMT
 - request:
     method: get
@@ -8986,7 +8986,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"label":"Princeton Collection","code":"p","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Forrestal
         Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 17 May 2018 00:07:44 GMT
 - request:
     method: get
@@ -9040,7 +9040,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb3RvzIQsIE1laXNlaSwgMTkzMi0xOTk5Iiwi5b6M6Jek5piO55SfLCAxOTMyLTE5OTkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR290b8yELCBNZWlzZWkiLCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wi5b6M6Jek5piO55SfXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1XCIsXCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrlcIl0sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvzIQsIE1laXNlaVwifSIsImF1dGhvcl9zIjpbIkdvdG/MhCwgTWVpc2VpLCAxOTMyLTE5OTkiLCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1Iiwi5b6M6Jek5piO55SfLCAxOTMyLTE5OTkiLCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrkiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiSW50ZXJ2aWV3ZWUiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRhIGt1amlzaGlraSBHb3RvzIQgTWVpc2VpLiBaYWRhbiBoZW4gLyBHb3RvzIQgTWVpc2VpIDsgQcyEcmnMhCBCYcyEZG8gQnVra3VzdSBoZW4uIiwidGl0bGVfdmVybl9kaXNwbGF5Ijoi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744KkLiDluqfoq4fnr4cgLyDlvozol6TmmI7nlJ8gOyDjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrnnt6guIiwidGl0bGVfdCI6WyJBbWlkYSBrdWppc2hpa2kgR290b8yEIE1laXNlaS4gWmFkYW4gaGVuIC8gR290b8yEIE1laXNlaSA7IEHMhHJpzIQgQmHMhGRvIEJ1a2t1c3UgaGVuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkFtaWRhIGt1amlzaGlraSBHb3RvzIQgTWVpc2VpIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744KkLiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW1pZGEga3VqaXNoaWtpIEdvdG/MhCBNZWlzZWkuIFphZGFuIGhlbiAvIEdvdG/MhCBNZWlzZWkgOyBBzIRyacyEIEJhzIRkbyBCdWtrdXN1IGhlbi4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqQuIOW6p+irh+evhyAvIOW+jOiXpOaYjueUnyA7IOOCouODvOODquODvOODkOODvOODieODu+ODluODg+OCr+OCuee3qC4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIkRhaSAxLWhhbi4iLCLnrKwx54mILiJdLCJwdWJfY3JlYXRlZF92ZXJuX2Rpc3BsYXkiOlsi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlRvzIRreW/MhCA6IFRzdWthZGFtYSBTaG9ib8yELCAyMDE3LiIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNy4iXSwicHViX2NyZWF0ZWRfcyI6WyJUb8yEa3lvzIQgOiBUc3VrYWRhbWEgU2hvYm/MhCwgMjAxNy4iLCLmnbHkuqwgOiDjgaTjgYvjgaDjgb7mm7jmiL8sIDIwMTcuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRvzIRreW/MhDogVHN1a2FkYW1hIFNob2JvzIQiLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywicHViX2RhdGVfZW5kX3NvcnQiOjIwMTcsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTA4LTI0VDE3OjI2OjM3WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNDQ2IHBhZ2VzIDsgMjIgY20iXSwiZGVzY3JpcHRpb25fdCI6WyI0NDYgcGFnZXMgOyAyMiBjbSJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI0NDYgcGFnZXMiXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiamEiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJFZGl0b3JcIjpbXCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1XCIsXCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrlcIl19Iiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyLluqfoq4fnr4ciXSwiYWx0X3RpdGxlXzI0Nl9kaXNwbGF5IjpbIuW6p+irh+evhyJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCIsIjQ5MDg2MjQwMTEiXSwiaXNibl9zIjpbIjk3ODQ5MDg2MjQwMTgiXSwiaXNibl90IjpbIjk3ODQ5MDg2MjQwMTgiXSwib2NsY19zIjpbIjk4ODI1MzIwMyJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTg4MjUzMjAzIiwiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIlBMODUxLk84MyBBNjIyIDIwMTdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiUEw4NTEuTzgzIEE2MjIgMjAxN1wifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb3RvzIQsIE1laXNlaSwgMTkzMi0xOTk5LiBBbWlkYSBrdWppc2hpa2kgR290b8yEIE1laXNlaSIsIuW+jOiXpOaYjueUnywgMTkzMi0xOTk5LiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqQuIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUEw4NTEuTzgzIEE2MjIgMjAxNyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJQTDg1MS5PODMgQTYyMiAyMDE3Il0sIl92ZXJzaW9uXyI6MTYxMjA0ODE0MTk2MTM5NjIyNCwidGltZXN0YW1wIjoiMjAxOC0wOS0xOVQxNDo1NTowOS43MDRaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:43 GMT
 - request:
     method: get
@@ -9094,7 +9094,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMwOCIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJ1bmlmb3JtX3RpdGxlX3MiOlsiSGFyZCB0aW1lcyAoV2FzaGluZ3RvbiwgRC5DLikiXSwidGl0bGVfZGlzcGxheSI6IkhhcmQgdGltZXMuIiwidGl0bGVfdCI6WyJIYXJkIHRpbWVzLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkhhcmQgdGltZXMiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkhhcmQgdGltZXMuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiV2FzaGluZ3RvbiwgRC5DLiA6IE5ldyBXZWVrbHkgUHJvamVjdCwiXSwicHViX2NyZWF0ZWRfcyI6WyJXYXNoaW5ndG9uLCBELkMuIDogTmV3IFdlZWtseSBQcm9qZWN0LCJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJXYXNoaW5ndG9uLCBELkMuOiBOZXcgV2Vla2x5IFByb2plY3QiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTY5Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NjksInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTcwLCJmb3JtYXQiOlsiSm91cm5hbCJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjY2IHYuIDsgMjggY20uIiwiTm8uIDIyIChNYXIuIDEwLzE3IDE5NjkpLW5vLiA4NyAoU2VwdC4gMTQsIDE5NzApLiJdLCJkZXNjcmlwdGlvbl90IjpbIjY2IHYuIDsgMjggY20uIiwiTm8uIDIyIChNYXIuIDEwLzE3IDE5NjkpLW5vLiA4NyAoU2VwdC4gMTQsIDE5NzApLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2NiB2LiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJjb250aW51ZXNfZGlzcGxheSI6WyJNYXlkYXkgKFdhc2hpbmd0b24sIEQuIEMuKSJdLCJhYnNvcmJlZF9ieV9kaXNwbGF5IjpbIlJhbXBhcnRzIChCZXJrZWxleSwgQ2FsaWYuKSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJXZWVrbHkgKGJpd2Vla2x5IGR1cmluZyBKdWx5IGFuZCBBdWcuKSJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJSYWRpY2FsaXNt4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiUmFkaWNhbGlzbeKAlFVuaXRlZCBTdGF0ZXPigJRQZXJpb2RpY2FscyJdLCJpc3NuX2Rpc3BsYXkiOlsiMDAyNS02MTQ1Il0sImlzc25fcyI6WyIwMDI1NjE0NSJdLCJvY2xjX3MiOlsiMjI0NDYxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiMDAyNTYxNDUiLCJvY20wMjI0NDYxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjM0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIFVzZSBpbiBGaXJlc3RvbmUgTWljcm9mb3JtcyBvbmx5XCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiTUlDUk9GSUxNIFMwMDUzNFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJNSUNST0ZJTE0gUzAwNTM0XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMjIgKE1hci4gMTAvMTcgMTk2OSktbm8uIDQ3IChPY3QuIDYsIDE5NjkpXCIsXCJOby4gMjItNDcgb24gcmVlbCB3aXRoIG5vLiAxLTIxIG9mIHRoZSBlYXJsaWVyIHRpdGxlLlwiXX0sXCIzNDJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIk92ZXJzaXplIEhYMSAuSDM3M3FcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSFgxIC5IMzczcVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDgyIChKdW5lIDI5LCAxOTcwKS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKVwiLFwiTEFDS1M6IG5vLiA4M1wiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBmIiwiZiJdLCJsb2NhdGlvbiI6WyJSZUNBUCIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBVc2UgaW4gRmlyZXN0b25lIE1pY3JvZm9ybXMgb25seSIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsicmNwcGYiLCJmIiwiUmVDQVAiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJPdmVyc2l6ZSBIWDEgLkgzNzNxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJIWDEgLkgzNzNxIl0sIl92ZXJzaW9uXyI6MTYxMTU4ODkzOTA5ODg4MjA0OCwidGltZXN0YW1wIjoiMjAxOC0wOS0xNFQxMzoxNjoxOS43NzBaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:44 GMT
 - request:
     method: get
@@ -9148,7 +9148,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk0OTMzMTgiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlNhbWjMo2HMhG4sIE5hamHMhHQiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjCJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJTYW1ozKNhzIRuLCBOYWphzIR0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wi2LPZhdit2KfZhtiMINmG2KzYp9ip2IxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU2FtaMyjYcyEbiwgTmFqYcyEdFwifSIsImF1dGhvcl9zIjpbIlNhbWjMo2HMhG4sIE5hamHMhHQiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjCJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Isq7QXdhzIR0zKNpZiBtYWRmdcyEbmFoIC8gTmFqYcyEdCBhbC1TYW1ozKNhzIRuLiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6Iti52YjYp9i32YEg2YXYr9mB2YjZhtipIC8g2YbYrNin2Kkg2KfZhNiz2YXYrdin2YYuIiwidGl0bGVfdCI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIE5hamHMhHQgYWwtU2FtaMyjYcyEbi4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCIsIti52YjYp9i32YEg2YXYr9mB2YjZhtipIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIE5hamHMhHQgYWwtU2FtaMyjYcyEbi4iLCLYudmI2KfYt9mBINmF2K/ZgdmI2YbYqSAvINmG2KzYp9ipINin2YTYs9mF2K3Yp9mGLiJdLCJwdWJfY3JlYXRlZF92ZXJuX2Rpc3BsYXkiOlsi2KfZhNmC2KfZh9ix2KkgOiDYr9in2LEg2KfZhNmD2KrYp9ioINin2YTYrdiv2YrYq9iMIDIwMTYuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiYWwtUWHMhGhpcmFoIDogRGHMhHIgYWwtS2l0YcyEYiBhbC1IzKNhZGnMhHRoLCAyMDE2LiIsItin2YTZgtin2YfYsdipIDog2K/Yp9ixINin2YTZg9iq2KfYqCDYp9mE2K3Yr9mK2KvYjCAyMDE2LiJdLCJwdWJfY3JlYXRlZF9zIjpbImFsLVFhzIRoaXJhaCA6IERhzIRyIGFsLUtpdGHMhGIgYWwtSMyjYWRpzIR0aCwgMjAxNi4iLCLYp9mE2YLYp9mH2LHYqSA6INiv2KfYsSDYp9mE2YPYqtin2Kgg2KfZhNit2K/Zitir2IwgMjAxNi4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiYWwtUWHMhGhpcmFoOiBEYcyEciBhbC1LaXRhzIRiIGFsLUjMo2FkacyEdGgiLCLYp9mE2YLYp9mH2LHYqTog2K/Yp9ixINin2YTZg9iq2KfYqCDYp9mE2K3Yr9mK2KvYjCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDEtMTlUMTM6NDk6MzdaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIyMzAgcGFnZXMgOyAyMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjIzMCBwYWdlcyA7IDIwIGNtIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjIzMCBwYWdlcyJdLCJub3Rlc19kaXNwbGF5IjpbIlNob3J0IHN0b3JpZXMuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJhciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU2hvcnQgc3RvcmllcywgQXJhYmlj4oCUMjFzdCBjZW50dXJ5Il0sInN1YmplY3RfZmFjZXQiOlsiU2hvcnQgc3RvcmllcywgQXJhYmlj4oCUMjFzdCBjZW50dXJ5Il0sImlzYm5fZGlzcGxheSI6WyI5Nzg5NzczNTA2ODI3IiwiOTc3MzUwNjgyNyJdLCJpc2JuX3MiOlsiOTc4OTc3MzUwNjgyNyJdLCJpc2JuX3QiOlsiOTc4OTc3MzUwNjgyNyJdLCJvY2xjX3MiOlsiOTM1MjE5MzEwIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY245MzUyMTkzMTAiLCI5Nzg5NzczNTA2ODI3Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjIxc3QgY2VudHVyeSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjkzNTE5NjdcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIlBKNzk2Mi5BNTQ5NSBBOTUgMjAxNlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJQSjc5NjIuQTU0OTUgQTk1IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiU2FtaMyjYcyEbiwgTmFqYcyEdC4gyrtBd2HMhHTMo2lmIG1hZGZ1zIRuYWgiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjC4g2LnZiNin2LfZgSDZhdiv2YHZiNmG2KkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJQSjc5NjIuQTU0OTUgQTk1IDIwMTYiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiUEo3OTYyLkE1NDk1IEE5NSAyMDE2Il0sIl92ZXJzaW9uXyI6MTYxMTYyMzYzMTU0MDk3NzY2NCwidGltZXN0YW1wIjoiMjAxOC0wOS0xNFQyMjoyNzo0NC45MjFaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:46 GMT
 - request:
     method: get
@@ -9202,7 +9202,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMjQ3ODA2IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJEaW5jzKdhc2xhbiwgTS4gQmFoYWTEsXJoYW4sIDE5OTAtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhblwifSIsImF1dGhvcl9zIjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiwgMTk5MC0iXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIiwidGl0bGVfdCI6WyJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyAvIE0uIEJhaGFkxLFyaGFuIERpbmPMp2FzbGFuLiJdLCJlZGl0aW9uX2Rpc3BsYXkiOlsiMS4gYmFza8SxLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkthZMSxa2/MiHksIEnMh3N0YW5idWwgOiBBeWdhbiBZYXnEsW5jxLFsxLFrLCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9zIjpbIkthZMSxa2/MiHksIEnMh3N0YW5idWwgOiBBeWdhbiBZYXnEsW5jxLFsxLFrLCAyMDE3LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJLYWTEsWtvzIh5LCBJzIdzdGFuYnVsOiBBeWdhbiBZYXnEsW5jxLFsxLFrIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE3LCJjYXRhbG9nZWRfdGR0IjoiMjAxNy0wNi0wNVQxNjowNDo0MFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjE2OSBwYWdlcyA7IDIwIGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjE2OSBwYWdlcyA7IDIwIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNjkgcGFnZXMiXSwic2VyaWVzX2Rpc3BsYXkiOlsiQXlnYW4gWWF5xLFuY8SxbMSxayA7IG5vOiA0NSJdLCJub3Rlc19kaXNwbGF5IjpbIlwiQmlyIFR1zIhyayBtaWxsaXlldGPMp2lzaW5pbiBtaXRvbG9qaSBkZWZ0ZXJpbmRlbi5cIiJdLCJsYW5ndWFnZV9mYWNldCI6WyJUdXJraXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJ0dXIiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbInRyIl0sInN1YmplY3RfZGlzcGxheSI6WyJNeXRob2xvZ3kiXSwic3ViamVjdF9mYWNldCI6WyJNeXRob2xvZ3kiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODYwNTk3MDcyNDQiXSwiaXNibl9zIjpbIjk3ODYwNTk3MDcyNDQiXSwiaXNibl90IjpbIjk3ODYwNTk3MDcyNDQiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODYwNTk3MDcyNDQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIxMDAyODEwMlwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiQkwzMTIgLkQ1NSAyMDE3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkJMMzEyIC5ENTUgMjAxN1wifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEaW5jzKdhc2xhbiwgTS4gQmFoYWTEsXJoYW4sIDE5OTAtLiBLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiQkwzMTIgLkQ1NSAyMDE3Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkJMMzEyIC5ENTUgMjAxNyJdLCJfdmVyc2lvbl8iOjE2MTE2MjY1NDU3Mjg3MTY4MDAsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjM6MTQ6MDQuMjM5WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:48 GMT
 - request:
     method: get
@@ -9256,7 +9256,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMTQ0Njk4IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb2xmZXIsIEFkYW0iLCLXkteV15zXpNeoLCDXkNeT150iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiR29sZmVyLCBBZGFtXCIsXCJHb2xmZXIsIEFkYW1cIixcIkdvbGZlciwgQWRhbVwiLFwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlXCIsXCLXkteV15zXpNeoLCDXkNeT151cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiR29sZmVyLCBBZGFtXCJ9IiwiYXV0aG9yX3MiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIiwi15LXldec16TXqCwg15DXk9edIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIlBob3RvZ3JhcGhlciJdLCJ1bmlmb3JtX3RpdGxlX3MiOlsiUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwidGl0bGVfZGlzcGxheSI6IkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIiwidGl0bGVfdCI6WyJBIGhvdXNlIHdpdGhvdXQgYSByb29mIC8gQWRhbSBHb2xmZXIgOyB0cmFuc2xhdGlvbnM6IE1vc3RhZmEgT3VhamphbmkgKEFyYWJpYyksIEdhYnJpZWxhIFZhaW5zZW5jaGVyIChIZWJyZXcpLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIl0sImVkaXRpb25fZGlzcGxheSI6WyJGaXJzdCBlZGl0aW9uLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY3JlYXRlZF9zIjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJCcm9va2x5biwgTmV3IFlvcms6IEJvb2tseW4iXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTYsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTAzLTMwVDE4OjQ2OjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIDogaWxsdXN0cmF0aW9ucyAoY2hpZWZseSBjb2xvcikgOyAzMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjE2MSBwYWdlcyA6IGlsbHVzdHJhdGlvbnMgKGNoaWVmbHkgY29sb3IpIDsgMzAgY20iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJJc3JhZWwiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiU2hvcnRsaXN0ZWQgZm9yIHRoZSBQYXJpcy1QaG90by8gQXBlcnR1cmUgRmlyc3QgQm9vayBBd2FyZCwgJ0EgSG91c2UgV2l0aG91dCBhIFJvb2YnIGNvbnNpZGVycyB0aGUgb3ZlcmxhcHBpbmcgaGlzdG9yaWVzIG9mIHZpb2xlbmNlIGFuZCBkaXNwbGFjZW1lbnQgY29ubmVjdGluZyBFdXJvcGUsIElzcmFlbCBhbmQgUGFsZXN0aW5lLiBXaXRoIHBob3RvZ3JhcGhzLCBhcmNoaXZhbCBpbWFnZXJ5IGFuZCBvcmlnaW5hbCB0ZXh0cywgQnJvb2tseW4tYmFzZWQgYXJ0aXN0IEFkYW0gR29sZmVyIHdlYXZlcyB0b2dldGhlciBmaWN0aW9ucyBvZiBoaXMgZmFtaWx5IGhpc3Rvcnkgd2l0aCByZXByZXNlbnRhdGlvbnMgZnJvbSBJc3JhZWw/cyBmb3VuZGluZyBhbmQgb25nb2luZyBtaWxpdGFyeSBvY2N1cGF0aW9uLiBFdGhuaWMgYW5kIG5hdGlvbmFsIGlkZW50aXRpZXMgYXJlIHJ1cHR1cmVkIGFuZCByZWFzc2VtYmxlZCBhcyBoZSBpbnRlcnJvZ2F0ZXMgY29udHJhZGljdG9yeSBoaXN0b3JpZXMgYW5kIG5vdGlvbnMgb2Ygc2VsZmhvb2QsIGV4cGxvcmluZyBzdHJhbmRzIHRoYXQgY29ubmVjdCB0aGUgSmV3aXNoIERpYXNwb3JhIG91dCBvZiBFdXJvcGUgYW5kIGZvcmNlZCBtYXNzIG1pZ3JhdGlvbnMgZnJvbSBQYWxlc3RpbmUgZm9sbG93aW5nIFdvcmxkIFdhciBJSS4gR29sZmVyIHNpdHVhdGVzIHRoaXMgaW5xdWlyeSB0aHJvdWdoIHRoZSB0cmlhbmd1bGFyIHJlbGF0aW9uc2hpcCBiZXR3ZWVuIGhpcyBncmFuZGZhdGhlciAoYSBzdXJ2aXZvciBvZiBEYWNoYXUpLCBoaXMgZmF0aGVyICh3aG8gbGl2ZWQgb24gYSBraWJidXR6IGluIHRoZSBlYXJseSAxOTcwcykgYW5kIGhpbXNlbGYuIl0sIm5vdGVzX2Rpc3BsYXkiOlsiQ292ZXIgdGl0bGUuIiwiUHVibGlzaGVkIG9uIHRoZSBvY2Nhc2lvbiBvZiBhbiBleGhpYml0aW9uIGhlbGQgYXQgQm9va2x5biwgSnVseSAxMC1TZXB0ZW1iZXIgNSwgMjAxNS4iXSwibGFuZ3VhZ2VfZGlzcGxheSI6WyJUZXh0IGluIEVuZ2xpc2ggd2l0aCBIZWJyZXcgYW5kIEFyYWJpYyBhdCB0aGUgYm90dG9tIG9mIHRoZSBwYWdlcy4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCIsIkhlYnJldyIsIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIiwiaGViIiwiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiIsImhlIiwiYXIiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIkhvc3QgaW5zdGl0dXRpb25cIjpbXCJCb29rbHluIEFydGlzdHMgQWxsaWFuY2VcIl19IiwiY29udGFpbnNfMWRpc3BsYXkiOiJbW1wiR29sZmVyLCBBZGFtLlwiLFwiSG91c2Ugd2l0aG91dCBhIHJvb2YuXCJdLFtcIkdvbGZlciwgQWRhbS5cIixcIkhvdXNlIHdpdGhvdXQgYSByb29mLlwiLFwiSGVicmV3LlwiXSxbXCJHb2xmZXIsIEFkYW0uXCIsXCJIb3VzZSB3aXRob3V0IGEgcm9vZi5cIixcIkFyYWJpYy5cIl1dIiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyJCYXlpdCBiZWxpIGdhZyIsIteR15nXqiDXkdec15kg15LXkiJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiQmF5aXQgYmVsaSBnYWciLCLXkdeZ16og15HXnNeZINeS15IiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODA2OTI3MjY1MDEiLCIwNjkyNzI2NTAwIl0sImlzYm5fcyI6WyI5NzgwNjkyNzI2NTAxIl0sImlzYm5fdCI6WyI5NzgwNjkyNzI2NTAxIl0sIm9jbGNfcyI6WyI5ODE3NjY2NjAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjk4MTc2NjY2MCIsIjk3ODA2OTI3MjY1MDEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5OTMzODc4XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBqXCIsXCJjYWxsX251bWJlclwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBqIl0sImxvY2F0aW9uIjpbIlJlQ0FQIiwiTWFycXVhbmQgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBqIiwiUmVDQVAiLCJNYXJxdWFuZCBMaWJyYXJ5Il0sIm5hbWVfdW5pZm9ybV90aXRsZV8xZGlzcGxheSI6IltbXCJHb2xmZXIsIEFkYW0uXCIsXCJQaG90b2dyYXBocy5cIixcIlNlbGVjdGlvbnNcIl1dIiwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb2xmZXIsIEFkYW0uIEhvdXNlIHdpdGhvdXQgYSByb29mIiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gSGVicmV3IiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gQXJhYmljIiwiR29sZmVyLCBBZGFtLiBQaG90b2dyYXBocyIsIkdvbGZlciwgQWRhbS4gUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJfdmVyc2lvbl8iOjE2MTE2MjU2OTc5NTE4NzUwNzIsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjM6MDA6MzUuNzUzWiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:50 GMT
 - request:
     method: get
@@ -9310,7 +9310,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjQ4ODg0OTQiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlNhbmJvcm4gTWFwIENvbXBhbnkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FuYm9ybiBNYXAgQ29tcGFueSIsIkxpYnJhcnkgb2YgQ29uZ3Jlc3MiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJMaWJyYXJ5IG9mIENvbmdyZXNzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNhbmJvcm4gTWFwIENvbXBhbnlcIn0iLCJhdXRob3JfcyI6WyJTYW5ib3JuIE1hcCBDb21wYW55IiwiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiRnJlZWhvbGQsIE4uIEouIFttYXBdLiIsInRpdGxlX3QiOlsiRnJlZWhvbGQsIE4uIEouIFttYXBdLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZyZWVob2xkLCBOLiBKLiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRnJlZWhvbGQsIE4uIEouIFttYXBdLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIk5ldyBZb3JrIDogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkLCAxODg1LiJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkLCAxODg1LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTg4NSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxODg1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0xOFQxNzo1OTowMFoiLCJmb3JtYXQiOlsiTWFwIl0sImVsZWN0cm9uaWNfYWNjZXNzXzFkaXNwbGF5Ijoie1wiaHR0cHM6Ly9jYXRhbG9nLnByaW5jZXRvbi5lZHUvY2F0YWxvZy80ODg4NDk0I3ZpZXdcIjpbXCJEaWdpdGFsIGNvbnRlbnRcIl0sXCJpaWlmX21hbmlmZXN0X3BhdGhzXCI6e1wiaHR0cDovL2Fya3MucHJpbmNldG9uLmVkdS9hcms6Lzg4NDM1L241ODN4eDkxeFwiOlwiaHR0cHM6Ly9maWdneS5wcmluY2V0b24uZWR1L2NvbmNlcm4vc2Nhbm5lZF9tYXBzL2JhMjhkYTFhLTBiMmQtNDRhMC1iNDU1LTIyYjVmZTc1MzJmMy9tYW5pZmVzdFwifX0iLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjEgbWFwIG9uIDMgc2hlZXRzIDogY29sLiA7IGVhY2ggNjQgeCA1NCBjbS4iXSwiZGVzY3JpcHRpb25fdCI6WyJTY2FsZSBbY2EuIDE6NjAwXS4gNTAgZnQuIHRvIGFuIGluY2guIiwiMSBtYXAgb24gMyBzaGVldHMgOiBjb2wuIDsgZWFjaCA2NCB4IDU0IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxIG1hcCBvbiAzIHNoZWV0cyJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiTmV3IEplcnNleSJdLCJzY2FsZV9kaXNwbGF5IjpbIlNjYWxlIFtjYS4gMTo2MDBdLiA1MCBmdC4gdG8gYW4gaW5jaC4iXSwibm90ZXNfZGlzcGxheSI6WyJcIkphbi4gMTg4NS5cIiIsIkluY2x1ZGVzIGtleSBhbmQgdGV4dC4iLCJOb3J0aCBvcmllbnRlZCB0b3dhcmQgdXBwZXIgbGVmdC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJwcm92ZW5hbmNlX2Rpc3BsYXkiOlsiSGlzdG9yaWMgTWFwcyBjb3B5IGhhcyBzdGFtcCBvZiBNYXAgRGl2aXNpb24sIExpYnJhcnkgb2YgQ29uZ3Jlc3MsIGRhdGVkIE1hci4gNiwgMTg4NS4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmlyZSBpbnN1cmFuY2UgbWFwcyBOZXcgSmVyc2V5IEZyZWVob2xkIDE4ODUuIiwiTWFwcyBOZXcgSmVyc2V5IEZyZWVob2xkIDE4ODUuIl0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiRm9ybWVyIG93bmVyXCI6W1wiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uXCJdfSIsImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiNTA4NTQ5M1wiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIEhpc3RvcmljIE1hcHMgT2ZmLVNpdGUgU3RvcmFnZVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHhwXCIsXCJjYWxsX251bWJlclwiOlwiSE1DMDQgKEZyZWVob2xkKVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJITUMwNCAoRnJlZWhvbGQpXCJ9LFwiNzQyNjI3MlwiOntcImxvY2F0aW9uXCI6XCJPbmxpbmUgLSAqT05MSU5FKlwiLFwibGlicmFyeVwiOlwiT25saW5lXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJlbGYxXCIsXCJjYWxsX251bWJlclwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJFbGVjdHJvbmljIFJlc291cmNlXCJ9fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJyY3B4cCIsImVsZjEiXSwibG9jYXRpb24iOlsiUmVDQVAiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBIaXN0b3JpYyBNYXBzIE9mZi1TaXRlIFN0b3JhZ2UiLCJPbmxpbmUgLSAqT05MSU5FKiJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHhwIiwiZWxmMSIsIlJlQ0FQIiwiT25saW5lIiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlNhbmJvcm4gTWFwIENvbXBhbnkuIEZyZWVob2xkLCBOLiBKLiJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhNQzA0IChGcmVlaG9sZCkiLCJFbGVjdHJvbmljIFJlc291cmNlIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkhNQzA0IChGcmVlaG9sZCkiLCJFbGVjdHJvbmljIFJlc291cmNlIl0sIl92ZXJzaW9uXyI6MTYxMTYwODQ5MzI0NTA3MTM2MCwidGltZXN0YW1wIjoiMjAxOC0wOS0xNFQxODoyNzowOC4wNTRaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:52 GMT
 - request:
     method: get
@@ -9391,7 +9391,7 @@ http_interactions:
         Library","Online"],"name_title_browse_s":["Gray, Brayton, 1940-. Abelian Properties
         of Anick Spaces"],"call_number_display":["QA3 .A57 no.1162","Electronic Resource"],"call_number_browse_s":["QA3
         .A57 no.1162","Electronic Resource"],"_version_":1611625682445533184,"timestamp":"2018-09-14T23:00:20.987Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:53 GMT
 - request:
     method: get
@@ -9445,7 +9445,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMwMTg1NjciLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIk1hcnlsYW5kIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hcnlsYW5kIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W10sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiTWFyeWxhbmRcIn0iLCJhdXRob3JfcyI6WyJNYXJ5bGFuZCJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQuIiwidGl0bGVfdCI6WyJBbiBhY3QgdG8gc2VjdXJlIGZhaXIgZWxlY3Rpb25zIGluIE1hcnlsYW5kLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiW24ucC4sIG4uZC5dIl0sInB1Yl9jcmVhdGVkX3MiOlsiW24ucC4sIG4uZC5dIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIm4ucC4iXSwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyI0MSBwLiAyNCBjbS4iXSwiZGVzY3JpcHRpb25fdCI6WyI0MSBwLiAyNCBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiNDEgcC4iXSwic2VyaWVzX2Rpc3BsYXkiOlsiSGlzdG9yeSwgdi4gMzU2LiJdLCJtb3JlX2luX3RoaXNfc2VyaWVzX3QiOlsiSGlzdG9yeSJdLCJub3Rlc19kaXNwbGF5IjpbIkhhbGYtdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIkVsZWN0aW9uIGxhd+KAlE1hcnlsYW5kIl0sInN1YmplY3RfZmFjZXQiOlsiRWxlY3Rpb24gbGF34oCUTWFyeWxhbmQiXSwib2NsY19zIjpbIjI3NDEyOTA4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20yNzQxMjkwOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjMzMzQ3OTJcIjp7XCJsb2NhdGlvblwiOlwiRm9ycmVzdGFsIEFubmV4IC0gUHJpbmNldG9uIENvbGxlY3Rpb25cIixcImxpYnJhcnlcIjpcIkZvcnJlc3RhbCBBbm5leFwiLFwibG9jYXRpb25fY29kZVwiOlwicFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJQOTQuODQ5LjAzNi4xNVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJQOTQuODQ5LjAzNi4xNVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicCJdLCJsb2NhdGlvbiI6WyJGb3JyZXN0YWwgQW5uZXgiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGb3JyZXN0YWwgQW5uZXggLSBQcmluY2V0b24gQ29sbGVjdGlvbiJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInAiLCJGb3JyZXN0YWwgQW5uZXgiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJNYXJ5bGFuZC4gQW4gYWN0IHRvIHNlY3VyZSBmYWlyIGVsZWN0aW9ucyBpbiBNYXJ5bGFuZCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIlA5NC44NDkuMDM2LjE1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIlA5NC44NDkuMDM2LjE1Il0sIl92ZXJzaW9uXyI6MTYxMTYwMTEzNzI0MDExMzE1MywidGltZXN0YW1wIjoiMjAxOC0wOS0xNFQxNjozMDoxMC41NTZaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:55 GMT
 - request:
     method: get
@@ -9499,7 +9499,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJhdXRob3JfcyI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NyZWF0ZWRfcyI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2VuZWdhbDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNiJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE2LCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDktMjBUMTk6MzQ6MTRaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJBZnJpY2EiLCJTZW5lZ2FsIl0sImNvbnRpbnVlc19kaXNwbGF5IjpbIkXMgWNyaXZhaW4sIGpvdXJuYWwgY3VsdHVyZWwgcGFuYWZyaWNhaW4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbjogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pOyB0aXRsZSBmcm9tIGNvdmVyLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IEhvcnMgc2XMgXJpZSAocHVibGlzaGVkIGluIDIwMTY/KS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImZyIl0sInN1YmplY3RfZGlzcGxheSI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJfdmVyc2lvbl8iOjE2MTE2MTI4Njc3OTYxNDAwMzIsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTk6MzY6MzkuODk2WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:56:56 GMT
 - request:
     method: get
@@ -9553,7 +9553,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQiLCJCb2huZXIsIEthdGUiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJCb2huZXIsIEthdGVcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiVHJ1bXAsIERvbmFsZFwifSIsImF1dGhvcl9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIiwiQm9obmVyLCBLYXRlIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiIsInRpdGxlX3QiOlsiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2siXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsieHgsIDI0NCBwLiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGluZGV4LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJfdmVyc2lvbl8iOjE2MTE1OTY0NDMyNzYwMTc2NjQsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTU6MTU6MzYuMjcwWiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:57:00 GMT
 - request:
     method: get
@@ -9607,7 +9607,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5MyJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXNcIn0iLCJhdXRob3JfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwidGl0bGVfdCI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NyZWF0ZWRfcyI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGFyaXMiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTQzIl0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NDMsInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTQ1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0wNVQxODoxOToyMloiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjYxIHAuIDE3IGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjYxIHAuIDE3IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2MSBwLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiUHJlbWllzIByZSBlzIFkaXRpb24gcHVibGlxdWUuXCIiLCJBdXRob3IncyBwc2V1ZC4sIEFyZ29ubmUsIGF0IGhlYWQgb2YgdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkZyZW5jaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZnJlIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJmciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiR3JlYXQgQnJpdGFpbuKAlFJlbGF0aW9uc+KAlEZyYW5jZSIsIkZyYW5jZeKAlFJlbGF0aW9uc+KAlEdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWlu4oCUQ2l2aWxpemF0aW9u4oCUSGlzdG9yeSJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJFZGl0aW9ucyBkZSBNaW51aXRcIl19IiwibGNjbl9kaXNwbGF5IjpbIiAgIDQ3MDI4Nzk5ICAiXSwibGNjbl9zIjpbIjQ3MDI4Nzk5Il0sIm9jbGNfcyI6WyI2Njc4NjgxIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20wNjY3ODY4MSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjI0NTM2OTNcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFN5bHZpYSBCZWFjaCBDb2xsZWN0aW9uXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJiZWFjXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiREE0Ny4xIC5EMzUgMTk0NVwifSxcIjI0NTM2OTRcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3NcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImV4XCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIjMyMjkuMzE5LjI4XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjMyMjkuMzE5LjI4XCJ9LFwiMzUyMDU0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiMTQ1OS4yODdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTQ1OS4yODdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImJlYWMiLCJleCIsInJjcHBhIl0sImxvY2F0aW9uIjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvbiIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIiwiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5My4gQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJfdmVyc2lvbl8iOjE2MTE1OTc4NjEwNzEzNTU5MDQsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTU6Mzg6MDguMzc2WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:57:06 GMT
 - request:
     method: get
@@ -9661,7 +9661,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMzNjUyNSIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgQXJ0Il0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnNcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU3BpZWdlbG1hbiwgQXJ0XCJ9IiwiYXV0aG9yX3MiOlsiU3BpZWdlbG1hbiwgQXJ0IiwiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnMiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJNYXVzIDogYSBzdXJ2aXZvcidzIHRhbGUgLyBieSBBcnQgU3BpZWdlbG1hbi4iLCJ0aXRsZV90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBQYW50aGVvbiBCb29rcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5ODYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk4NiwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIxNTkgcC4gOiBpbGwuIDsgMjMgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNTkgcC4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdfSIsImlzYm5fZGlzcGxheSI6WyIwMzk0NzQ3MjMyIDoiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDg2MDQyNjQyICJdLCJsY2NuX3MiOlsiODYwNDI2NDIiXSwiaXNibl9zIjpbIjk3ODAzOTQ3NDcyMzEiXSwiaXNibl90IjpbIjk3ODAzOTQ3NDcyMzEiXSwib2NsY19zIjpbIjEzNTI0MzE0Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwMzk0NzQ3MjMxIiwib2NtMTM1MjQzMTQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIzNjc4ODJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCJ9LFwiMzY3ODgzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJQcmluY2V0b24gY29weSAxXCJdfX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiIsImV4Il0sImxvY2F0aW9uIjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3MiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiZXgiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTcGllZ2VsbWFuLCBBcnQuIE1hdXMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJfdmVyc2lvbl8iOjE2MTE1OTAzODkyMzk2NDQxNjAsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTM6Mzk6MjIuNzQyWiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:57:10 GMT
 - request:
     method: get
@@ -9715,7 +9715,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uIiwiU2Nocm9lZGVyLCBDYXJvbGluZSBULiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC5cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiQ2hpbiwgQ2F0aGVyaW5lIE0uXCJ9IiwiYXV0aG9yX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsInRpdGxlX3QiOlsiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5Il0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEgb25saW5lIHJlc291cmNlIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwicmVsYXRlZF9yZWNvcmRfaW5mb19kaXNwbGF5IjpbIlByaW50IHZlcnNpb246Il0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTWVsYW5pYSB0aGUgRWxkZXIgYW5kIGhlciBncmFuZGRhdWdodGVyIE1lbGFuaWEgdGhlIFlvdW5nZXIgd2VyZSBtYWpvciBmaWd1cmVzIGluIGVhcmx5IENocmlzdGlhbiBoaXN0b3J5LCB1c2luZyB0aGVpciB3ZWFsdGgsIHN0YXR1cywgYW5kIGZvcmNlZnVsIHBlcnNvbmFsaXRpZXMgdG8gc2hhcGUgdGhlIGRldmVsb3BtZW50IG9mIG5lYXJseSBldmVyeSBhc3BlY3Qgb2YgdGhlIHJlbGlnaW9uIHdlIG5vdyBrbm93IGFzIENocmlzdGlhbml0eS4gVGhpcyB2b2x1bWUgZXhhbWluZXMgdGhlIGluZmx1ZW5jZSB0aGF0IHRoZXNlIHR3byB3b21lbiBoYWQgb24gdGhlIGRldmVsb3BtZW50IG9mIENocmlzdGlhbml0eSBhbmQgcHJvdmlkZXMgYW4gaW5zaWdodGZ1bCBwb3J0cmFpdCBvZiB0aGUgdGhlaXIgbGVnYWNpZXMgaW4gdGhlIG1vZGVybiB3b3JsZC4gSW5zdGVhZCBvZiB0aGUgdHJhZGl0aW9uYWxseSBwYXRyaWFyY2hhbCB2aWV3LCB0aGlzIHBlcnNwZWN0aXZlIGdpdmVzIGEgcG9pZ25hbnQgYW5kIHNvbWV0aW1lcyBzdXJwcmlzaW5nIHZpZXcgb2YgaG93IHRoZSByaXNlIG9mIENocmlzdGlhbiBpbnN0aXR1dGlvbnMgaW4gdGhlIFJvbWFuIEVtcGlyZSBzaGFwZWQgdGhlIHVuZGVyc3RhbmRpbmcgb2Ygd29tZW4ncyByb2xlcyBpbiB0aGUgbGFyZ2VyIHdvcmxkLlwiLS1Qcm92aWRlZCBieSBwdWJsaXNoZXIuIl0sImJpYl9yZWZfbm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBiaWJsaW9ncmFwaGljYWwgcmVmZXJlbmNlcyBhbmQgaW5kZXguIl0sInNvdXJjZV9kZXNjX25vdGVzX2Rpc3BsYXkiOlsiRGVzY3JpcHRpb24gYmFzZWQgb24gcHJpbnQgdmVyc2lvbiByZWNvcmQgYW5kIENJUCBkYXRhIHByb3ZpZGVkIGJ5IHB1Ymxpc2hlcjsgcmVzb3VyY2Ugbm90IHZpZXdlZC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKChlbGVjdHJvbmljIGJrLikpIiwiMDUyMDk2NTYzOSAoKGVsZWN0cm9uaWMgYmsuKSkiLCIiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxNjAyMDM0MSJdLCJsY2NuX3MiOlsiMjAxNjAyMDM0MSJdLCJpc2JuX3MiOlsiOTc4MDUyMDk2NTYzOCJdLCJpc2JuX3QiOlsiOTc4MDUyMDk2NTYzOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDUyMDk2NTYzOCIsIjk3ODA1MjAyOTIwODYiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5ODAwOTEwXCI6e1wibG9jYXRpb25cIjpcIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXNcIixcImxpYnJhcnlcIjpcIk9ubGluZVwiLFwibG9jYXRpb25fY29kZVwiOlwiZWxmM1wiLFwiY2FsbF9udW1iZXJcIjpcIkVsZWN0cm9uaWMgUmVzb3VyY2VcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZWxmMyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXMiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJlbGYzIiwiT25saW5lIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLS4gTWVsYW5pYSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkVsZWN0cm9uaWMgUmVzb3VyY2UiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJfdmVyc2lvbl8iOjE2MTE2MjUwODk2MjY4MDAxMjgsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjI6NTA6NTUuNjQ4WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:57:13 GMT
 - request:
     method: get
@@ -9779,7 +9779,7 @@ http_interactions:
         Books","Firestone Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone
         Library"],"call_number_display":["Oversize HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766
         .B53f","HQ766 .B53"],"_version_":1611598476842369024,"timestamp":"2018-09-14T15:47:55.672Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:57:19 GMT
 - request:
     method: get
@@ -9855,7 +9855,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"_version_":1611608287253364736,"timestamp":"2018-09-14T18:23:51.638Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Thu, 20 Sep 2018 20:57:25 GMT
 - request:
     method: get
@@ -9909,7 +9909,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMTQ0Njk4IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb2xmZXIsIEFkYW0iLCLXkteV15zXpNeoLCDXkNeT150iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiR29sZmVyLCBBZGFtXCIsXCJHb2xmZXIsIEFkYW1cIixcIkdvbGZlciwgQWRhbVwiLFwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlXCIsXCLXkteV15zXpNeoLCDXkNeT151cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiR29sZmVyLCBBZGFtXCJ9IiwiYXV0aG9yX3MiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIiwi15LXldec16TXqCwg15DXk9edIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIlBob3RvZ3JhcGhlciJdLCJ1bmlmb3JtX3RpdGxlX3MiOlsiUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwidGl0bGVfZGlzcGxheSI6IkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIiwidGl0bGVfdCI6WyJBIGhvdXNlIHdpdGhvdXQgYSByb29mIC8gQWRhbSBHb2xmZXIgOyB0cmFuc2xhdGlvbnM6IE1vc3RhZmEgT3VhamphbmkgKEFyYWJpYyksIEdhYnJpZWxhIFZhaW5zZW5jaGVyIChIZWJyZXcpLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIl0sImVkaXRpb25fZGlzcGxheSI6WyJGaXJzdCBlZGl0aW9uLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY3JlYXRlZF9zIjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJCcm9va2x5biwgTmV3IFlvcms6IEJvb2tseW4iXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTYsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTAzLTMwVDE4OjQ2OjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIDogaWxsdXN0cmF0aW9ucyAoY2hpZWZseSBjb2xvcikgOyAzMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjE2MSBwYWdlcyA6IGlsbHVzdHJhdGlvbnMgKGNoaWVmbHkgY29sb3IpIDsgMzAgY20iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJJc3JhZWwiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiU2hvcnRsaXN0ZWQgZm9yIHRoZSBQYXJpcy1QaG90by8gQXBlcnR1cmUgRmlyc3QgQm9vayBBd2FyZCwgJ0EgSG91c2UgV2l0aG91dCBhIFJvb2YnIGNvbnNpZGVycyB0aGUgb3ZlcmxhcHBpbmcgaGlzdG9yaWVzIG9mIHZpb2xlbmNlIGFuZCBkaXNwbGFjZW1lbnQgY29ubmVjdGluZyBFdXJvcGUsIElzcmFlbCBhbmQgUGFsZXN0aW5lLiBXaXRoIHBob3RvZ3JhcGhzLCBhcmNoaXZhbCBpbWFnZXJ5IGFuZCBvcmlnaW5hbCB0ZXh0cywgQnJvb2tseW4tYmFzZWQgYXJ0aXN0IEFkYW0gR29sZmVyIHdlYXZlcyB0b2dldGhlciBmaWN0aW9ucyBvZiBoaXMgZmFtaWx5IGhpc3Rvcnkgd2l0aCByZXByZXNlbnRhdGlvbnMgZnJvbSBJc3JhZWw/cyBmb3VuZGluZyBhbmQgb25nb2luZyBtaWxpdGFyeSBvY2N1cGF0aW9uLiBFdGhuaWMgYW5kIG5hdGlvbmFsIGlkZW50aXRpZXMgYXJlIHJ1cHR1cmVkIGFuZCByZWFzc2VtYmxlZCBhcyBoZSBpbnRlcnJvZ2F0ZXMgY29udHJhZGljdG9yeSBoaXN0b3JpZXMgYW5kIG5vdGlvbnMgb2Ygc2VsZmhvb2QsIGV4cGxvcmluZyBzdHJhbmRzIHRoYXQgY29ubmVjdCB0aGUgSmV3aXNoIERpYXNwb3JhIG91dCBvZiBFdXJvcGUgYW5kIGZvcmNlZCBtYXNzIG1pZ3JhdGlvbnMgZnJvbSBQYWxlc3RpbmUgZm9sbG93aW5nIFdvcmxkIFdhciBJSS4gR29sZmVyIHNpdHVhdGVzIHRoaXMgaW5xdWlyeSB0aHJvdWdoIHRoZSB0cmlhbmd1bGFyIHJlbGF0aW9uc2hpcCBiZXR3ZWVuIGhpcyBncmFuZGZhdGhlciAoYSBzdXJ2aXZvciBvZiBEYWNoYXUpLCBoaXMgZmF0aGVyICh3aG8gbGl2ZWQgb24gYSBraWJidXR6IGluIHRoZSBlYXJseSAxOTcwcykgYW5kIGhpbXNlbGYuIl0sIm5vdGVzX2Rpc3BsYXkiOlsiQ292ZXIgdGl0bGUuIiwiUHVibGlzaGVkIG9uIHRoZSBvY2Nhc2lvbiBvZiBhbiBleGhpYml0aW9uIGhlbGQgYXQgQm9va2x5biwgSnVseSAxMC1TZXB0ZW1iZXIgNSwgMjAxNS4iXSwibGFuZ3VhZ2VfZGlzcGxheSI6WyJUZXh0IGluIEVuZ2xpc2ggd2l0aCBIZWJyZXcgYW5kIEFyYWJpYyBhdCB0aGUgYm90dG9tIG9mIHRoZSBwYWdlcy4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCIsIkhlYnJldyIsIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIiwiaGViIiwiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiIsImhlIiwiYXIiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIkhvc3QgaW5zdGl0dXRpb25cIjpbXCJCb29rbHluIEFydGlzdHMgQWxsaWFuY2VcIl19IiwiY29udGFpbnNfMWRpc3BsYXkiOiJbW1wiR29sZmVyLCBBZGFtLlwiLFwiSG91c2Ugd2l0aG91dCBhIHJvb2YuXCJdLFtcIkdvbGZlciwgQWRhbS5cIixcIkhvdXNlIHdpdGhvdXQgYSByb29mLlwiLFwiSGVicmV3LlwiXSxbXCJHb2xmZXIsIEFkYW0uXCIsXCJIb3VzZSB3aXRob3V0IGEgcm9vZi5cIixcIkFyYWJpYy5cIl1dIiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyJCYXlpdCBiZWxpIGdhZyIsIteR15nXqiDXkdec15kg15LXkiJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiQmF5aXQgYmVsaSBnYWciLCLXkdeZ16og15HXnNeZINeS15IiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODA2OTI3MjY1MDEiLCIwNjkyNzI2NTAwIl0sImlzYm5fcyI6WyI5NzgwNjkyNzI2NTAxIl0sImlzYm5fdCI6WyI5NzgwNjkyNzI2NTAxIl0sIm9jbGNfcyI6WyI5ODE3NjY2NjAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjk4MTc2NjY2MCIsIjk3ODA2OTI3MjY1MDEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5OTMzODc4XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBqXCIsXCJjYWxsX251bWJlclwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBqIl0sImxvY2F0aW9uIjpbIlJlQ0FQIiwiTWFycXVhbmQgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBqIiwiUmVDQVAiLCJNYXJxdWFuZCBMaWJyYXJ5Il0sIm5hbWVfdW5pZm9ybV90aXRsZV8xZGlzcGxheSI6IltbXCJHb2xmZXIsIEFkYW0uXCIsXCJQaG90b2dyYXBocy5cIixcIlNlbGVjdGlvbnNcIl1dIiwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb2xmZXIsIEFkYW0uIEhvdXNlIHdpdGhvdXQgYSByb29mIiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gSGVicmV3IiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gQXJhYmljIiwiR29sZmVyLCBBZGFtLiBQaG90b2dyYXBocyIsIkdvbGZlciwgQWRhbS4gUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJfdmVyc2lvbl8iOjE2MTE2MjU2OTc5NTE4NzUwNzIsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjM6MDA6MzUuNzUzWiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:12:02 GMT
 - request:
     method: get
@@ -9963,7 +9963,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjMzNjUyNSIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgQXJ0Il0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnNcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU3BpZWdlbG1hbiwgQXJ0XCJ9IiwiYXV0aG9yX3MiOlsiU3BpZWdlbG1hbiwgQXJ0IiwiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnMiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJNYXVzIDogYSBzdXJ2aXZvcidzIHRhbGUgLyBieSBBcnQgU3BpZWdlbG1hbi4iLCJ0aXRsZV90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBQYW50aGVvbiBCb29rcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5ODYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk4NiwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDQ6MDA6MDBaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIxNTkgcC4gOiBpbGwuIDsgMjMgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNTkgcC4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdfSIsImlzYm5fZGlzcGxheSI6WyIwMzk0NzQ3MjMyIDoiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDg2MDQyNjQyICJdLCJsY2NuX3MiOlsiODYwNDI2NDIiXSwiaXNibl9zIjpbIjk3ODAzOTQ3NDcyMzEiXSwiaXNibl90IjpbIjk3ODAzOTQ3NDcyMzEiXSwib2NsY19zIjpbIjEzNTI0MzE0Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwMzk0NzQ3MjMxIiwib2NtMTM1MjQzMTQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIzNjc4ODJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCJ9LFwiMzY3ODgzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJQcmluY2V0b24gY29weSAxXCJdfX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiIsImV4Il0sImxvY2F0aW9uIjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3MiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiZXgiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTcGllZ2VsbWFuLCBBcnQuIE1hdXMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJfdmVyc2lvbl8iOjE2MTE1OTAzODkyMzk2NDQxNjAsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTM6Mzk6MjIuNzQyWiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:13:08 GMT
 - request:
     method: get
@@ -10017,7 +10017,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjE3ODg3OTYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQiLCJCb2huZXIsIEthdGUiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJCb2huZXIsIEthdGVcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiVHJ1bXAsIERvbmFsZFwifSIsImF1dGhvcl9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIiwiQm9obmVyLCBLYXRlIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiIsInRpdGxlX3QiOlsiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2siXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsieHgsIDI0NCBwLiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGluZGV4LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaXNibl90IjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJfdmVyc2lvbl8iOjE2MTE1OTY0NDMyNzYwMTc2NjQsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTU6MTU6MzYuMjcwWiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:13:10 GMT
 - request:
     method: get
@@ -10071,7 +10071,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjEwMDgxNTY2IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb3RvzIQsIE1laXNlaSwgMTkzMi0xOTk5Iiwi5b6M6Jek5piO55SfLCAxOTMyLTE5OTkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR290b8yELCBNZWlzZWkiLCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wi5b6M6Jek5piO55SfXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1XCIsXCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrlcIl0sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJHb3RvzIQsIE1laXNlaVwifSIsImF1dGhvcl9zIjpbIkdvdG/MhCwgTWVpc2VpLCAxOTMyLTE5OTkiLCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1Iiwi5b6M6Jek5piO55SfLCAxOTMyLTE5OTkiLCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrkiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiSW50ZXJ2aWV3ZWUiXSwidGl0bGVfZGlzcGxheSI6IkFtaWRhIGt1amlzaGlraSBHb3RvzIQgTWVpc2VpLiBaYWRhbiBoZW4gLyBHb3RvzIQgTWVpc2VpIDsgQcyEcmnMhCBCYcyEZG8gQnVra3VzdSBoZW4uIiwidGl0bGVfdmVybl9kaXNwbGF5Ijoi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744KkLiDluqfoq4fnr4cgLyDlvozol6TmmI7nlJ8gOyDjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrnnt6guIiwidGl0bGVfdCI6WyJBbWlkYSBrdWppc2hpa2kgR290b8yEIE1laXNlaS4gWmFkYW4gaGVuIC8gR290b8yEIE1laXNlaSA7IEHMhHJpzIQgQmHMhGRvIEJ1a2t1c3UgaGVuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkFtaWRhIGt1amlzaGlraSBHb3RvzIQgTWVpc2VpIiwi44Ki44Of44OA44Kv44K45byP44K044OI44Km44Oh44Kk44K744KkLiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiQW1pZGEga3VqaXNoaWtpIEdvdG/MhCBNZWlzZWkuIFphZGFuIGhlbiAvIEdvdG/MhCBNZWlzZWkgOyBBzIRyacyEIEJhzIRkbyBCdWtrdXN1IGhlbi4iLCLjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqQuIOW6p+irh+evhyAvIOW+jOiXpOaYjueUnyA7IOOCouODvOODquODvOODkOODvOODieODu+ODluODg+OCr+OCuee3qC4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIkRhaSAxLWhhbi4iLCLnrKwx54mILiJdLCJwdWJfY3JlYXRlZF92ZXJuX2Rpc3BsYXkiOlsi5p2x5LqsIDog44Gk44GL44Gg44G+5pu45oi/LCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlRvzIRreW/MhCA6IFRzdWthZGFtYSBTaG9ib8yELCAyMDE3LiIsIuadseS6rCA6IOOBpOOBi+OBoOOBvuabuOaIvywgMjAxNy4iXSwicHViX2NyZWF0ZWRfcyI6WyJUb8yEa3lvzIQgOiBUc3VrYWRhbWEgU2hvYm/MhCwgMjAxNy4iLCLmnbHkuqwgOiDjgaTjgYvjgaDjgb7mm7jmiL8sIDIwMTcuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRvzIRreW/MhDogVHN1a2FkYW1hIFNob2JvzIQiLCLmnbHkuqw6IOOBpOOBi+OBoOOBvuabuOaIvyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTciXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNywicHViX2RhdGVfZW5kX3NvcnQiOjIwMTcsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTA4LTI0VDE3OjI2OjM3WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiNDQ2IHBhZ2VzIDsgMjIgY20iXSwiZGVzY3JpcHRpb25fdCI6WyI0NDYgcGFnZXMgOyAyMiBjbSJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI0NDYgcGFnZXMiXSwibGFuZ3VhZ2VfZmFjZXQiOlsiSmFwYW5lc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbImpwbiJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiamEiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJFZGl0b3JcIjpbXCJBzIRyacyEIEJhzIRkbyBCdWtrdXN1XCIsXCLjgqLjg7zjg6rjg7zjg5Djg7zjg4njg7vjg5bjg4Pjgq/jgrlcIl19Iiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyLluqfoq4fnr4ciXSwiYWx0X3RpdGxlXzI0Nl9kaXNwbGF5IjpbIuW6p+irh+evhyJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4NDkwODYyNDAxOCIsIjQ5MDg2MjQwMTEiXSwiaXNibl9zIjpbIjk3ODQ5MDg2MjQwMTgiXSwiaXNibl90IjpbIjk3ODQ5MDg2MjQwMTgiXSwib2NsY19zIjpbIjk4ODI1MzIwMyJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuOTg4MjUzMjAzIiwiOTc4NDkwODYyNDAxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjk4NzgyMzVcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIlBMODUxLk84MyBBNjIyIDIwMTdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiUEw4NTEuTzgzIEE2MjIgMjAxN1wifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb3RvzIQsIE1laXNlaSwgMTkzMi0xOTk5LiBBbWlkYSBrdWppc2hpa2kgR290b8yEIE1laXNlaSIsIuW+jOiXpOaYjueUnywgMTkzMi0xOTk5LiDjgqLjg5/jg4Djgq/jgrjlvI/jgrTjg4jjgqbjg6HjgqTjgrvjgqQuIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUEw4NTEuTzgzIEE2MjIgMjAxNyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJQTDg1MS5PODMgQTYyMiAyMDE3Il0sIl92ZXJzaW9uXyI6MTYxMjA0ODE0MTk2MTM5NjIyNCwidGltZXN0YW1wIjoiMjAxOC0wOS0xOVQxNDo1NTowOS43MDRaIn19fQ==
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:13:12 GMT
 - request:
     method: get
@@ -10125,7 +10125,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjIxNjc2NjkiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5MyJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXNcIn0iLCJhdXRob3JfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwidGl0bGVfdCI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NyZWF0ZWRfcyI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGFyaXMiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTQzIl0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NDMsInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTQ1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0wNVQxODoxOToyMloiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjYxIHAuIDE3IGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjYxIHAuIDE3IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2MSBwLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiUHJlbWllzIByZSBlzIFkaXRpb24gcHVibGlxdWUuXCIiLCJBdXRob3IncyBwc2V1ZC4sIEFyZ29ubmUsIGF0IGhlYWQgb2YgdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkZyZW5jaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZnJlIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJmciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiR3JlYXQgQnJpdGFpbuKAlFJlbGF0aW9uc+KAlEZyYW5jZSIsIkZyYW5jZeKAlFJlbGF0aW9uc+KAlEdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWlu4oCUQ2l2aWxpemF0aW9u4oCUSGlzdG9yeSJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJFZGl0aW9ucyBkZSBNaW51aXRcIl19IiwibGNjbl9kaXNwbGF5IjpbIiAgIDQ3MDI4Nzk5ICAiXSwibGNjbl9zIjpbIjQ3MDI4Nzk5Il0sIm9jbGNfcyI6WyI2Njc4NjgxIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20wNjY3ODY4MSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjI0NTM2OTNcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFN5bHZpYSBCZWFjaCBDb2xsZWN0aW9uXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJiZWFjXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiREE0Ny4xIC5EMzUgMTk0NVwifSxcIjI0NTM2OTRcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3NcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImV4XCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIjMyMjkuMzE5LjI4XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjMyMjkuMzE5LjI4XCJ9LFwiMzUyMDU0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiMTQ1OS4yODdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTQ1OS4yODdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImJlYWMiLCJleCIsInJjcHBhIl0sImxvY2F0aW9uIjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvbiIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIiwiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5My4gQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJfdmVyc2lvbl8iOjE2MTE1OTc4NjEwNzEzNTU5MDQsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTU6Mzg6MDguMzc2WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:13:19 GMT
 - request:
     method: get
@@ -10189,7 +10189,7 @@ http_interactions:
         Books","Firestone Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone
         Library"],"call_number_display":["Oversize HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766
         .B53f","HQ766 .B53"],"_version_":1611598476842369024,"timestamp":"2018-09-14T15:47:55.672Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:13:21 GMT
 - request:
     method: get
@@ -10243,7 +10243,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5NDQzNTUiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJhdXRob3JfcyI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NyZWF0ZWRfcyI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2VuZWdhbDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNiJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE2LCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDktMjBUMTk6MzQ6MTRaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJBZnJpY2EiLCJTZW5lZ2FsIl0sImNvbnRpbnVlc19kaXNwbGF5IjpbIkXMgWNyaXZhaW4sIGpvdXJuYWwgY3VsdHVyZWwgcGFuYWZyaWNhaW4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbjogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pOyB0aXRsZSBmcm9tIGNvdmVyLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IEhvcnMgc2XMgXJpZSAocHVibGlzaGVkIGluIDIwMTY/KS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImZyIl0sInN1YmplY3RfZGlzcGxheSI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJfdmVyc2lvbl8iOjE2MTE2MTI4Njc3OTYxNDAwMzIsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMTk6MzY6MzkuODk2WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:13:26 GMT
 - request:
     method: get
@@ -10297,7 +10297,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6Ijk5OTQ2OTIiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uIiwiU2Nocm9lZGVyLCBDYXJvbGluZSBULiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC5cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiQ2hpbiwgQ2F0aGVyaW5lIE0uXCJ9IiwiYXV0aG9yX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsInRpdGxlX3QiOlsiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5Il0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTg6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEgb25saW5lIHJlc291cmNlIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwicmVsYXRlZF9yZWNvcmRfaW5mb19kaXNwbGF5IjpbIlByaW50IHZlcnNpb246Il0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTWVsYW5pYSB0aGUgRWxkZXIgYW5kIGhlciBncmFuZGRhdWdodGVyIE1lbGFuaWEgdGhlIFlvdW5nZXIgd2VyZSBtYWpvciBmaWd1cmVzIGluIGVhcmx5IENocmlzdGlhbiBoaXN0b3J5LCB1c2luZyB0aGVpciB3ZWFsdGgsIHN0YXR1cywgYW5kIGZvcmNlZnVsIHBlcnNvbmFsaXRpZXMgdG8gc2hhcGUgdGhlIGRldmVsb3BtZW50IG9mIG5lYXJseSBldmVyeSBhc3BlY3Qgb2YgdGhlIHJlbGlnaW9uIHdlIG5vdyBrbm93IGFzIENocmlzdGlhbml0eS4gVGhpcyB2b2x1bWUgZXhhbWluZXMgdGhlIGluZmx1ZW5jZSB0aGF0IHRoZXNlIHR3byB3b21lbiBoYWQgb24gdGhlIGRldmVsb3BtZW50IG9mIENocmlzdGlhbml0eSBhbmQgcHJvdmlkZXMgYW4gaW5zaWdodGZ1bCBwb3J0cmFpdCBvZiB0aGUgdGhlaXIgbGVnYWNpZXMgaW4gdGhlIG1vZGVybiB3b3JsZC4gSW5zdGVhZCBvZiB0aGUgdHJhZGl0aW9uYWxseSBwYXRyaWFyY2hhbCB2aWV3LCB0aGlzIHBlcnNwZWN0aXZlIGdpdmVzIGEgcG9pZ25hbnQgYW5kIHNvbWV0aW1lcyBzdXJwcmlzaW5nIHZpZXcgb2YgaG93IHRoZSByaXNlIG9mIENocmlzdGlhbiBpbnN0aXR1dGlvbnMgaW4gdGhlIFJvbWFuIEVtcGlyZSBzaGFwZWQgdGhlIHVuZGVyc3RhbmRpbmcgb2Ygd29tZW4ncyByb2xlcyBpbiB0aGUgbGFyZ2VyIHdvcmxkLlwiLS1Qcm92aWRlZCBieSBwdWJsaXNoZXIuIl0sImJpYl9yZWZfbm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBiaWJsaW9ncmFwaGljYWwgcmVmZXJlbmNlcyBhbmQgaW5kZXguIl0sInNvdXJjZV9kZXNjX25vdGVzX2Rpc3BsYXkiOlsiRGVzY3JpcHRpb24gYmFzZWQgb24gcHJpbnQgdmVyc2lvbiByZWNvcmQgYW5kIENJUCBkYXRhIHByb3ZpZGVkIGJ5IHB1Ymxpc2hlcjsgcmVzb3VyY2Ugbm90IHZpZXdlZC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKChlbGVjdHJvbmljIGJrLikpIiwiMDUyMDk2NTYzOSAoKGVsZWN0cm9uaWMgYmsuKSkiLCIiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxNjAyMDM0MSJdLCJsY2NuX3MiOlsiMjAxNjAyMDM0MSJdLCJpc2JuX3MiOlsiOTc4MDUyMDk2NTYzOCJdLCJpc2JuX3QiOlsiOTc4MDUyMDk2NTYzOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDUyMDk2NTYzOCIsIjk3ODA1MjAyOTIwODYiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5ODAwOTEwXCI6e1wibG9jYXRpb25cIjpcIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXNcIixcImxpYnJhcnlcIjpcIk9ubGluZVwiLFwibG9jYXRpb25fY29kZVwiOlwiZWxmM1wiLFwiY2FsbF9udW1iZXJcIjpcIkVsZWN0cm9uaWMgUmVzb3VyY2VcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZWxmMyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXMiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJlbGYzIiwiT25saW5lIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLS4gTWVsYW5pYSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkVsZWN0cm9uaWMgUmVzb3VyY2UiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJfdmVyc2lvbl8iOjE2MTE2MjUwODk2MjY4MDAxMjgsInRpbWVzdGFtcCI6IjIwMTgtMDktMTRUMjI6NTA6NTUuNjQ4WiJ9fX0=
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:13:30 GMT
 - request:
     method: get
@@ -10373,7 +10373,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"_version_":1611608287253364736,"timestamp":"2018-09-14T18:23:51.638Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 00:13:32 GMT
 - request:
     method: get
@@ -10445,7 +10445,7 @@ http_interactions:
         Library"],"location_display":["Marquand Library"],"advanced_location_s":["sa","Marquand
         Library"],"name_title_browse_s":["Burrows, Roger. 3D THINKING IN DESIGN AND
         ARCHITECTURE: FROM ANTIQUITY TO THE FUTURE"],"_version_":1612048154518093824,"timestamp":"2018-09-19T14:55:21.689Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 14:00:10 GMT
 - request:
     method: get
@@ -10497,7 +10497,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"10672583":{"more_items":false,"location":"sa","status":"Pending Order","label":"Marquand
         Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 14:00:10 GMT
 - request:
     method: get
@@ -10569,7 +10569,7 @@ http_interactions:
         Library"],"location_display":["Marquand Library"],"advanced_location_s":["sa","Marquand
         Library"],"name_title_browse_s":["Burrows, Roger. 3D THINKING IN DESIGN AND
         ARCHITECTURE: FROM ANTIQUITY TO THE FUTURE"],"_version_":1612048154518093824,"timestamp":"2018-09-19T14:55:21.693Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 14:00:25 GMT
 - request:
     method: get
@@ -10621,7 +10621,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"10672583":{"more_items":false,"location":"sa","status":"Pending Order","label":"Marquand
         Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 14:00:25 GMT
 - request:
     method: get
@@ -10693,7 +10693,7 @@ http_interactions:
         Library"],"location_display":["Marquand Library"],"advanced_location_s":["sa","Marquand
         Library"],"name_title_browse_s":["Burrows, Roger. 3D THINKING IN DESIGN AND
         ARCHITECTURE: FROM ANTIQUITY TO THE FUTURE"],"_version_":1612048154518093824,"timestamp":"2018-09-19T14:55:21.693Z"}}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 14:21:18 GMT
 - request:
     method: get
@@ -10745,7 +10745,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"10672583":{"more_items":false,"location":"sa","status":"Pending Order","label":"Marquand
         Library"}}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 14:21:18 GMT
 - request:
     method: get
@@ -10799,7 +10799,7 @@ http_interactions:
         Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand
         Library of Art and Archaeology","code":"marquand"},"delivery_locations":[{"label":"Marquand
         Library of Art and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Fri, 21 Sep 2018 14:21:18 GMT
 - request:
     method: get
@@ -10863,7 +10863,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 76.0.3809.126
-    http_version: null
+    http_version: 
   recorded_at: Tue, 10 Sep 2019 18:22:55 GMT
 - request:
     method: get
@@ -10917,7 +10917,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6Ijk0OTMzMTgiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlNhbWjMo2HMhG4sIE5hamHMhHQiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjCJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJTYW1ozKNhzIRuLCBOYWphzIR0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wi2LPZhdit2KfZhtiMINmG2KzYp9ip2IxcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU2FtaMyjYcyEbiwgTmFqYcyEdFwifSIsImF1dGhvcl9zIjpbIlNhbWjMo2HMhG4sIE5hamHMhHQiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjCJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6Isq7QXdhzIR0zKNpZiBtYWRmdcyEbmFoIC8gTmFqYcyEdCBhbC1TYW1ozKNhzIRuLiIsInRpdGxlX3Zlcm5fZGlzcGxheSI6Iti52YjYp9i32YEg2YXYr9mB2YjZhtipIC8g2YbYrNin2Kkg2KfZhNiz2YXYrdin2YYuIiwidGl0bGVfdCI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIE5hamHMhHQgYWwtU2FtaMyjYcyEbi4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCIsIti52YjYp9i32YEg2YXYr9mB2YjZhtipIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyLKu0F3YcyEdMyjaWYgbWFkZnXMhG5haCAvIE5hamHMhHQgYWwtU2FtaMyjYcyEbi4iLCLYudmI2KfYt9mBINmF2K/ZgdmI2YbYqSAvINmG2KzYp9ipINin2YTYs9mF2K3Yp9mGLiJdLCJwdWJfY3JlYXRlZF92ZXJuX2Rpc3BsYXkiOlsi2KfZhNmC2KfZh9ix2KkgOiDYr9in2LEg2KfZhNmD2KrYp9ioINin2YTYrdiv2YrYq9iMIDIwMTYuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiYWwtUWHMhGhpcmFoIDogRGHMhHIgYWwtS2l0YcyEYiBhbC1IzKNhZGnMhHRoLCAyMDE2LiIsItin2YTZgtin2YfYsdipIDog2K/Yp9ixINin2YTZg9iq2KfYqCDYp9mE2K3Yr9mK2KvYjCAyMDE2LiJdLCJwdWJfY3JlYXRlZF9zIjpbImFsLVFhzIRoaXJhaCA6IERhzIRyIGFsLUtpdGHMhGIgYWwtSMyjYWRpzIR0aCwgMjAxNi4iLCLYp9mE2YLYp9mH2LHYqSA6INiv2KfYsSDYp9mE2YPYqtin2Kgg2KfZhNit2K/Zitir2IwgMjAxNi4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiYWwtUWHMhGhpcmFoOiBEYcyEciBhbC1LaXRhzIRiIGFsLUjMo2FkacyEdGgiLCLYp9mE2YLYp9mH2LHYqTog2K/Yp9ixINin2YTZg9iq2KfYqCDYp9mE2K3Yr9mK2KvYjCJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxNiwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDEtMTlUMTQ6NDk6MzdaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIyMzAgcGFnZXMgOyAyMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjIzMCBwYWdlcyA7IDIwIGNtIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjIzMCBwYWdlcyJdLCJub3Rlc19kaXNwbGF5IjpbIlNob3J0IHN0b3JpZXMuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJhciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU2hvcnQgc3RvcmllcywgQXJhYmlj4oCUMjFzdCBjZW50dXJ5Il0sInN1YmplY3RfZmFjZXQiOlsiU2hvcnQgc3RvcmllcywgQXJhYmlj4oCUMjFzdCBjZW50dXJ5Il0sImlzYm5fZGlzcGxheSI6WyI5Nzg5NzczNTA2ODI3IiwiOTc3MzUwNjgyNyJdLCJpc2JuX3MiOlsiOTc4OTc3MzUwNjgyNyJdLCJvY2xjX3MiOlsiOTM1MjE5MzEwIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY245MzUyMTkzMTAiLCI5Nzg5NzczNTA2ODI3Il0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjIxc3QgY2VudHVyeSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjkzNTE5NjdcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3BwYVwiLFwiY2FsbF9udW1iZXJcIjpcIlBKNzk2Mi5BNTQ5NSBBOTUgMjAxNlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJQSjc5NjIuQTU0OTUgQTk1IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiU2FtaMyjYcyEbiwgTmFqYcyEdC4gyrtBd2HMhHTMo2lmIG1hZGZ1zIRuYWgiLCLYs9mF2K3Yp9mG2Iwg2YbYrNin2KnYjC4g2LnZiNin2LfZgSDZhdiv2YHZiNmG2KkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJQSjc5NjIuQTU0OTUgQTk1IDIwMTYiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiUEo3OTYyLkE1NDk1IEE5NSAyMDE2Il0sIl92ZXJzaW9uXyI6MTYyMTEzNjc1NDMzMTM1MzA4OCwidGltZXN0YW1wIjoiMjAxOC0xMi0yOFQyMjozNDo0NS45MjlaIn0=
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 13:34:20 GMT
 - request:
     method: get
@@ -10996,7 +10996,7 @@ http_interactions:
         Library"],"name_title_browse_s":["Gray, Brayton, 1940-. Abelian Properties
         of Anick Spaces"],"call_number_display":["QA3 .A57 no.1162"],"call_number_browse_s":["QA3
         .A57 no.1162"],"_version_":1626871176845328384,"timestamp":"2019-03-02T05:40:57.356Z"}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 13:34:21 GMT
 - request:
     method: get
@@ -11050,7 +11050,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjEwOTU4NzA1IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJCdXJyb3dzLCBSb2dlciwgMTk0NS0iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQnVycm93cywgUm9nZXIiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJCdXJyb3dzLCBSb2dlclwifSIsImF1dGhvcl9zIjpbIkJ1cnJvd3MsIFJvZ2VyLCAxOTQ1LSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IjNEIHRoaW5raW5nIGluIGRlc2lnbiBhbmQgYXJjaGl0ZWN0dXJlIDogZnJvbSBhbnRpcXVpdHkgdG8gdGhlIGZ1dHVyZSAvIFJvZ2VyIEJ1cnJvd3MuIiwidGl0bGVfdCI6WyIzRCB0aGlua2luZyBpbiBkZXNpZ24gYW5kIGFyY2hpdGVjdHVyZSA6IGZyb20gYW50aXF1aXR5IHRvIHRoZSBmdXR1cmUgLyBSb2dlciBCdXJyb3dzLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIjNEIHRoaW5raW5nIGluIGRlc2lnbiBhbmQgYXJjaGl0ZWN0dXJlIDogZnJvbSBhbnRpcXVpdHkgdG8gdGhlIGZ1dHVyZSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiM0QgdGhpbmtpbmcgaW4gZGVzaWduIGFuZCBhcmNoaXRlY3R1cmUgOiBmcm9tIGFudGlxdWl0eSB0byB0aGUgZnV0dXJlIC8gUm9nZXIgQnVycm93cy4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRoYW1lcyBcdTAwMjYgSHVkc29uLCAyMDE4LiIsIsKpMjAxOCJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogVGhhbWVzIFx1MDAyNiBIdWRzb24sIDIwMTguIiwiwqkyMDE4Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBUaGFtZXMgXHUwMDI2IEh1ZHNvbiJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTgsImNhdGFsb2dlZF90ZHQiOiIyMDE4LTA5LTI2VDE3OjA2OjEyWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMzI4IHBhZ2VzIDogaWxsdXN0cmF0aW9ucyAoY2hpZWZseSBjb2xvdXIpIDsgMjkgY20iXSwiZGVzY3JpcHRpb25fdCI6WyIzMjggcGFnZXMgOiBpbGx1c3RyYXRpb25zIChjaGllZmx5IGNvbG91cikgOyAyOSBjbSJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIzMjggcGFnZXMiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiVGhlIGdlb21ldHJpYyBmb3VuZGF0aW9ucywgZm9ybXMsIGFuZCBwYXR0ZXJucyBpbiB0b2RheSdzIGFyY2hpdGVjdHVyZSwgZGVzaWduIGFuZCwgZGVjb3JhdGl2ZSBhcnRzIGNhbiB0cmFjZSB0aGVpciBvcmlnaW5zIGluIHBhc3QgY3VsdHVyZXMuIEZyb20gaHVtYW5raW5kJ3MgZmlyc3QgcGF0aC1saWtlIGRvb2RsZXMgb24gY2F2ZSB3YWxscyB0aHJvdWdoIHRvIHRoZSBoaWdoZXIgYWJzdHJhY3Rpb25zIGRldmVsb3BlZCB0byBtYWtlIGFjY3VyYXRlIG1lYXN1cmVtZW50cyBhbmQgcHJlZGljdGlvbnMsIHRoZSB0aHJlZS1kaW1lbnNpb25hbCBmb3JtcyB3ZSBkZXNpZ24gYW5kIGJ1aWxkIGhhdmUgYWx3YXlzIGJlZW4gZGVwZW5kZW50IG9uIGF2YWlsYWJsZSBtYXRlcmlhbHMsIGh1bWFuIG5lZWRzLCBhbmQgdGhlIGxpbWl0cyBvZiBvdXIgaW1hZ2luYXRpb25zLiAnM0QgVGhpbmtpbmcgaW4gRGVzaWduIGFuZCBBcmNoaXRlY3R1cmUnIHRlbGxzIHRoZSBzdG9yeSBvZiB0aGUgaW50aW1hdGUgcmVsYXRpb25zaGlwIGJldHdlZW4gZ2VvbWV0cnksIG1hdGhlbWF0aWNzIGFuZCBtYW4tbWFkZSBkZXNpZ24gdGhyb3VnaG91dCBodW1hbiBoaXN0b3J5LCBmcm9tIHRoZSBOZW9saXRoaWMgcGVyaW9kIHRocm91Z2ggdGhlIEluZGlhbiwgRWd5cHRpYW4sIEJhYnlsb25pYW4sIENoaW5lc2UsIEdyZWVrLCBDZWx0aWMsIElzbGFtaWMgYW5kIFJlbmFpc3NhbmNlIGN1bHR1cmVzLCB0byB0aGUgcHJlc2VudCBhbmQgdGhlIHBvc3NpYmxlIGZ1dHVyZS4gUHJlc2VudGluZyBrZXkgcHJpbmNpcGxlcyB0aGF0IGNhbiBiZSBhcHBsaWVkIGFjcm9zcyBhbGwgZGVzaWduIGRpc2NpcGxpbmVzLCBkZXNpZ24gZXhwZXJ0IFJvZ2VyIEJ1cnJvd3MgcmVsYXRlcyBob3cgZ2VvbWV0cnkgYXMgYSB2aXN1YWwgbGFuZ3VhZ2UgaGFzIGV2b2x2ZWQgdG8gbWVldCBvdXIgbmVlZHMsIGluaXRpYXRlZCBuZXcgdGVjaG5vbG9naWVzLCBhbmQgY2hhbmdlZCB0aGUgd2F5IHdlIHRoaW5rIGFib3V0IHRoZSB3b3JsZCBhcm91bmQgdXMuIFdpdGggYSB3ZWFsdGggb2Ygb3JpZ2luYWwgYXJ0d29yayBieSB0aGUgYXV0aG9yIHRvIGV4cGxhaW4gaGlzIGlkZWFzLCB0aGlzIGJvb2sgd2lsbCBiZSBhbiBlc3NlbnRpYWwgcmVmZXJlbmNlIGFuZCBzb3VyY2Ugb2YgaW5zcGlyYXRpb24gZm9yIHN0dWRlbnRzIGFuZCBkZXNpZ24gcHJvZmVzc2lvbmFscy4iXSwiYmliX3JlZl9ub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGJpYmxpb2dyYXBoaWNhbCByZWZlcmVuY2VzIGFuZCBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJjb250ZW50c19kaXNwbGF5IjpbIkludHJvZHVjdGlvbiAtLSAxLiBWaXN1YWwgTG9naWMgLS0gVmlzdWFsIExvZ2ljIFRocm91Z2ggVGltZSAtLSAyLiBOZW9saXRoaWMgR2VvbWV0cmllcyAtLSAzLiBUaGUgUml2ZXIgQ3VsdHVyZXMgLS0gNC4gTmF0aXZlIEFtZXJpY2FuIEN1bHR1cmVzIC0tIDUuIFRoZSBQeXRoYWdvcmVhbnMgLS0gNi4gRXVyb3BlYW4gVHJpYmFsIEdlb21ldHJ5IC0tIDcuIEdlb21ldHJpZXMgb2YgdGhlIEVhcmx5IElzbGFtaWMgUGVyaW9kIC0tIDguIFRoZSBSZW5haXNzYW5jZSAtLSBPdXQgb2YgdGhlIFBhc3QgLS0gSW50byB0aGUgRnV0dXJlIC0tIDkuIE1vZGVsbGluZyB3aXRoIEVxdWF0aW9ucyAtLSAxMC4gRnJhY3RhbHMgLS0gMTEuIFNoYXBlLUNoYW5nZXJzIC0tIDEyLiBEeW5hbWljIENpcmNsZXMgYW5kIFNwaGVyZXMgLS0gMTMuIFRoZSBGdXR1cmUgb2YgM0QgR2VvbWV0cnkgLS0gMTQuIEFkZGl0aW9uYWwgVGhvdWdodHMgYW5kIElkZWFzLiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiR2VvbWV0cnkgaW4gYXJjaGl0ZWN0dXJl4oCUSGlzdG9yeSIsIkFyY2hpdGVjdHVyZeKAlE1hdGhlbWF0aWNzIiwiQXJjaGl0ZWN0dXJhbCBkZXNpZ27igJRIaXN0b3J5IiwiRGVjb3JhdGlvbiBhbmQgb3JuYW1lbnQsIEFyY2hpdGVjdHVyYWzigJRIaXN0b3J5IiwiQXJjaGl0ZWN0dXJlLCBBbmNpZW504oCUSW5mbHVlbmNlIiwiQ2l2aWxpemF0aW9uLCBBbmNpZW504oCUSW5mbHVlbmNlIiwiVGhyZWUtZGltZW5zaW9uYWwgaW1hZ2luZyBpbiBhcmNoaXRlY3R1cmUiXSwic3ViamVjdF9mYWNldCI6WyJHZW9tZXRyeSBpbiBhcmNoaXRlY3R1cmXigJRIaXN0b3J5IiwiQXJjaGl0ZWN0dXJl4oCUTWF0aGVtYXRpY3MiLCJBcmNoaXRlY3R1cmFsIGRlc2lnbuKAlEhpc3RvcnkiLCJEZWNvcmF0aW9uIGFuZCBvcm5hbWVudCwgQXJjaGl0ZWN0dXJhbOKAlEhpc3RvcnkiLCJBcmNoaXRlY3R1cmUsIEFuY2llbnTigJRJbmZsdWVuY2UiLCJDaXZpbGl6YXRpb24sIEFuY2llbnTigJRJbmZsdWVuY2UiLCJUaHJlZS1kaW1lbnNpb25hbCBpbWFnaW5nIGluIGFyY2hpdGVjdHVyZSJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiSGlzdG9yeSJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4MDUwMDUxOTU0NyAoKGhhcmRjb3ZlcikpIiwiMDUwMDUxOTU0NCAoKGhhcmRjb3ZlcikpIl0sImxjY25fZGlzcGxheSI6WyIgIDIwMTc5NTgxMjciXSwibGNjbl9zIjpbIjIwMTc5NTgxMjciXSwiaXNibl9zIjpbIjk3ODA1MDA1MTk1NDciXSwib2NsY19zIjpbIjEwMDUxMDM2MTUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9uMTAwNTEwMzYxNSIsIjk3ODA1MDA1MTk1NDciXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIxMDY3MjU4M1wiOntcImxvY2F0aW9uXCI6XCJBcmNoaXRlY3R1cmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiQXJjaGl0ZWN0dXJlIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcInVlc1wiLFwiY2FsbF9udW1iZXJcIjpcIk5BMjc1MCAuQjg2NyAyMDE4XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIk5BMjc1MCAuQjg2NyAyMDE4XCJ9fSIsImZvcm1fZ2VucmVfcmVtYWluaW5nX2Rpc3BsYXkiOlsiSGlzdG9yeSJdLCJsb2NhdGlvbl9jb2RlX3MiOlsidWVzIl0sImxvY2F0aW9uIjpbIkFyY2hpdGVjdHVyZSBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiQXJjaGl0ZWN0dXJlIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJ1ZXMiLCJBcmNoaXRlY3R1cmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkJ1cnJvd3MsIFJvZ2VyLCAxOTQ1LS4gM0QgdGhpbmtpbmcgaW4gZGVzaWduIGFuZCBhcmNoaXRlY3R1cmUiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJOQTI3NTAgLkI4NjcgMjAxOCJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJOQTI3NTAgLkI4NjcgMjAxOCJdLCJfdmVyc2lvbl8iOjE2MjExNDE2OTk0MTk5NjMzOTIsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjM6NTM6MjEuOTM5WiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 13:34:22 GMT
 - request:
     method: get
@@ -11104,7 +11104,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjMwMTg1NjciLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIk1hcnlsYW5kIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hcnlsYW5kIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W10sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiTWFyeWxhbmRcIn0iLCJhdXRob3JfcyI6WyJNYXJ5bGFuZCJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQuIiwidGl0bGVfdCI6WyJBbiBhY3QgdG8gc2VjdXJlIGZhaXIgZWxlY3Rpb25zIGluIE1hcnlsYW5kLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuIGFjdCB0byBzZWN1cmUgZmFpciBlbGVjdGlvbnMgaW4gTWFyeWxhbmQuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiW24ucC4sIG4uZC5dIl0sInB1Yl9jcmVhdGVkX3MiOlsiW24ucC4sIG4uZC5dIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIm4ucC4iXSwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyI0MSBwLiAyNCBjbS4iXSwiZGVzY3JpcHRpb25fdCI6WyI0MSBwLiAyNCBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiNDEgcC4iXSwic2VyaWVzX2Rpc3BsYXkiOlsiSGlzdG9yeSwgdi4gMzU2LiJdLCJtb3JlX2luX3RoaXNfc2VyaWVzX3QiOlsiSGlzdG9yeSJdLCJub3Rlc19kaXNwbGF5IjpbIkhhbGYtdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIkVsZWN0aW9uIGxhd+KAlE1hcnlsYW5kIl0sInN1YmplY3RfZmFjZXQiOlsiRWxlY3Rpb24gbGF34oCUTWFyeWxhbmQiXSwib2NsY19zIjpbIjI3NDEyOTA4Il0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20yNzQxMjkwOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjMzMzQ3OTJcIjp7XCJsb2NhdGlvblwiOlwiRm9ycmVzdGFsIEFubmV4IC0gUHJpbmNldG9uIENvbGxlY3Rpb25cIixcImxpYnJhcnlcIjpcIkZvcnJlc3RhbCBBbm5leFwiLFwibG9jYXRpb25fY29kZVwiOlwicFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJQOTQuODQ5LjAzNi4xNVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJQOTQuODQ5LjAzNi4xNVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicCJdLCJsb2NhdGlvbiI6WyJGb3JyZXN0YWwgQW5uZXgiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGb3JyZXN0YWwgQW5uZXggLSBQcmluY2V0b24gQ29sbGVjdGlvbiJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInAiLCJGb3JyZXN0YWwgQW5uZXgiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJNYXJ5bGFuZC4gQW4gYWN0IHRvIHNlY3VyZSBmYWlyIGVsZWN0aW9ucyBpbiBNYXJ5bGFuZCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIlA5NC44NDkuMDM2LjE1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIlA5NC44NDkuMDM2LjE1Il0sIl92ZXJzaW9uXyI6MTYyMTExNzI5NzEwNjA5MjAzMiwidGltZXN0YW1wIjoiMjAxOC0xMi0yOFQxNzoyNTozMC4wNTRaIn0=
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 13:34:22 GMT
 - request:
     method: get
@@ -11158,7 +11158,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjMwOCIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJ1bmlmb3JtX3RpdGxlX3MiOlsiSGFyZCB0aW1lcyAoV2FzaGluZ3RvbiwgRC5DLikiXSwidGl0bGVfZGlzcGxheSI6IkhhcmQgdGltZXMuIiwidGl0bGVfdCI6WyJIYXJkIHRpbWVzLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkhhcmQgdGltZXMiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkhhcmQgdGltZXMuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiV2FzaGluZ3RvbiwgRC5DLiA6IE5ldyBXZWVrbHkgUHJvamVjdCwiXSwicHViX2NyZWF0ZWRfcyI6WyJXYXNoaW5ndG9uLCBELkMuIDogTmV3IFdlZWtseSBQcm9qZWN0LCJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJXYXNoaW5ndG9uLCBELkMuOiBOZXcgV2Vla2x5IFByb2plY3QiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTY5Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NjksInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTcwLCJmb3JtYXQiOlsiSm91cm5hbCJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjY2IHYuIDsgMjggY20uIiwiTm8uIDIyIChNYXIuIDEwLzE3IDE5NjkpLW5vLiA4NyAoU2VwdC4gMTQsIDE5NzApLiJdLCJkZXNjcmlwdGlvbl90IjpbIjY2IHYuIDsgMjggY20uIiwiTm8uIDIyIChNYXIuIDEwLzE3IDE5NjkpLW5vLiA4NyAoU2VwdC4gMTQsIDE5NzApLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2NiB2LiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJjb250aW51ZXNfZGlzcGxheSI6WyJNYXlkYXkgKFdhc2hpbmd0b24sIEQuIEMuKSJdLCJhYnNvcmJlZF9ieV9kaXNwbGF5IjpbIlJhbXBhcnRzIChCZXJrZWxleSwgQ2FsaWYuKSJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJXZWVrbHkgKGJpd2Vla2x5IGR1cmluZyBKdWx5IGFuZCBBdWcuKSJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJSYWRpY2FsaXNt4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIl0sInN1YmplY3RfZmFjZXQiOlsiUmFkaWNhbGlzbeKAlFVuaXRlZCBTdGF0ZXPigJRQZXJpb2RpY2FscyJdLCJpc3NuX2Rpc3BsYXkiOlsiMDAyNS02MTQ1Il0sImlzc25fcyI6WyIwMDI1NjE0NSJdLCJvY2xjX3MiOlsiMjI0NDYxOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiMDAyNTYxNDUiLCJvY20wMjI0NDYxOCJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjM0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUCAtIFVzZSBpbiBGaXJlc3RvbmUgTWljcm9mb3JtcyBvbmx5XCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGZcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiTUlDUk9GSUxNIFMwMDUzNFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJNSUNST0ZJTE0gUzAwNTM0XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJOby4gMjIgKE1hci4gMTAvMTcgMTk2OSktbm8uIDQ3IChPY3QuIDYsIDE5NjkpXCIsXCJOby4gMjItNDcgb24gcmVlbCB3aXRoIG5vLiAxLTIxIG9mIHRoZSBlYXJsaWVyIHRpdGxlLlwiXX0sXCIzNDJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIk92ZXJzaXplIEhYMSAuSDM3M3FcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSFgxIC5IMzczcVwiLFwibG9jYXRpb25faGFzXCI6W1wiTm8uIDgyIChKdW5lIDI5LCAxOTcwKS1uby4gODcgKFNlcHQuIDE0LCAxOTcwKVwiLFwiTEFDS1M6IG5vLiA4M1wiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBmIiwiZiJdLCJsb2NhdGlvbiI6WyJSZUNBUCIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAgLSBVc2UgaW4gRmlyZXN0b25lIE1pY3JvZm9ybXMgb25seSIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsicmNwcGYiLCJmIiwiUmVDQVAiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJPdmVyc2l6ZSBIWDEgLkgzNzNxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIk1JQ1JPRklMTSBTMDA1MzQiLCJIWDEgLkgzNzNxIl0sIl92ZXJzaW9uXyI6MTYyMTEwNjAxODk2NjU2ODk2MCwidGltZXN0YW1wIjoiMjAxOC0xMi0yOFQxNDoyNjoxNC40NjZaIn0=
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 13:34:23 GMT
 - request:
     method: get
@@ -11212,7 +11212,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjQ4ODg0OTQiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlNhbmJvcm4gTWFwIENvbXBhbnkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2FuYm9ybiBNYXAgQ29tcGFueSIsIkxpYnJhcnkgb2YgQ29uZ3Jlc3MiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJMaWJyYXJ5IG9mIENvbmdyZXNzXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIlNhbmJvcm4gTWFwIENvbXBhbnlcIn0iLCJhdXRob3JfcyI6WyJTYW5ib3JuIE1hcCBDb21wYW55IiwiTGlicmFyeSBvZiBDb25ncmVzcy4gTWFwIERpdmlzaW9uIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiRnJlZWhvbGQsIE4uIEouIFttYXBdLiIsInRpdGxlX3QiOlsiRnJlZWhvbGQsIE4uIEouIFttYXBdLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkZyZWVob2xkLCBOLiBKLiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRnJlZWhvbGQsIE4uIEouIFttYXBdLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIk5ldyBZb3JrIDogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkLCAxODg1LiJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkLCAxODg1LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJOZXcgWW9yazogU2FuYm9ybiBNYXAgXHUwMDI2IFB1Ymxpc2hpbmcgQ28uLCBMaW1pdGVkIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTg4NSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxODg1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0xOFQxODo1OTowMFoiLCJmb3JtYXQiOlsiTWFwIl0sImVsZWN0cm9uaWNfYWNjZXNzXzFkaXNwbGF5Ijoie1wiaHR0cHM6Ly9jYXRhbG9nLnByaW5jZXRvbi5lZHUvY2F0YWxvZy80ODg4NDk0I3ZpZXdcIjpbXCJEaWdpdGFsIGNvbnRlbnRcIl0sXCJpaWlmX21hbmlmZXN0X3BhdGhzXCI6e1wiaHR0cDovL2Fya3MucHJpbmNldG9uLmVkdS9hcms6Lzg4NDM1L241ODN4eDkxeFwiOlwiaHR0cHM6Ly9maWdneS5wcmluY2V0b24uZWR1L2NvbmNlcm4vc2Nhbm5lZF9tYXBzL2JhMjhkYTFhLTBiMmQtNDRhMC1iNDU1LTIyYjVmZTc1MzJmMy9tYW5pZmVzdFwifX0iLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjEgbWFwIG9uIDMgc2hlZXRzIDogY29sLiA7IGVhY2ggNjQgeCA1NCBjbS4iXSwiZGVzY3JpcHRpb25fdCI6WyJTY2FsZSBbY2EuIDE6NjAwXS4gNTAgZnQuIHRvIGFuIGluY2guIiwiMSBtYXAgb24gMyBzaGVldHMgOiBjb2wuIDsgZWFjaCA2NCB4IDU0IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxIG1hcCBvbiAzIHNoZWV0cyJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiTmV3IEplcnNleSJdLCJzY2FsZV9kaXNwbGF5IjpbIlNjYWxlIFtjYS4gMTo2MDBdLiA1MCBmdC4gdG8gYW4gaW5jaC4iXSwibm90ZXNfZGlzcGxheSI6WyJcIkphbi4gMTg4NS5cIiIsIkluY2x1ZGVzIGtleSBhbmQgdGV4dC4iLCJOb3J0aCBvcmllbnRlZCB0b3dhcmQgdXBwZXIgbGVmdC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJwcm92ZW5hbmNlX2Rpc3BsYXkiOlsiSGlzdG9yaWMgTWFwcyBjb3B5IGhhcyBzdGFtcCBvZiBNYXAgRGl2aXNpb24sIExpYnJhcnkgb2YgQ29uZ3Jlc3MsIGRhdGVkIE1hci4gNiwgMTg4NS4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlJlYWwgcHJvcGVydHnigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJRNYXBzIiwiRnJlZWhvbGQgKE4uSi4p4oCUTWFwcyJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiRmlyZSBpbnN1cmFuY2UgbWFwc+KAlE5ldyBKZXJzZXnigJRGcmVlaG9sZOKAlDE4ODUiLCJNYXBz4oCUTmV3IEplcnNleeKAlEZyZWVob2xk4oCUMTg4NSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIkZvcm1lciBvd25lclwiOltcIkxpYnJhcnkgb2YgQ29uZ3Jlc3MuIE1hcCBEaXZpc2lvblwiXX0iLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjUwODU0OTNcIjp7XCJsb2NhdGlvblwiOlwiUmVDQVAgLSBIaXN0b3JpYyBNYXBzIE9mZi1TaXRlIFN0b3JhZ2VcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJyY3B4cFwiLFwiY2FsbF9udW1iZXJcIjpcIkhNQzA0IChGcmVlaG9sZClcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSE1DMDQgKEZyZWVob2xkKVwifSxcIjc0MjYyNzJcIjp7XCJsb2NhdGlvblwiOlwiT25saW5lIC0gKk9OTElORSpcIixcImxpYnJhcnlcIjpcIk9ubGluZVwiLFwibG9jYXRpb25fY29kZVwiOlwiZWxmMVwiLFwiY2FsbF9udW1iZXJcIjpcIkVsZWN0cm9uaWMgUmVzb3VyY2VcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwifX0iLCJmb3JtX2dlbnJlX3JlbWFpbmluZ19kaXNwbGF5IjpbIkZpcmUgaW5zdXJhbmNlIG1hcHPigJROZXcgSmVyc2V54oCURnJlZWhvbGTigJQxODg1IiwiTWFwc+KAlE5ldyBKZXJzZXnigJRGcmVlaG9sZOKAlDE4ODUiXSwibG9jYXRpb25fY29kZV9zIjpbInJjcHhwIiwiZWxmMSJdLCJsb2NhdGlvbiI6WyJSZUNBUCIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCAtIEhpc3RvcmljIE1hcHMgT2ZmLVNpdGUgU3RvcmFnZSIsIk9ubGluZSAtICpPTkxJTkUqIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsicmNweHAiLCJlbGYxIiwiUmVDQVAiLCJPbmxpbmUiLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiU2FuYm9ybiBNYXAgQ29tcGFueS4gRnJlZWhvbGQsIE4uIEouIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiSE1DMDQgKEZyZWVob2xkKSIsIkVsZWN0cm9uaWMgUmVzb3VyY2UiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSE1DMDQgKEZyZWVob2xkKSIsIkVsZWN0cm9uaWMgUmVzb3VyY2UiXSwiX3ZlcnNpb25fIjoxNjIxMTIzNDAwNjQwNDk1NjE2LCJ0aW1lc3RhbXAiOiIyMDE4LTEyLTI4VDE5OjAyOjMwLjg5OFoifQ==
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 13:34:23 GMT
 - request:
     method: get
@@ -11267,7 +11267,7 @@ http_interactions:
         Library","code":"architecture"},"delivery_locations":[{"label":"Architecture
         Library","address":"School of Architecture Building, Second Floor Princeton,
         NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 13:37:58 GMT
 - request:
     method: get
@@ -11321,7 +11321,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6Ijk5NDQzNTUiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJhdXRob3JfcyI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NyZWF0ZWRfcyI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2VuZWdhbDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNiJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE2LCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDktMjBUMjA6MzQ6MTRaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJBZnJpY2EiLCJTZW5lZ2FsIl0sImNvbnRpbnVlc19kaXNwbGF5IjpbIkXMgWNyaXZhaW4sIGpvdXJuYWwgY3VsdHVyZWwgcGFuYWZyaWNhaW4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbjogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pOyB0aXRsZSBmcm9tIGNvdmVyLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IEhvcnMgc2XMgXJpZSAocHVibGlzaGVkIGluIDIwMTY/KS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImZyIl0sInN1YmplY3RfZGlzcGxheSI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJfdmVyc2lvbl8iOjE2MjExMzgyMTYwMDIyNTY4OTYsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjI6NTc6NTkuOTQwWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:17:25 GMT
 - request:
     method: get
@@ -11397,7 +11397,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"_version_":1621123173478039552,"timestamp":"2018-12-28T18:58:54.113Z"}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:18:13 GMT
 - request:
     method: get
@@ -11473,7 +11473,7 @@ http_interactions:
         Library","Stokes Library","Firestone Library","Marquand Library"],"name_title_browse_s":["Tufte,
         Edward R., 1942-. Beautiful evidence"],"call_number_display":["P93.5 .T847
         2006"],"call_number_browse_s":["P93.5 .T847 2006"],"_version_":1621123173478039552,"timestamp":"2018-12-28T18:58:54.113Z"}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:18:16 GMT
 - request:
     method: get
@@ -11527,7 +11527,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6Ijk5NDQzNTUiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbCJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkFzc29jaWF0aW9uIGRlcyBlzIFjcml2YWlucyBkdSBTZcyBbmXMgWdhbFwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJhdXRob3JfcyI6WyJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWwiXSwidW5pZm9ybV90aXRsZV9zIjpbIkXMgWNyaXZhaW4gKERha2FyLCBTZW5lZ2FsIDogMjAxNikiXSwidGl0bGVfZGlzcGxheSI6IkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iLCJ0aXRsZV90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJMJ2XMgWNyaXZhaW4sIG1hZ2F6aW5lIGxpdHRlcmFpcmUgdHJpbWVzdHJpZWwiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkwnZcyBY3JpdmFpbiwgbWFnYXppbmUgbGl0dGVyYWlyZSB0cmltZXN0cmllbC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NyZWF0ZWRfcyI6WyJTZW5lZ2FsIDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsLCBbZGF0ZSBvZiBwdWJsaWNhdGlvbiBub3QgaWRlbnRpZmllZF0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiU2VuZWdhbDogQ2Fpc3NlIGRlIFNlY3VyaXRlIFNvY2lhbCBkdSBTZW5lZ2FsIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNiJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE2LCJwdWJfZGF0ZV9lbmRfc29ydCI6OTk5OSwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMDktMjBUMjA6MzQ6MTRaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJBZnJpY2EiLCJTZW5lZ2FsIl0sImNvbnRpbnVlc19kaXNwbGF5IjpbIkXMgWNyaXZhaW4sIGpvdXJuYWwgY3VsdHVyZWwgcGFuYWZyaWNhaW4iXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbjogSG9ycyBzZcyBcmllIChwdWJsaXNoZWQgaW4gMjAxNj8pOyB0aXRsZSBmcm9tIGNvdmVyLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IEhvcnMgc2XMgXJpZSAocHVibGlzaGVkIGluIDIwMTY/KS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRnJlbmNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJmcmUiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImZyIl0sInN1YmplY3RfZGlzcGxheSI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJBdXRob3JzLCBBZnJpY2Fu4oCUUGVyaW9kaWNhbHMiLCJTZW5lZ2Fs4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJJc3N1aW5nIGJvZHlcIjpbXCJBc3NvY2lhdGlvbiBkZXMgZcyBY3JpdmFpbnMgZHUgU2XMgW5lzIFnYWxcIl19Iiwib3RoZXJfdmVyc2lvbl9zIjpbIjA4NTIwMDExIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTc1NzUxMVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkRUNTQ5IC5FMjc0cVwiLFwibG9jYXRpb25faGFzXCI6W1wiSG9ycyBzZcyBcmllICgyMDE2KVwiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIl0sImxvY2F0aW9uIjpbIlJlQ0FQIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJyY3BwYSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiT3ZlcnNpemUgRFQ1NDkgLkUyNzRxIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkRUNTQ5IC5FMjc0cSJdLCJfdmVyc2lvbl8iOjE2MjExMzgyMTYwMDIyNTY4OTYsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjI6NTc6NTkuOTQwWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:18:18 GMT
 - request:
     method: get
@@ -11581,7 +11581,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjMzNjUyNSIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgQXJ0Il0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnNcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU3BpZWdlbG1hbiwgQXJ0XCJ9IiwiYXV0aG9yX3MiOlsiU3BpZWdlbG1hbiwgQXJ0IiwiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnMiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJNYXVzIDogYSBzdXJ2aXZvcidzIHRhbGUgLyBieSBBcnQgU3BpZWdlbG1hbi4iLCJ0aXRsZV90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBQYW50aGVvbiBCb29rcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5ODYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk4NiwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDU6MDA6MDBaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIxNTkgcC4gOiBpbGwuIDsgMjMgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNTkgcC4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdfSIsImlzYm5fZGlzcGxheSI6WyIwMzk0NzQ3MjMyIDoiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDg2MDQyNjQyICJdLCJsY2NuX3MiOlsiODYwNDI2NDIiXSwiaXNibl9zIjpbIjk3ODAzOTQ3NDcyMzEiXSwib2NsY19zIjpbIjEzNTI0MzE0Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwMzk0NzQ3MjMxIiwib2NtMTM1MjQzMTQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIzNjc4ODJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCJ9LFwiMzY3ODgzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJQcmluY2V0b24gY29weSAxXCJdfX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiIsImV4Il0sImxvY2F0aW9uIjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3MiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiZXgiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTcGllZ2VsbWFuLCBBcnQuIE1hdXMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJfdmVyc2lvbl8iOjE2MjExMDczNTM5ODYyNjkxODQsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMTQ6NDc6MjcuNTkzWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:39 GMT
 - request:
     method: get
@@ -11635,7 +11635,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjMzNjUyNSIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX2Rpc3BsYXkiOlsiU3BpZWdlbG1hbiwgQXJ0Il0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIEFydCIsIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnNcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiU3BpZWdlbG1hbiwgQXJ0XCJ9IiwiYXV0aG9yX3MiOlsiU3BpZWdlbG1hbiwgQXJ0IiwiTGVvbmFyZCBMLiBNaWxiZXJnIENvbGxlY3Rpb24gb2YgSmV3aXNoIEFtZXJpY2FuIFdyaXRlcnMiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJNYXVzIDogYSBzdXJ2aXZvcidzIHRhbGUgLyBieSBBcnQgU3BpZWdlbG1hbi4iLCJ0aXRsZV90IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSAvIGJ5IEFydCBTcGllZ2VsbWFuLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1hdXMgOiBhIHN1cnZpdm9yJ3MgdGFsZSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiTWF1cyA6IGEgc3Vydml2b3IncyB0YWxlIC8gYnkgQXJ0IFNwaWVnZWxtYW4uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBQYW50aGVvbiBCb29rcywgYzE5ODYuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBQYW50aGVvbiBCb29rcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjE5ODYiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MTk4NiwiY2F0YWxvZ2VkX3RkdCI6IjIwMDAtMDYtMTNUMDU6MDA6MDBaIiwiZm9ybWF0IjpbIkJvb2siXSwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIxNTkgcC4gOiBpbGwuIDsgMjMgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTU5IHAuIDogaWxsLiA7IDIzIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNTkgcC4iXSwibm90ZXNfZGlzcGxheSI6WyJQcmluY2V0b24gY29weSAxIGlzIGdpZnQgb2YgTGVvbmFyZCBMLiBNaWxiZXJnICc1MyBpbiBob25vciBvZiBQcmVzaWRlbnQgSGFyb2xkIFQuIFNoYXBpcm8uIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwic3ViamVjdF9kaXNwbGF5IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlNwaWVnZWxtYW4sIFZsYWRla+KAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyIsIkhvbG9jYXVzdCwgSmV3aXNoICgxOTM5LTE5NDUp4oCUUG9sYW5k4oCUQmlvZ3JhcGh54oCUQ29taWMgYm9va3MsIHN0cmlwcywgZXRjIiwiSG9sb2NhdXN0IHN1cnZpdm9yc+KAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHnigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJTcGllZ2VsbWFuLCBBcnTigJRDb21pYyBib29rcywgc3RyaXBzLCBldGMiLCJDaGlsZHJlbiBvZiBIb2xvY2F1c3Qgc3Vydml2b3Jz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeeKAlENvbWljIGJvb2tzLCBzdHJpcHMsIGV0YyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkxlb25hcmQgTC4gTWlsYmVyZyBDb2xsZWN0aW9uIG9mIEpld2lzaCBBbWVyaWNhbiBXcml0ZXJzXCJdfSIsImlzYm5fZGlzcGxheSI6WyIwMzk0NzQ3MjMyIDoiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDg2MDQyNjQyICJdLCJsY2NuX3MiOlsiODYwNDI2NDIiXSwiaXNibl9zIjpbIjk3ODAzOTQ3NDcyMzEiXSwib2NsY19zIjpbIjEzNTI0MzE0Il0sIm90aGVyX3ZlcnNpb25fcyI6WyI5NzgwMzk0NzQ3MjMxIiwib2NtMTM1MjQzMTQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIzNjc4ODJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkQ4MTAuSjQgUzY0MyAxOTg2XCJ9LFwiMzY3ODgzXCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJleFwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJEODEwLko0IFM2NDMgMTk4NiBNaWxiZXJnIEpBbVdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRDgxMC5KNCBTNjQzIDE5ODYgTWlsYmVyZyBKQW1XXCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJQcmluY2V0b24gY29weSAxXCJdfX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiIsImV4Il0sImxvY2F0aW9uIjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3MiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiZXgiLCJGaXJlc3RvbmUgTGlicmFyeSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJTcGllZ2VsbWFuLCBBcnQuIE1hdXMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEODEwLko0IFM2NDMgMTk4NiIsIkQ4MTAuSjQgUzY0MyAxOTg2IE1pbGJlcmcgSkFtVyJdLCJfdmVyc2lvbl8iOjE2MjExMDczNTM5ODYyNjkxODQsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMTQ6NDc6MjcuNTkzWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:40 GMT
 - request:
     method: get
@@ -11689,7 +11689,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjEwMTQ0Njk4IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb2xmZXIsIEFkYW0iLCLXkteV15zXpNeoLCDXkNeT150iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiR29sZmVyLCBBZGFtXCIsXCJHb2xmZXIsIEFkYW1cIixcIkdvbGZlciwgQWRhbVwiLFwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlXCIsXCLXkteV15zXpNeoLCDXkNeT151cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiR29sZmVyLCBBZGFtXCJ9IiwiYXV0aG9yX3MiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIiwi15LXldec16TXqCwg15DXk9edIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIlBob3RvZ3JhcGhlciJdLCJ1bmlmb3JtX3RpdGxlX3MiOlsiUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwidGl0bGVfZGlzcGxheSI6IkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIiwidGl0bGVfdCI6WyJBIGhvdXNlIHdpdGhvdXQgYSByb29mIC8gQWRhbSBHb2xmZXIgOyB0cmFuc2xhdGlvbnM6IE1vc3RhZmEgT3VhamphbmkgKEFyYWJpYyksIEdhYnJpZWxhIFZhaW5zZW5jaGVyIChIZWJyZXcpLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIl0sImVkaXRpb25fZGlzcGxheSI6WyJGaXJzdCBlZGl0aW9uLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY3JlYXRlZF9zIjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJCcm9va2x5biwgTmV3IFlvcms6IEJvb2tseW4iXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTYsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTAzLTMwVDE5OjQ2OjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIDogaWxsdXN0cmF0aW9ucyAoY2hpZWZseSBjb2xvcikgOyAzMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjE2MSBwYWdlcyA6IGlsbHVzdHJhdGlvbnMgKGNoaWVmbHkgY29sb3IpIDsgMzAgY20iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJJc3JhZWwiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiU2hvcnRsaXN0ZWQgZm9yIHRoZSBQYXJpcy1QaG90by8gQXBlcnR1cmUgRmlyc3QgQm9vayBBd2FyZCwgJ0EgSG91c2UgV2l0aG91dCBhIFJvb2YnIGNvbnNpZGVycyB0aGUgb3ZlcmxhcHBpbmcgaGlzdG9yaWVzIG9mIHZpb2xlbmNlIGFuZCBkaXNwbGFjZW1lbnQgY29ubmVjdGluZyBFdXJvcGUsIElzcmFlbCBhbmQgUGFsZXN0aW5lLiBXaXRoIHBob3RvZ3JhcGhzLCBhcmNoaXZhbCBpbWFnZXJ5IGFuZCBvcmlnaW5hbCB0ZXh0cywgQnJvb2tseW4tYmFzZWQgYXJ0aXN0IEFkYW0gR29sZmVyIHdlYXZlcyB0b2dldGhlciBmaWN0aW9ucyBvZiBoaXMgZmFtaWx5IGhpc3Rvcnkgd2l0aCByZXByZXNlbnRhdGlvbnMgZnJvbSBJc3JhZWw/cyBmb3VuZGluZyBhbmQgb25nb2luZyBtaWxpdGFyeSBvY2N1cGF0aW9uLiBFdGhuaWMgYW5kIG5hdGlvbmFsIGlkZW50aXRpZXMgYXJlIHJ1cHR1cmVkIGFuZCByZWFzc2VtYmxlZCBhcyBoZSBpbnRlcnJvZ2F0ZXMgY29udHJhZGljdG9yeSBoaXN0b3JpZXMgYW5kIG5vdGlvbnMgb2Ygc2VsZmhvb2QsIGV4cGxvcmluZyBzdHJhbmRzIHRoYXQgY29ubmVjdCB0aGUgSmV3aXNoIERpYXNwb3JhIG91dCBvZiBFdXJvcGUgYW5kIGZvcmNlZCBtYXNzIG1pZ3JhdGlvbnMgZnJvbSBQYWxlc3RpbmUgZm9sbG93aW5nIFdvcmxkIFdhciBJSS4gR29sZmVyIHNpdHVhdGVzIHRoaXMgaW5xdWlyeSB0aHJvdWdoIHRoZSB0cmlhbmd1bGFyIHJlbGF0aW9uc2hpcCBiZXR3ZWVuIGhpcyBncmFuZGZhdGhlciAoYSBzdXJ2aXZvciBvZiBEYWNoYXUpLCBoaXMgZmF0aGVyICh3aG8gbGl2ZWQgb24gYSBraWJidXR6IGluIHRoZSBlYXJseSAxOTcwcykgYW5kIGhpbXNlbGYuIl0sIm5vdGVzX2Rpc3BsYXkiOlsiQ292ZXIgdGl0bGUuIiwiUHVibGlzaGVkIG9uIHRoZSBvY2Nhc2lvbiBvZiBhbiBleGhpYml0aW9uIGhlbGQgYXQgQm9va2x5biwgSnVseSAxMC1TZXB0ZW1iZXIgNSwgMjAxNS4iXSwibGFuZ3VhZ2VfZGlzcGxheSI6WyJUZXh0IGluIEVuZ2xpc2ggd2l0aCBIZWJyZXcgYW5kIEFyYWJpYyBhdCB0aGUgYm90dG9tIG9mIHRoZSBwYWdlcy4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCIsIkhlYnJldyIsIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIiwiaGViIiwiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiIsImhlIiwiYXIiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIkhvc3QgaW5zdGl0dXRpb25cIjpbXCJCb29rbHluIEFydGlzdHMgQWxsaWFuY2VcIl19IiwiY29udGFpbnNfMWRpc3BsYXkiOiJbW1wiR29sZmVyLCBBZGFtLlwiLFwiSG91c2Ugd2l0aG91dCBhIHJvb2YuXCJdLFtcIkdvbGZlciwgQWRhbS5cIixcIkhvdXNlIHdpdGhvdXQgYSByb29mLlwiLFwiSGVicmV3LlwiXSxbXCJHb2xmZXIsIEFkYW0uXCIsXCJIb3VzZSB3aXRob3V0IGEgcm9vZi5cIixcIkFyYWJpYy5cIl1dIiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyJCYXlpdCBiZWxpIGdhZyIsIteR15nXqiDXkdec15kg15LXkiJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiQmF5aXQgYmVsaSBnYWciLCLXkdeZ16og15HXnNeZINeS15IiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODA2OTI3MjY1MDEiLCIwNjkyNzI2NTAwIl0sImlzYm5fcyI6WyI5NzgwNjkyNzI2NTAxIl0sIm9jbGNfcyI6WyI5ODE3NjY2NjAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjk4MTc2NjY2MCIsIjk3ODA2OTI3MjY1MDEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5OTMzODc4XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBqXCIsXCJjYWxsX251bWJlclwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBqIl0sImxvY2F0aW9uIjpbIlJlQ0FQIiwiTWFycXVhbmQgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBqIiwiUmVDQVAiLCJNYXJxdWFuZCBMaWJyYXJ5Il0sIm5hbWVfdW5pZm9ybV90aXRsZV8xZGlzcGxheSI6IltbXCJHb2xmZXIsIEFkYW0uXCIsXCJQaG90b2dyYXBocy5cIixcIlNlbGVjdGlvbnNcIl1dIiwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb2xmZXIsIEFkYW0uIEhvdXNlIHdpdGhvdXQgYSByb29mIiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gSGVicmV3IiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gQXJhYmljIiwiR29sZmVyLCBBZGFtLiBQaG90b2dyYXBocyIsIkdvbGZlciwgQWRhbS4gUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJfdmVyc2lvbl8iOjE2MjExMzg5MjM3NDM4NzA5NzYsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjM6MDk6MTQuODM2WiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:47 GMT
 - request:
     method: get
@@ -11743,7 +11743,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjEwMTQ0Njk4IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJHb2xmZXIsIEFkYW0iLCLXkteV15zXpNeoLCDXkNeT150iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiR29sZmVyLCBBZGFtXCIsXCJHb2xmZXIsIEFkYW1cIixcIkdvbGZlciwgQWRhbVwiLFwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlXCIsXCLXkteV15zXpNeoLCDXkNeT151cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiR29sZmVyLCBBZGFtXCJ9IiwiYXV0aG9yX3MiOlsiR29sZmVyLCBBZGFtIiwiQm9va2x5biBBcnRpc3RzIEFsbGlhbmNlIiwi15LXldec16TXqCwg15DXk9edIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIlBob3RvZ3JhcGhlciJdLCJ1bmlmb3JtX3RpdGxlX3MiOlsiUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwidGl0bGVfZGlzcGxheSI6IkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIiwidGl0bGVfdCI6WyJBIGhvdXNlIHdpdGhvdXQgYSByb29mIC8gQWRhbSBHb2xmZXIgOyB0cmFuc2xhdGlvbnM6IE1vc3RhZmEgT3VhamphbmkgKEFyYWJpYyksIEdhYnJpZWxhIFZhaW5zZW5jaGVyIChIZWJyZXcpLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkEgaG91c2Ugd2l0aG91dCBhIHJvb2YgLyBBZGFtIEdvbGZlciA7IHRyYW5zbGF0aW9uczogTW9zdGFmYSBPdWFqamFuaSAoQXJhYmljKSwgR2FicmllbGEgVmFpbnNlbmNoZXIgKEhlYnJldykuIl0sImVkaXRpb25fZGlzcGxheSI6WyJGaXJzdCBlZGl0aW9uLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY3JlYXRlZF9zIjpbIkJyb29rbHluLCBOZXcgWW9yayA6IEJvb2tseW4sIFsyMDE2XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJCcm9va2x5biwgTmV3IFlvcms6IEJvb2tseW4iXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE2Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTYsImNhdGFsb2dlZF90ZHQiOiIyMDE3LTAzLTMwVDE5OjQ2OjAwWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIDogaWxsdXN0cmF0aW9ucyAoY2hpZWZseSBjb2xvcikgOyAzMCBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjE2MSBwYWdlcyA6IGlsbHVzdHJhdGlvbnMgKGNoaWVmbHkgY29sb3IpIDsgMzAgY20iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiMTYxIHBhZ2VzIl0sImdlb2NvZGVfZGlzcGxheSI6WyJJc3JhZWwiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiU2hvcnRsaXN0ZWQgZm9yIHRoZSBQYXJpcy1QaG90by8gQXBlcnR1cmUgRmlyc3QgQm9vayBBd2FyZCwgJ0EgSG91c2UgV2l0aG91dCBhIFJvb2YnIGNvbnNpZGVycyB0aGUgb3ZlcmxhcHBpbmcgaGlzdG9yaWVzIG9mIHZpb2xlbmNlIGFuZCBkaXNwbGFjZW1lbnQgY29ubmVjdGluZyBFdXJvcGUsIElzcmFlbCBhbmQgUGFsZXN0aW5lLiBXaXRoIHBob3RvZ3JhcGhzLCBhcmNoaXZhbCBpbWFnZXJ5IGFuZCBvcmlnaW5hbCB0ZXh0cywgQnJvb2tseW4tYmFzZWQgYXJ0aXN0IEFkYW0gR29sZmVyIHdlYXZlcyB0b2dldGhlciBmaWN0aW9ucyBvZiBoaXMgZmFtaWx5IGhpc3Rvcnkgd2l0aCByZXByZXNlbnRhdGlvbnMgZnJvbSBJc3JhZWw/cyBmb3VuZGluZyBhbmQgb25nb2luZyBtaWxpdGFyeSBvY2N1cGF0aW9uLiBFdGhuaWMgYW5kIG5hdGlvbmFsIGlkZW50aXRpZXMgYXJlIHJ1cHR1cmVkIGFuZCByZWFzc2VtYmxlZCBhcyBoZSBpbnRlcnJvZ2F0ZXMgY29udHJhZGljdG9yeSBoaXN0b3JpZXMgYW5kIG5vdGlvbnMgb2Ygc2VsZmhvb2QsIGV4cGxvcmluZyBzdHJhbmRzIHRoYXQgY29ubmVjdCB0aGUgSmV3aXNoIERpYXNwb3JhIG91dCBvZiBFdXJvcGUgYW5kIGZvcmNlZCBtYXNzIG1pZ3JhdGlvbnMgZnJvbSBQYWxlc3RpbmUgZm9sbG93aW5nIFdvcmxkIFdhciBJSS4gR29sZmVyIHNpdHVhdGVzIHRoaXMgaW5xdWlyeSB0aHJvdWdoIHRoZSB0cmlhbmd1bGFyIHJlbGF0aW9uc2hpcCBiZXR3ZWVuIGhpcyBncmFuZGZhdGhlciAoYSBzdXJ2aXZvciBvZiBEYWNoYXUpLCBoaXMgZmF0aGVyICh3aG8gbGl2ZWQgb24gYSBraWJidXR6IGluIHRoZSBlYXJseSAxOTcwcykgYW5kIGhpbXNlbGYuIl0sIm5vdGVzX2Rpc3BsYXkiOlsiQ292ZXIgdGl0bGUuIiwiUHVibGlzaGVkIG9uIHRoZSBvY2Nhc2lvbiBvZiBhbiBleGhpYml0aW9uIGhlbGQgYXQgQm9va2x5biwgSnVseSAxMC1TZXB0ZW1iZXIgNSwgMjAxNS4iXSwibGFuZ3VhZ2VfZGlzcGxheSI6WyJUZXh0IGluIEVuZ2xpc2ggd2l0aCBIZWJyZXcgYW5kIEFyYWJpYyBhdCB0aGUgYm90dG9tIG9mIHRoZSBwYWdlcy4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCIsIkhlYnJldyIsIkFyYWJpYyJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIiwiaGViIiwiYXJhIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiIsImhlIiwiYXIiXSwic3ViamVjdF9kaXNwbGF5IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdvbGZlciwgQWRhbeKAlEV4aGliaXRpb25zIiwiUGhvdG9ncmFwaHnigJRJc3JhZWzigJRFeGhpYml0aW9ucyIsIkRvY3VtZW50YXJ5IHBob3RvZ3JhcGh54oCURXhoaWJpdGlvbnMiLCJQaG90b2dyYXBoeSwgQXJ0aXN0aWPigJRFeGhpYml0aW9ucyIsIklkZW50aXR5IChQaGlsb3NvcGhpY2FsIGNvbmNlcHQp4oCUUGhvdG9ncmFwaHnigJRFeGhpYml0aW9ucyJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIkhvc3QgaW5zdGl0dXRpb25cIjpbXCJCb29rbHluIEFydGlzdHMgQWxsaWFuY2VcIl19IiwiY29udGFpbnNfMWRpc3BsYXkiOiJbW1wiR29sZmVyLCBBZGFtLlwiLFwiSG91c2Ugd2l0aG91dCBhIHJvb2YuXCJdLFtcIkdvbGZlciwgQWRhbS5cIixcIkhvdXNlIHdpdGhvdXQgYSByb29mLlwiLFwiSGVicmV3LlwiXSxbXCJHb2xmZXIsIEFkYW0uXCIsXCJIb3VzZSB3aXRob3V0IGEgcm9vZi5cIixcIkFyYWJpYy5cIl1dIiwib3RoZXJfdGl0bGVfZGlzcGxheSI6WyJCYXlpdCBiZWxpIGdhZyIsIteR15nXqiDXkdec15kg15LXkiJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiQmF5aXQgYmVsaSBnYWciLCLXkdeZ16og15HXnNeZINeS15IiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODA2OTI3MjY1MDEiLCIwNjkyNzI2NTAwIl0sImlzYm5fcyI6WyI5NzgwNjkyNzI2NTAxIl0sIm9jbGNfcyI6WyI5ODE3NjY2NjAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjk4MTc2NjY2MCIsIjk3ODA2OTI3MjY1MDEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5OTMzODc4XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seVwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBqXCIsXCJjYWxsX251bWJlclwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiVFI2NDcgLkc2NDg0IDIwMTZcIn19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBqIl0sImxvY2F0aW9uIjpbIlJlQ0FQIiwiTWFycXVhbmQgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJlQ0FQIC0gTWFycXVhbmQgTGlicmFyeSB1c2Ugb25seSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBqIiwiUmVDQVAiLCJNYXJxdWFuZCBMaWJyYXJ5Il0sIm5hbWVfdW5pZm9ybV90aXRsZV8xZGlzcGxheSI6IltbXCJHb2xmZXIsIEFkYW0uXCIsXCJQaG90b2dyYXBocy5cIixcIlNlbGVjdGlvbnNcIl1dIiwibmFtZV90aXRsZV9icm93c2VfcyI6WyJHb2xmZXIsIEFkYW0uIEhvdXNlIHdpdGhvdXQgYSByb29mIiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gSGVicmV3IiwiR29sZmVyLCBBZGFtLiBIb3VzZSB3aXRob3V0IGEgcm9vZi4gQXJhYmljIiwiR29sZmVyLCBBZGFtLiBQaG90b2dyYXBocyIsIkdvbGZlciwgQWRhbS4gUGhvdG9ncmFwaHMuIFNlbGVjdGlvbnMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJUUjY0NyAuRzY0ODQgMjAxNiJdLCJfdmVyc2lvbl8iOjE2MjExMzg5MjM3NDM4NzA5NzYsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjM6MDk6MTQuODM2WiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:47 GMT
 - request:
     method: get
@@ -11797,7 +11797,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjEwOTU4NzA1IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJCdXJyb3dzLCBSb2dlciwgMTk0NS0iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQnVycm93cywgUm9nZXIiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJCdXJyb3dzLCBSb2dlclwifSIsImF1dGhvcl9zIjpbIkJ1cnJvd3MsIFJvZ2VyLCAxOTQ1LSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IjNEIHRoaW5raW5nIGluIGRlc2lnbiBhbmQgYXJjaGl0ZWN0dXJlIDogZnJvbSBhbnRpcXVpdHkgdG8gdGhlIGZ1dHVyZSAvIFJvZ2VyIEJ1cnJvd3MuIiwidGl0bGVfdCI6WyIzRCB0aGlua2luZyBpbiBkZXNpZ24gYW5kIGFyY2hpdGVjdHVyZSA6IGZyb20gYW50aXF1aXR5IHRvIHRoZSBmdXR1cmUgLyBSb2dlciBCdXJyb3dzLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIjNEIHRoaW5raW5nIGluIGRlc2lnbiBhbmQgYXJjaGl0ZWN0dXJlIDogZnJvbSBhbnRpcXVpdHkgdG8gdGhlIGZ1dHVyZSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiM0QgdGhpbmtpbmcgaW4gZGVzaWduIGFuZCBhcmNoaXRlY3R1cmUgOiBmcm9tIGFudGlxdWl0eSB0byB0aGUgZnV0dXJlIC8gUm9nZXIgQnVycm93cy4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRoYW1lcyBcdTAwMjYgSHVkc29uLCAyMDE4LiIsIsKpMjAxOCJdLCJwdWJfY3JlYXRlZF9zIjpbIk5ldyBZb3JrIDogVGhhbWVzIFx1MDAyNiBIdWRzb24sIDIwMTguIiwiwqkyMDE4Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBUaGFtZXMgXHUwMDI2IEh1ZHNvbiJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwicHViX2RhdGVfZW5kX3NvcnQiOjIwMTgsImNhdGFsb2dlZF90ZHQiOiIyMDE4LTA5LTI2VDE3OjA2OjEyWiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMzI4IHBhZ2VzIDogaWxsdXN0cmF0aW9ucyAoY2hpZWZseSBjb2xvdXIpIDsgMjkgY20iXSwiZGVzY3JpcHRpb25fdCI6WyIzMjggcGFnZXMgOiBpbGx1c3RyYXRpb25zIChjaGllZmx5IGNvbG91cikgOyAyOSBjbSJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIzMjggcGFnZXMiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiVGhlIGdlb21ldHJpYyBmb3VuZGF0aW9ucywgZm9ybXMsIGFuZCBwYXR0ZXJucyBpbiB0b2RheSdzIGFyY2hpdGVjdHVyZSwgZGVzaWduIGFuZCwgZGVjb3JhdGl2ZSBhcnRzIGNhbiB0cmFjZSB0aGVpciBvcmlnaW5zIGluIHBhc3QgY3VsdHVyZXMuIEZyb20gaHVtYW5raW5kJ3MgZmlyc3QgcGF0aC1saWtlIGRvb2RsZXMgb24gY2F2ZSB3YWxscyB0aHJvdWdoIHRvIHRoZSBoaWdoZXIgYWJzdHJhY3Rpb25zIGRldmVsb3BlZCB0byBtYWtlIGFjY3VyYXRlIG1lYXN1cmVtZW50cyBhbmQgcHJlZGljdGlvbnMsIHRoZSB0aHJlZS1kaW1lbnNpb25hbCBmb3JtcyB3ZSBkZXNpZ24gYW5kIGJ1aWxkIGhhdmUgYWx3YXlzIGJlZW4gZGVwZW5kZW50IG9uIGF2YWlsYWJsZSBtYXRlcmlhbHMsIGh1bWFuIG5lZWRzLCBhbmQgdGhlIGxpbWl0cyBvZiBvdXIgaW1hZ2luYXRpb25zLiAnM0QgVGhpbmtpbmcgaW4gRGVzaWduIGFuZCBBcmNoaXRlY3R1cmUnIHRlbGxzIHRoZSBzdG9yeSBvZiB0aGUgaW50aW1hdGUgcmVsYXRpb25zaGlwIGJldHdlZW4gZ2VvbWV0cnksIG1hdGhlbWF0aWNzIGFuZCBtYW4tbWFkZSBkZXNpZ24gdGhyb3VnaG91dCBodW1hbiBoaXN0b3J5LCBmcm9tIHRoZSBOZW9saXRoaWMgcGVyaW9kIHRocm91Z2ggdGhlIEluZGlhbiwgRWd5cHRpYW4sIEJhYnlsb25pYW4sIENoaW5lc2UsIEdyZWVrLCBDZWx0aWMsIElzbGFtaWMgYW5kIFJlbmFpc3NhbmNlIGN1bHR1cmVzLCB0byB0aGUgcHJlc2VudCBhbmQgdGhlIHBvc3NpYmxlIGZ1dHVyZS4gUHJlc2VudGluZyBrZXkgcHJpbmNpcGxlcyB0aGF0IGNhbiBiZSBhcHBsaWVkIGFjcm9zcyBhbGwgZGVzaWduIGRpc2NpcGxpbmVzLCBkZXNpZ24gZXhwZXJ0IFJvZ2VyIEJ1cnJvd3MgcmVsYXRlcyBob3cgZ2VvbWV0cnkgYXMgYSB2aXN1YWwgbGFuZ3VhZ2UgaGFzIGV2b2x2ZWQgdG8gbWVldCBvdXIgbmVlZHMsIGluaXRpYXRlZCBuZXcgdGVjaG5vbG9naWVzLCBhbmQgY2hhbmdlZCB0aGUgd2F5IHdlIHRoaW5rIGFib3V0IHRoZSB3b3JsZCBhcm91bmQgdXMuIFdpdGggYSB3ZWFsdGggb2Ygb3JpZ2luYWwgYXJ0d29yayBieSB0aGUgYXV0aG9yIHRvIGV4cGxhaW4gaGlzIGlkZWFzLCB0aGlzIGJvb2sgd2lsbCBiZSBhbiBlc3NlbnRpYWwgcmVmZXJlbmNlIGFuZCBzb3VyY2Ugb2YgaW5zcGlyYXRpb24gZm9yIHN0dWRlbnRzIGFuZCBkZXNpZ24gcHJvZmVzc2lvbmFscy4iXSwiYmliX3JlZl9ub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGJpYmxpb2dyYXBoaWNhbCByZWZlcmVuY2VzIGFuZCBpbmRleC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJjb250ZW50c19kaXNwbGF5IjpbIkludHJvZHVjdGlvbiAtLSAxLiBWaXN1YWwgTG9naWMgLS0gVmlzdWFsIExvZ2ljIFRocm91Z2ggVGltZSAtLSAyLiBOZW9saXRoaWMgR2VvbWV0cmllcyAtLSAzLiBUaGUgUml2ZXIgQ3VsdHVyZXMgLS0gNC4gTmF0aXZlIEFtZXJpY2FuIEN1bHR1cmVzIC0tIDUuIFRoZSBQeXRoYWdvcmVhbnMgLS0gNi4gRXVyb3BlYW4gVHJpYmFsIEdlb21ldHJ5IC0tIDcuIEdlb21ldHJpZXMgb2YgdGhlIEVhcmx5IElzbGFtaWMgUGVyaW9kIC0tIDguIFRoZSBSZW5haXNzYW5jZSAtLSBPdXQgb2YgdGhlIFBhc3QgLS0gSW50byB0aGUgRnV0dXJlIC0tIDkuIE1vZGVsbGluZyB3aXRoIEVxdWF0aW9ucyAtLSAxMC4gRnJhY3RhbHMgLS0gMTEuIFNoYXBlLUNoYW5nZXJzIC0tIDEyLiBEeW5hbWljIENpcmNsZXMgYW5kIFNwaGVyZXMgLS0gMTMuIFRoZSBGdXR1cmUgb2YgM0QgR2VvbWV0cnkgLS0gMTQuIEFkZGl0aW9uYWwgVGhvdWdodHMgYW5kIElkZWFzLiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiR2VvbWV0cnkgaW4gYXJjaGl0ZWN0dXJl4oCUSGlzdG9yeSIsIkFyY2hpdGVjdHVyZeKAlE1hdGhlbWF0aWNzIiwiQXJjaGl0ZWN0dXJhbCBkZXNpZ27igJRIaXN0b3J5IiwiRGVjb3JhdGlvbiBhbmQgb3JuYW1lbnQsIEFyY2hpdGVjdHVyYWzigJRIaXN0b3J5IiwiQXJjaGl0ZWN0dXJlLCBBbmNpZW504oCUSW5mbHVlbmNlIiwiQ2l2aWxpemF0aW9uLCBBbmNpZW504oCUSW5mbHVlbmNlIiwiVGhyZWUtZGltZW5zaW9uYWwgaW1hZ2luZyBpbiBhcmNoaXRlY3R1cmUiXSwic3ViamVjdF9mYWNldCI6WyJHZW9tZXRyeSBpbiBhcmNoaXRlY3R1cmXigJRIaXN0b3J5IiwiQXJjaGl0ZWN0dXJl4oCUTWF0aGVtYXRpY3MiLCJBcmNoaXRlY3R1cmFsIGRlc2lnbuKAlEhpc3RvcnkiLCJEZWNvcmF0aW9uIGFuZCBvcm5hbWVudCwgQXJjaGl0ZWN0dXJhbOKAlEhpc3RvcnkiLCJBcmNoaXRlY3R1cmUsIEFuY2llbnTigJRJbmZsdWVuY2UiLCJDaXZpbGl6YXRpb24sIEFuY2llbnTigJRJbmZsdWVuY2UiLCJUaHJlZS1kaW1lbnNpb25hbCBpbWFnaW5nIGluIGFyY2hpdGVjdHVyZSJdLCJmb3JtX2dlbnJlX2Rpc3BsYXkiOlsiSGlzdG9yeSJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4MDUwMDUxOTU0NyAoKGhhcmRjb3ZlcikpIiwiMDUwMDUxOTU0NCAoKGhhcmRjb3ZlcikpIl0sImxjY25fZGlzcGxheSI6WyIgIDIwMTc5NTgxMjciXSwibGNjbl9zIjpbIjIwMTc5NTgxMjciXSwiaXNibl9zIjpbIjk3ODA1MDA1MTk1NDciXSwib2NsY19zIjpbIjEwMDUxMDM2MTUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9uMTAwNTEwMzYxNSIsIjk3ODA1MDA1MTk1NDciXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIxMDY3MjU4M1wiOntcImxvY2F0aW9uXCI6XCJBcmNoaXRlY3R1cmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiQXJjaGl0ZWN0dXJlIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcInVlc1wiLFwiY2FsbF9udW1iZXJcIjpcIk5BMjc1MCAuQjg2NyAyMDE4XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIk5BMjc1MCAuQjg2NyAyMDE4XCJ9fSIsImZvcm1fZ2VucmVfcmVtYWluaW5nX2Rpc3BsYXkiOlsiSGlzdG9yeSJdLCJsb2NhdGlvbl9jb2RlX3MiOlsidWVzIl0sImxvY2F0aW9uIjpbIkFyY2hpdGVjdHVyZSBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiQXJjaGl0ZWN0dXJlIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJ1ZXMiLCJBcmNoaXRlY3R1cmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkJ1cnJvd3MsIFJvZ2VyLCAxOTQ1LS4gM0QgdGhpbmtpbmcgaW4gZGVzaWduIGFuZCBhcmNoaXRlY3R1cmUiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJOQTI3NTAgLkI4NjcgMjAxOCJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJOQTI3NTAgLkI4NjcgMjAxOCJdLCJfdmVyc2lvbl8iOjE2MjExNDE2OTk0MTk5NjMzOTIsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjM6NTM6MjEuOTM5WiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:49 GMT
 - request:
     method: get
@@ -11852,7 +11852,7 @@ http_interactions:
         Library","code":"architecture"},"delivery_locations":[{"label":"Architecture
         Library","address":"School of Architecture Building, Second Floor Princeton,
         NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:52 GMT
 - request:
     method: get
@@ -11906,7 +11906,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6Ijk5OTQ2OTIiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uIiwiU2Nocm9lZGVyLCBDYXJvbGluZSBULiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC5cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiQ2hpbiwgQ2F0aGVyaW5lIE0uXCJ9IiwiYXV0aG9yX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsInRpdGxlX3QiOlsiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5Il0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTk6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEgb25saW5lIHJlc291cmNlIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwicmVsYXRlZF9yZWNvcmRfaW5mb19kaXNwbGF5IjpbIlByaW50IHZlcnNpb246Il0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTWVsYW5pYSB0aGUgRWxkZXIgYW5kIGhlciBncmFuZGRhdWdodGVyIE1lbGFuaWEgdGhlIFlvdW5nZXIgd2VyZSBtYWpvciBmaWd1cmVzIGluIGVhcmx5IENocmlzdGlhbiBoaXN0b3J5LCB1c2luZyB0aGVpciB3ZWFsdGgsIHN0YXR1cywgYW5kIGZvcmNlZnVsIHBlcnNvbmFsaXRpZXMgdG8gc2hhcGUgdGhlIGRldmVsb3BtZW50IG9mIG5lYXJseSBldmVyeSBhc3BlY3Qgb2YgdGhlIHJlbGlnaW9uIHdlIG5vdyBrbm93IGFzIENocmlzdGlhbml0eS4gVGhpcyB2b2x1bWUgZXhhbWluZXMgdGhlIGluZmx1ZW5jZSB0aGF0IHRoZXNlIHR3byB3b21lbiBoYWQgb24gdGhlIGRldmVsb3BtZW50IG9mIENocmlzdGlhbml0eSBhbmQgcHJvdmlkZXMgYW4gaW5zaWdodGZ1bCBwb3J0cmFpdCBvZiB0aGUgdGhlaXIgbGVnYWNpZXMgaW4gdGhlIG1vZGVybiB3b3JsZC4gSW5zdGVhZCBvZiB0aGUgdHJhZGl0aW9uYWxseSBwYXRyaWFyY2hhbCB2aWV3LCB0aGlzIHBlcnNwZWN0aXZlIGdpdmVzIGEgcG9pZ25hbnQgYW5kIHNvbWV0aW1lcyBzdXJwcmlzaW5nIHZpZXcgb2YgaG93IHRoZSByaXNlIG9mIENocmlzdGlhbiBpbnN0aXR1dGlvbnMgaW4gdGhlIFJvbWFuIEVtcGlyZSBzaGFwZWQgdGhlIHVuZGVyc3RhbmRpbmcgb2Ygd29tZW4ncyByb2xlcyBpbiB0aGUgbGFyZ2VyIHdvcmxkLlwiLS1Qcm92aWRlZCBieSBwdWJsaXNoZXIuIl0sImJpYl9yZWZfbm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBiaWJsaW9ncmFwaGljYWwgcmVmZXJlbmNlcyBhbmQgaW5kZXguIl0sInNvdXJjZV9kZXNjX25vdGVzX2Rpc3BsYXkiOlsiRGVzY3JpcHRpb24gYmFzZWQgb24gcHJpbnQgdmVyc2lvbiByZWNvcmQgYW5kIENJUCBkYXRhIHByb3ZpZGVkIGJ5IHB1Ymxpc2hlcjsgcmVzb3VyY2Ugbm90IHZpZXdlZC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKChlbGVjdHJvbmljIGJrLikpIiwiMDUyMDk2NTYzOSAoKGVsZWN0cm9uaWMgYmsuKSkiLCIiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxNjAyMDM0MSJdLCJsY2NuX3MiOlsiMjAxNjAyMDM0MSJdLCJpc2JuX3MiOlsiOTc4MDUyMDk2NTYzOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDUyMDk2NTYzOCIsIjk3ODA1MjAyOTIwODYiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5ODAwOTEwXCI6e1wibG9jYXRpb25cIjpcIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXNcIixcImxpYnJhcnlcIjpcIk9ubGluZVwiLFwibG9jYXRpb25fY29kZVwiOlwiZWxmM1wiLFwiY2FsbF9udW1iZXJcIjpcIkVsZWN0cm9uaWMgUmVzb3VyY2VcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZWxmMyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXMiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJlbGYzIiwiT25saW5lIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLS4gTWVsYW5pYSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkVsZWN0cm9uaWMgUmVzb3VyY2UiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJfdmVyc2lvbl8iOjE2MjExMzgzOTcyOTg5NTAxNDQsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjM6MDA6NTIuODAwWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:53 GMT
 - request:
     method: get
@@ -11960,7 +11960,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6Ijk5OTQ2OTIiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkNoaW4sIENhdGhlcmluZSBNLiwgMTk3Mi0iXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uIiwiU2Nocm9lZGVyLCBDYXJvbGluZSBULiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC5cIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiQ2hpbiwgQ2F0aGVyaW5lIE0uXCJ9IiwiYXV0aG9yX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLSIsIlNjaHJvZWRlciwgQ2Fyb2xpbmUgVC4sIDE5NzEtIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiIsInRpdGxlX3QiOlsiTWVsYW5pYSA6IGVhcmx5IENocmlzdGlhbml0eSB0aHJvdWdoIHRoZSBsaWZlIG9mIG9uZSBmYW1pbHkgLyBDYXRoZXJpbmUgTS4gQ2hpbiBhbmQgQ2Fyb2xpbmUgVC4gU2Nocm9lZGVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIk1lbGFuaWEgOiBlYXJseSBDaHJpc3RpYW5pdHkgdGhyb3VnaCB0aGUgbGlmZSBvZiBvbmUgZmFtaWx5Il0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJNZWxhbmlhIDogZWFybHkgQ2hyaXN0aWFuaXR5IHRocm91Z2ggdGhlIGxpZmUgb2Ygb25lIGZhbWlseSAvIENhdGhlcmluZSBNLiBDaGluIGFuZCBDYXJvbGluZSBULiBTY2hyb2VkZXIuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jcmVhdGVkX3MiOlsiT2FrbGFuZCwgQ2FsaWZvcm5pYSA6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcywgWzIwMThdIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk9ha2xhbmQsIENhbGlmb3JuaWE6IFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYSBQcmVzcyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTgiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxOCwiY2F0YWxvZ2VkX3RkdCI6IjIwMTYtMTAtMzFUMTk6MDc6MDlaIiwiZm9ybWF0IjpbIkJvb2siXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vd3d3LmpzdG9yLm9yZy9zdGFibGUvMTAuMTUyNS9qLmN0dDFnZ2pocDRcIjpbXCJ3d3cuanN0b3Iub3JnXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBvbmxpbmUgcmVzb3VyY2UuIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEgb25saW5lIHJlc291cmNlIl0sInNlcmllc19kaXNwbGF5IjpbIkNocmlzdGlhbml0eSBpbiBsYXRlIGFudGlxdWl0eSA7IDIiXSwicmVsYXRlZF9yZWNvcmRfaW5mb19kaXNwbGF5IjpbIlByaW50IHZlcnNpb246Il0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlwiTWVsYW5pYSB0aGUgRWxkZXIgYW5kIGhlciBncmFuZGRhdWdodGVyIE1lbGFuaWEgdGhlIFlvdW5nZXIgd2VyZSBtYWpvciBmaWd1cmVzIGluIGVhcmx5IENocmlzdGlhbiBoaXN0b3J5LCB1c2luZyB0aGVpciB3ZWFsdGgsIHN0YXR1cywgYW5kIGZvcmNlZnVsIHBlcnNvbmFsaXRpZXMgdG8gc2hhcGUgdGhlIGRldmVsb3BtZW50IG9mIG5lYXJseSBldmVyeSBhc3BlY3Qgb2YgdGhlIHJlbGlnaW9uIHdlIG5vdyBrbm93IGFzIENocmlzdGlhbml0eS4gVGhpcyB2b2x1bWUgZXhhbWluZXMgdGhlIGluZmx1ZW5jZSB0aGF0IHRoZXNlIHR3byB3b21lbiBoYWQgb24gdGhlIGRldmVsb3BtZW50IG9mIENocmlzdGlhbml0eSBhbmQgcHJvdmlkZXMgYW4gaW5zaWdodGZ1bCBwb3J0cmFpdCBvZiB0aGUgdGhlaXIgbGVnYWNpZXMgaW4gdGhlIG1vZGVybiB3b3JsZC4gSW5zdGVhZCBvZiB0aGUgdHJhZGl0aW9uYWxseSBwYXRyaWFyY2hhbCB2aWV3LCB0aGlzIHBlcnNwZWN0aXZlIGdpdmVzIGEgcG9pZ25hbnQgYW5kIHNvbWV0aW1lcyBzdXJwcmlzaW5nIHZpZXcgb2YgaG93IHRoZSByaXNlIG9mIENocmlzdGlhbiBpbnN0aXR1dGlvbnMgaW4gdGhlIFJvbWFuIEVtcGlyZSBzaGFwZWQgdGhlIHVuZGVyc3RhbmRpbmcgb2Ygd29tZW4ncyByb2xlcyBpbiB0aGUgbGFyZ2VyIHdvcmxkLlwiLS1Qcm92aWRlZCBieSBwdWJsaXNoZXIuIl0sImJpYl9yZWZfbm90ZXNfZGlzcGxheSI6WyJJbmNsdWRlcyBiaWJsaW9ncmFwaGljYWwgcmVmZXJlbmNlcyBhbmQgaW5kZXguIl0sInNvdXJjZV9kZXNjX25vdGVzX2Rpc3BsYXkiOlsiRGVzY3JpcHRpb24gYmFzZWQgb24gcHJpbnQgdmVyc2lvbiByZWNvcmQgYW5kIENJUCBkYXRhIHByb3ZpZGVkIGJ5IHB1Ymxpc2hlcjsgcmVzb3VyY2Ugbm90IHZpZXdlZC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInN1YmplY3RfZmFjZXQiOlsiTWVsYW5pYSwgdGhlIEVsZGVyLCBTYWludCwgMzQxPy00MTA/IiwiTWVsYW5pYSwgdGhlIFlvdW5nZXIsIFNhaW50LCAzODU/LTQzOSIsIkNocmlzdGlhbiB3b21lbiBzYWludHMiLCJXb21lbiBpbiBDaHJpc3RpYW5pdHnigJRIaXN0b3J5Il0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiQXV0aG9yXCI6W1wiU2Nocm9lZGVyLCBDYXJvbGluZSBULiwgMTk3MS1cIl19IiwiaXNibl9kaXNwbGF5IjpbIjk3ODA1MjA5NjU2MzggKChlbGVjdHJvbmljIGJrLikpIiwiMDUyMDk2NTYzOSAoKGVsZWN0cm9uaWMgYmsuKSkiLCIiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxNjAyMDM0MSJdLCJsY2NuX3MiOlsiMjAxNjAyMDM0MSJdLCJpc2JuX3MiOlsiOTc4MDUyMDk2NTYzOCJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDUyMDk2NTYzOCIsIjk3ODA1MjAyOTIwODYiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI5ODAwOTEwXCI6e1wibG9jYXRpb25cIjpcIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXNcIixcImxpYnJhcnlcIjpcIk9ubGluZVwiLFwibG9jYXRpb25fY29kZVwiOlwiZWxmM1wiLFwiY2FsbF9udW1iZXJcIjpcIkVsZWN0cm9uaWMgUmVzb3VyY2VcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiRWxlY3Ryb25pYyBSZXNvdXJjZVwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZWxmMyJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIk9ubGluZSAtIE9ubGluZSBSZXNvdXJjZXMiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJlbGYzIiwiT25saW5lIl0sIm5hbWVfdGl0bGVfYnJvd3NlX3MiOlsiQ2hpbiwgQ2F0aGVyaW5lIE0uLCAxOTcyLS4gTWVsYW5pYSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkVsZWN0cm9uaWMgUmVzb3VyY2UiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiRWxlY3Ryb25pYyBSZXNvdXJjZSJdLCJfdmVyc2lvbl8iOjE2MjExMzgzOTcyOTg5NTAxNDQsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjM6MDA6NTIuODAwWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:53 GMT
 - request:
     method: get
@@ -12014,7 +12014,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjIxNjc2NjkiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5MyJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXNcIn0iLCJhdXRob3JfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwidGl0bGVfdCI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NyZWF0ZWRfcyI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGFyaXMiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTQzIl0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NDMsInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTQ1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0wNVQxOToxOToyMloiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjYxIHAuIDE3IGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjYxIHAuIDE3IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2MSBwLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiUHJlbWllzIByZSBlzIFkaXRpb24gcHVibGlxdWUuXCIiLCJBdXRob3IncyBwc2V1ZC4sIEFyZ29ubmUsIGF0IGhlYWQgb2YgdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkZyZW5jaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZnJlIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJmciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiR3JlYXQgQnJpdGFpbuKAlFJlbGF0aW9uc+KAlEZyYW5jZSIsIkZyYW5jZeKAlFJlbGF0aW9uc+KAlEdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWlu4oCUQ2l2aWxpemF0aW9u4oCUSGlzdG9yeSJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJFZGl0aW9ucyBkZSBNaW51aXRcIl19IiwibGNjbl9kaXNwbGF5IjpbIiAgIDQ3MDI4Nzk5ICAiXSwibGNjbl9zIjpbIjQ3MDI4Nzk5Il0sIm9jbGNfcyI6WyI2Njc4NjgxIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20wNjY3ODY4MSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjI0NTM2OTNcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFN5bHZpYSBCZWFjaCBDb2xsZWN0aW9uXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJiZWFjXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiREE0Ny4xIC5EMzUgMTk0NVwifSxcIjI0NTM2OTRcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3NcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImV4XCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIjMyMjkuMzE5LjI4XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjMyMjkuMzE5LjI4XCJ9LFwiMzUyMDU0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiMTQ1OS4yODdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTQ1OS4yODdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImJlYWMiLCJleCIsInJjcHBhIl0sImxvY2F0aW9uIjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvbiIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIiwiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5My4gQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJfdmVyc2lvbl8iOjE2MjExMTQzMDIwNzk0MzQ3NTIsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMTY6Mzc6NTMuODE2WiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:54 GMT
 - request:
     method: get
@@ -12068,7 +12068,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjIxNjc2NjkiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5MyJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzIiwiRWRpdGlvbnMgZGUgTWludWl0Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiRWRpdGlvbnMgZGUgTWludWl0XCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXNcIn0iLCJhdXRob3JfcyI6WyJEZWJ1zIItQnJpZGVsLCBKYWNxdWVzLCAxOTAyLTE5OTMiLCJFZGl0aW9ucyBkZSBNaW51aXQiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIiwidGl0bGVfdCI6WyJBbmdsZXRlcnJlIChkJ0FsY3VpbiBhzIAgSHV4bGV5KSBbcGFyXSBBcmdvbm5lIFtwc2V1ZC5dIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkFuZ2xldGVycmUgKGQnQWxjdWluIGHMgCBIdXhsZXkpIFtwYXJdIEFyZ29ubmUgW3BzZXVkLl0iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NyZWF0ZWRfcyI6WyJQYXJpcywgRcyBZGl0aW9ucyBkZSBtaW51aXQsIDE5NDMgW2kuZS4gMTk0NV0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGFyaXMiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTQzIl0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5NDMsInB1Yl9kYXRlX2VuZF9zb3J0IjoxOTQ1LCJjYXRhbG9nZWRfdGR0IjoiMjAwNi0xMC0wNVQxOToxOToyMloiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjYxIHAuIDE3IGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjYxIHAuIDE3IGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyI2MSBwLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiUHJlbWllzIByZSBlzIFkaXRpb24gcHVibGlxdWUuXCIiLCJBdXRob3IncyBwc2V1ZC4sIEFyZ29ubmUsIGF0IGhlYWQgb2YgdGl0bGUuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkZyZW5jaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZnJlIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJmciJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiR3JlYXQgQnJpdGFpbuKAlFJlbGF0aW9uc+KAlEZyYW5jZSIsIkZyYW5jZeKAlFJlbGF0aW9uc+KAlEdyZWF0IEJyaXRhaW4iLCJHcmVhdCBCcml0YWlu4oCUQ2l2aWxpemF0aW9u4oCUSGlzdG9yeSJdLCJzdWJqZWN0X2ZhY2V0IjpbIkdyZWF0IEJyaXRhaW7igJRSZWxhdGlvbnPigJRGcmFuY2UiLCJGcmFuY2XigJRSZWxhdGlvbnPigJRHcmVhdCBCcml0YWluIiwiR3JlYXQgQnJpdGFpbuKAlENpdmlsaXphdGlvbuKAlEhpc3RvcnkiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJFZGl0aW9ucyBkZSBNaW51aXRcIl19IiwibGNjbl9kaXNwbGF5IjpbIiAgIDQ3MDI4Nzk5ICAiXSwibGNjbl9zIjpbIjQ3MDI4Nzk5Il0sIm9jbGNfcyI6WyI2Njc4NjgxIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY20wNjY3ODY4MSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjI0NTM2OTNcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFN5bHZpYSBCZWFjaCBDb2xsZWN0aW9uXCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJiZWFjXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkRBNDcuMSAuRDM1IDE5NDVcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiREE0Ny4xIC5EMzUgMTk0NVwifSxcIjI0NTM2OTRcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIFJhcmUgQm9va3NcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImV4XCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIjMyMjkuMzE5LjI4XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjMyMjkuMzE5LjI4XCJ9LFwiMzUyMDU0MVwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiMTQ1OS4yODdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiMTQ1OS4yODdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImJlYWMiLCJleCIsInJjcHBhIl0sImxvY2F0aW9uIjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBTeWx2aWEgQmVhY2ggQ29sbGVjdGlvbiIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBSYXJlIEJvb2tzIiwiUmVDQVAiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJiZWFjIiwiZXgiLCJyY3BwYSIsIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiLCJSZUNBUCJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIkRlYnXMgi1CcmlkZWwsIEphY3F1ZXMsIDE5MDItMTk5My4gQW5nbGV0ZXJyZSAoZCdBbGN1aW4gYcyAIEh1eGxleSkiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJEQTQ3LjEgLkQzNSAxOTQ1IiwiMzIyOS4zMTkuMjgiLCIxNDU5LjI4NyJdLCJfdmVyc2lvbl8iOjE2MjExMTQzMDIwNzk0MzQ3NTIsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMTY6Mzc6NTMuODE2WiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:55 GMT
 - request:
     method: get
@@ -12122,7 +12122,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjE3ODg3OTYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQiLCJCb2huZXIsIEthdGUiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJCb2huZXIsIEthdGVcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiVHJ1bXAsIERvbmFsZFwifSIsImF1dGhvcl9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIiwiQm9obmVyLCBLYXRlIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiIsInRpdGxlX3QiOlsiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2siXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNTowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsieHgsIDI0NCBwLiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGluZGV4LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJfdmVyc2lvbl8iOjE2MjExMTI3Njg4MDc1NjczNjAsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMTY6MTM6MzEuNDkzWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:56 GMT
 - request:
     method: get
@@ -12176,7 +12176,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjE3ODg3OTYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wLCBEb25hbGQiLCJCb2huZXIsIEthdGUiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJCb2huZXIsIEthdGVcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiVHJ1bXAsIERvbmFsZFwifSIsImF1dGhvcl9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtIiwiQm9obmVyLCBLYXRlIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiIsInRpdGxlX3QiOlsiVHJ1bXAgOiB0aGUgYXJ0IG9mIHRoZSBjb21lYmFjayAvIERvbmFsZCBKLiBUcnVtcCB3aXRoIEthdGUgQm9obmVyLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2siXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRydW1wIDogdGhlIGFydCBvZiB0aGUgY29tZWJhY2sgLyBEb25hbGQgSi4gVHJ1bXAgd2l0aCBLYXRlIEJvaG5lci4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIjFzdCBlZC4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NyZWF0ZWRfcyI6WyJOZXcgWW9yayA6IFRpbWVzIEJvb2tzLCBjMTk5Ny4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTmV3IFlvcms6IFRpbWVzIEJvb2tzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk5NyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTk3LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNTowMDowMFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInh4LCAyNDQgcC4gOiBpbGwuIDsgMjUgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsieHgsIDI0NCBwLiA6IGlsbC4gOyAyNSBjbS4iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsieHgsIDI0NCBwLiJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGluZGV4LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sInN1YmplY3RfZGlzcGxheSI6WyJUcnVtcCwgRG9uYWxkLCAxOTQ2LSIsIkJ1c2luZXNzbWVu4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSIsIlJlYWwgZXN0YXRlIGRldmVsb3BlcnPigJRVbml0ZWQgU3RhdGVz4oCUQmlvZ3JhcGh5Il0sInN1YmplY3RfZmFjZXQiOlsiVHJ1bXAsIERvbmFsZCwgMTk0Ni0iLCJCdXNpbmVzc21lbuKAlFVuaXRlZCBTdGF0ZXPigJRCaW9ncmFwaHkiLCJSZWFsIGVzdGF0ZSBkZXZlbG9wZXJz4oCUVW5pdGVkIFN0YXRlc+KAlEJpb2dyYXBoeSJdLCJyZWxhdGVkX25hbWVfanNvbl8xZGlzcGxheSI6IntcIlJlbGF0ZWQgbmFtZVwiOltcIkJvaG5lciwgS2F0ZVwiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiMDgxMjkyOTY0MCAoYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDk3MDM3Mjk2IC8vcjk4ICJdLCJsY2NuX3MiOlsiOTcwMzcyOTYiXSwiaXNibl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA4MTI5Mjk2NDUiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIyMDUzMDA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJIQzEwMi41LlQ3OCBBMyAxOTk3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkhDMTAyLjUuVDc4IEEzIDE5OTdcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlRydW1wLCBEb25hbGQsIDE5NDYtLiBUcnVtcCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkhDMTAyLjUuVDc4IEEzIDE5OTciXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSEMxMDIuNS5UNzggQTMgMTk5NyJdLCJfdmVyc2lvbl8iOjE2MjExMTI3Njg4MDc1NjczNjAsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMTY6MTM6MzEuNDkzWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:56 GMT
 - request:
     method: get
@@ -12240,7 +12240,7 @@ http_interactions:
         Books","Firestone Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone
         Library"],"call_number_display":["Oversize HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766
         .B53f","HQ766 .B53"],"_version_":1638774392317018112,"timestamp":"2019-07-11T14:57:28.316Z"}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:57 GMT
 - request:
     method: get
@@ -12304,7 +12304,7 @@ http_interactions:
         Books","Firestone Library"],"advanced_location_s":["l","f","Forrestal Annex","Firestone
         Library"],"call_number_display":["Oversize HQ766 .B53f","HQ766 .B53"],"call_number_browse_s":["HQ766
         .B53f","HQ766 .B53"],"_version_":1638774392317018112,"timestamp":"2019-07-11T14:57:28.316Z"}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:19:58 GMT
 - request:
     method: get
@@ -12358,7 +12358,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJpZCI6IjEwMjQ3ODA2IiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJEaW5jzKdhc2xhbiwgTS4gQmFoYWTEsXJoYW4sIDE5OTAtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhblwifSIsImF1dGhvcl9zIjpbIkRpbmPMp2FzbGFuLCBNLiBCYWhhZMSxcmhhbiwgMTk5MC0iXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIiwidGl0bGVfdCI6WyJLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIDogVG9sa2llbiBuZSB5YXB0xLE/IC8gTS4gQmFoYWTEsXJoYW4gRGluY8ynYXNsYW4uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiS2Fyc8ynxLFsYXPMp3TEsXJtYWzEsSBtaXRvbG9qaSA6IFRvbGtpZW4gbmUgeWFwdMSxPyAvIE0uIEJhaGFkxLFyaGFuIERpbmPMp2FzbGFuLiJdLCJlZGl0aW9uX2Rpc3BsYXkiOlsiMS4gYmFza8SxLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkthZMSxa2/MiHksIEnMh3N0YW5idWwgOiBBeWdhbiBZYXnEsW5jxLFsxLFrLCAyMDE3LiJdLCJwdWJfY3JlYXRlZF9zIjpbIkthZMSxa2/MiHksIEnMh3N0YW5idWwgOiBBeWdhbiBZYXnEsW5jxLFsxLFrLCAyMDE3LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJLYWTEsWtvzIh5LCBJzIdzdGFuYnVsOiBBeWdhbiBZYXnEsW5jxLFsxLFrIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNyJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE3LCJjYXRhbG9nZWRfdGR0IjoiMjAxNy0wNi0wNVQxNzowNDo0MFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjE2OSBwYWdlcyA7IDIwIGNtLiJdLCJkZXNjcmlwdGlvbl90IjpbIjE2OSBwYWdlcyA7IDIwIGNtLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxNjkgcGFnZXMiXSwic2VyaWVzX2Rpc3BsYXkiOlsiQXlnYW4gWWF5xLFuY8SxbMSxayA7IG5vOiA0NSJdLCJub3Rlc19kaXNwbGF5IjpbIlwiQmlyIFR1zIhyayBtaWxsaXlldGPMp2lzaW5pbiBtaXRvbG9qaSBkZWZ0ZXJpbmRlbi5cIiJdLCJsYW5ndWFnZV9mYWNldCI6WyJUdXJraXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJ0dXIiXSwibGFuZ3VhZ2VfaWFuYV9zIjpbInRyIl0sInN1YmplY3RfZGlzcGxheSI6WyJNeXRob2xvZ3kiXSwic3ViamVjdF9mYWNldCI6WyJNeXRob2xvZ3kiXSwiaXNibl9kaXNwbGF5IjpbIjk3ODYwNTk3MDcyNDQiXSwiaXNibl9zIjpbIjk3ODYwNTk3MDcyNDQiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODYwNTk3MDcyNDQiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIxMDAyODEwMlwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiQkwzMTIgLkQ1NSAyMDE3XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkJMMzEyIC5ENTUgMjAxN1wifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsicmNwcGEiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwiUmVDQVAiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJEaW5jzKdhc2xhbiwgTS4gQmFoYWTEsXJoYW4sIDE5OTAtLiBLYXJzzKfEsWxhc8yndMSxcm1hbMSxIG1pdG9sb2ppIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiQkwzMTIgLkQ1NSAyMDE3Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkJMMzEyIC5ENTUgMjAxNyJdLCJfdmVyc2lvbl8iOjE2MjExMzkyNjIzOTcyMTg4MTYsInRpbWVzdGFtcCI6IjIwMTgtMTItMjhUMjM6MTQ6MzcuODIwWiJ9
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:20:01 GMT
 - request:
     method: get
@@ -12435,7 +12435,7 @@ http_interactions:
         - *ONLINE*"],"advanced_location_s":["elf1","Online"],"name_title_browse_s":["Gray,
         Brayton, 1940-. Abelian properties of Anick spaces"],"call_number_display":["Electronic
         Resource"],"call_number_browse_s":["Electronic Resource"],"_version_":1626690102478503936,"timestamp":"2019-02-28T05:42:51.390Z"}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:33:24 GMT
 - request:
     method: get
@@ -12487,7 +12487,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"10878427":{"more_items":false,"location":"elf1","status":"Online","label":"Online
         - *ONLINE*"}}'
-    http_version: null
+    http_version: 
   recorded_at: Mon, 16 Sep 2019 14:33:24 GMT
 - request:
     method: get
@@ -12551,6 +12551,72 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 80.0.3987.106
-    http_version: null
-  recorded_at: Tue, 17 Mar 2020 21:11:33 GMT
-recorded_with: VCR 5.1.0
+    http_version: 
+  recorded_at: Wed, 18 Mar 2020 12:11:11 GMT
+- request:
+    method: get
+    uri: https://chromedriver.storage.googleapis.com/LATEST_RELEASE_73.0.3683
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - chromedriver.storage.googleapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UoV9dkKSqkT37uKSYORybh9OiBbUT3JSJlWa_ZZVXehiAiDnbujzTJx3xEic_pUWx27vAglChYx-q0n8L61DKeQgJTldw
+      Expires:
+      - Thu, 19 Mar 2020 13:35:09 GMT
+      Date:
+      - Thu, 19 Mar 2020 12:35:09 GMT
+      Last-Modified:
+      - Thu, 07 Mar 2019 22:34:59 GMT
+      Etag:
+      - '"4a51baa3e8827a77804c49bfc54a0c65"'
+      X-Goog-Generation:
+      - '1551998099301405'
+      X-Goog-Metageneration:
+      - '1'
+      X-Goog-Stored-Content-Encoding:
+      - identity
+      X-Goog-Stored-Content-Length:
+      - '12'
+      Content-Type:
+      - text/plain
+      Content-Language:
+      - en
+      X-Goog-Hash:
+      - crc32c=5Kcf3A==
+      - md5=SlG6o+iCeneATEm/xUoMZQ==
+      X-Goog-Storage-Class:
+      - STANDARD
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '12'
+      Server:
+      - UploadServer
+      Cache-Control:
+      - public, max-age=3600
+      Age:
+      - '495'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443";
+        ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443";
+        ma=2592000,h3-T050=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: 73.0.3683.68
+    http_version: 
+  recorded_at: Thu, 19 Mar 2020 12:43:24 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/request_models.yml
+++ b/spec/cassettes/request_models.yml
@@ -54,58 +54,6 @@ http_interactions:
   recorded_at: Thu, 26 May 2016 04:06:47 GMT
 - request:
     method: get
-    uri: https://bibdata.princeton.edu/locations/holding_locations/f.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 26 May 2016 04:06:03 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Request-Method:
-      - GET
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Token
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 01acbce9-1858-4f92-ab27-578119a71705
-      X-Runtime:
-      - '0.017987'
-      X-Powered-By:
-      - Phusion Passenger 4.0.59
-      Etag:
-      - W/"218cd0ed0ae6ed76a6add0a4e2d108d1"
-      Status:
-      - 200 OK
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"label":"","code":"f","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Firestone
-        Library","code":"firestone"},"hours_location":{"label":"Firestone Library
-        - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
-        Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
-    http_version: 
-  recorded_at: Thu, 26 May 2016 04:06:48 GMT
-- request:
-    method: get
     uri: https://bibdata.princeton.edu/availability?id=6009363
     body:
       encoding: US-ASCII
@@ -486,76 +434,6 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjQ5MDkzMCIsImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlNvdXRoZXJuIFBvbGl0aWNhbCBTY2llbmNlIEFzc29jaWF0aW9uIiwiVW5pdmVyc2l0eSBvZiBGbG9yaWRhIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiU291dGhlcm4gUG9saXRpY2FsIFNjaWVuY2UgQXNzb2NpYXRpb25cIixcIlVuaXZlcnNpdHkgb2YgRmxvcmlkYVwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJhdXRob3JfcyI6WyJTb3V0aGVybiBQb2xpdGljYWwgU2NpZW5jZSBBc3NvY2lhdGlvbiIsIlVuaXZlcnNpdHkgb2YgRmxvcmlkYSJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiU291dGhlcm4gUG9saXRpY2FsIFNjaWVuY2UgQXNzb2NpYXRpb24iLCJVbml2ZXJzaXR5IG9mIEZsb3JpZGEiLCJUaGUgam91cm5hbCBvZiBwb2xpdGljcy4iLCJQb2xpdGljYWwgc2NpZW5jZSJdLCJ0aXRsZV9kaXNwbGF5IjoiVGhlIGpvdXJuYWwgb2YgcG9saXRpY3MuIiwidGl0bGVfdCI6WyJUaGUgam91cm5hbCBvZiBwb2xpdGljcy4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJUaGUgam91cm5hbCBvZiBwb2xpdGljcy4iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRoZSBqb3VybmFsIG9mIHBvbGl0aWNzLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkdhaW5lc3ZpbGxlLCBGbGEuIDogU291dGhlcm4gUG9saXRpY2FsIFNjaWVuY2UgQXNzb2NpYXRpb24gYW5kIHRoZSBVbml2ZXJzaXR5IG9mIEZsb3JpZGEsIDE5MzktIl0sInB1Yl9jcmVhdGVkX3MiOlsiR2FpbmVzdmlsbGUsIEZsYS4gOiBTb3V0aGVybiBQb2xpdGljYWwgU2NpZW5jZSBBc3NvY2lhdGlvbiBhbmQgdGhlIFVuaXZlcnNpdHkgb2YgRmxvcmlkYSwgMTkzOS0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiR2FpbmVzdmlsbGUsIEZsYTogU291dGhlcm4gUG9saXRpY2FsIFNjaWVuY2UgQXNzb2NpYXRpb24gYW5kIHRoZSBVbml2ZXJzaXR5IG9mIEZsb3JpZGEiXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTM5Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5MzksInB1Yl9kYXRlX2VuZF9zb3J0Ijo5OTk5LCJjYXRhbG9nZWRfdGR0IjoiMjAwMC0wNi0xM1QwNDowMDowMFoiLCJmb3JtYXQiOlsiSm91cm5hbCJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInYuIDogaWxsLiA7IDIzLTI4IGNtLiIsIlZvbC4gMSwgbm8uIDEgKEZlYi4gMTkzOSktIl0sImRlc2NyaXB0aW9uX3QiOlsidi4gOiBpbGwuIDsgMjMtMjggY20uIiwiVm9sLiAxLCBuby4gMSAoRmViLiAxOTM5KS0iXSwiY29udGludWVzX2Rpc3BsYXkiOlsiU291dGhlcm4gUG9saXRpY2FsIFNjaWVuY2UgQXNzb2NpYXRpb24uIl0sImZyZXF1ZW5jeV9kaXNwbGF5IjpbIlF1YXJ0ZXJseSJdLCJub3Rlc19kaXNwbGF5IjpbIlB1Ymxpc2hlZCBcdTAwM2MyMDAwLTIwMDdcdTAwM2U6IEJvc3RvbiwgTWFzcy4gOiBCbGFja3dlbGwuIiwiTGF0ZXN0IGlzc3VlIGNvbnN1bHRlZDogVm9sLiA2OCwgbm8uIDQgKE5vdi4gMjAwNikuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiUG9saXRpY2FsIHNjaWVuY2XigJRQZXJpb2RpY2FscyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlBvbGl0aWNhbCBzY2llbmNl4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJTb3V0aGVybiBQb2xpdGljYWwgU2NpZW5jZSBBc3NvY2lhdGlvblwiLFwiVW5pdmVyc2l0eSBvZiBGbG9yaWRhXCJdfSIsIm90aGVyX3RpdGxlX2Rpc3BsYXkiOlsiVGhlIEpvdXJuYWwgb2YgcG9saXRpY3MiLCJKUCBcdTAwM2MxOTcyXHUwMDNlLTE5OTciLCJKT1AgMTk5OC1cdTAwM2MyMDA3XHUwMDNlIl0sImlzc25fZGlzcGxheSI6WyIwMDIyLTM4MTYiXSwibGNjbl9kaXNwbGF5IjpbIiAgIDQxMDE2NjA2ICAiXSwibGNjbl9zIjpbIjQxMDE2NjA2Il0sImlzc25fcyI6WyIwMDIyMzgxNiJdLCJvY2xjX3MiOlsiMTU5MDczNiJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiMDAyMjM4MTYiLCJvY20wMTU5MDczNiJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjUzMzIyNFwiOntcImxvY2F0aW9uXCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImZcIixcImNhbGxfbnVtYmVyXCI6XCJKQTEgLko2ODdcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSkExIC5KNjg3XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJWb2wuIDYyLCBuby4gMSAoRmViLiAyMDAwKS12LiA2OCwgbm8uIDQgKE5vdi4gMjAwNilcIixcIkVsZWN0cm9uaWMgZm9ybWF0IGF2YWlsYWJsZTsgcHJpbnQgc3Vic2NyaXB0aW9uIGNhbmNlbGxlZCB3aXRoIHRoZSBsYXN0IGlzc3VlIG9mIDIwMDZcIl19LFwiNDc0MDgzMFwiOntcImxvY2F0aW9uXCI6XCJSZUNBUFwiLFwibGlicmFyeVwiOlwiUmVDQVBcIixcImxvY2F0aW9uX2NvZGVcIjpcInJjcHBhXCIsXCJjYWxsX251bWJlclwiOlwiNzUwMC41MDNcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiNzUwMC41MDNcIixcImxvY2F0aW9uX2hhc1wiOltcIlZvbC4gMSwgbm8uIDEgKEZlYi4gMTkzOSktdi4gNjEsIG5vLiA0IChOb3YuIDE5OTkpXCJdfX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiIsInJjcHBhIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiLCJSZUNBUCJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIlJlQ0FQIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiSkExIC5KNjg3IiwiNzUwMC41MDMiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiSkExIC5KNjg3IiwiNzUwMC41MDMiXSwidGltZXN0YW1wIjoiMjAxNi0wNC0yNVQxOToxMTowNi40NzZaIn19fQ==
-    http_version: 
-  recorded_at: Thu, 26 May 2016 17:13:21 GMT
-- request:
-    method: get
-    uri: https://bibdata.princeton.edu/locations/holding_locations/rcppa.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 26 May 2016 17:12:59 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Request-Method:
-      - GET
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Token
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - c9c8241f-45cc-493a-9139-16454f1c2356
-      X-Runtime:
-      - '0.046096'
-      X-Powered-By:
-      - Phusion Passenger 4.0.59
-      Etag:
-      - W/"b52c851690c201c2c6c6c0ca35f64ffd"
-      Status:
-      - 200 OK
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"label":"","code":"rcppa","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"ReCAP","code":"recap"},"hours_location":null,"delivery_locations":[{"label":"Plasma
-        Physics Library","address":"Forrestal Campus Princeton, NJ 08544","phone_number":"609-243-3565","contact_email":"ppllib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Architecture
-        Library","address":"School of Architecture Building, Second Floor Princeton,
-        NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"East
-        Asian Library","address":"Frist Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Engineering
-        Library","address":"Friend Center for Engineering Education Princeton, NJ
-        08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Firestone
-        Library, Microforms","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false},{"label":"Marquand
-        Library of Art and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Mendel
-        Music Library","address":"Woolworth Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Mudd
-        Manuscript Library","address":"65 Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":false},{"label":"Stokes
-        Library","address":"Wallace Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Firestone
-        Library, Rare Books \u0026 Special Collections Reading Room","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":false},{"label":"Lewis
-        Library","address":"Washington Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Firestone
-        Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Humanities
-        Resource Center","address":"011 East Pyne Princeton, NJ 08544","phone_number":"609-258-1290","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QV","staff_only":false,"pickup_location":false,"digital_location":false},{"label":"Firestone
-        Library, Resource Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
-        Services","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Preservation","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
-        Services, Holdings Management","address":"One Washington Rd. Princeton, NJ
-        08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false}]}'
     http_version: 
   recorded_at: Thu, 26 May 2016 17:13:21 GMT
 - request:
@@ -1180,56 +1058,6 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjYxOTU5NDIiLCJhdXRob3JfZGlzcGxheSI6WyJXZWlyLCBNYXVyaWNlIEQuIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIldlaXIsIE1hdXJpY2UgRC4iLCJIYXNzLCBKb2VsIiwiVGhvbWFzLCBHZW9yZ2UgQi4iXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJIYXNzLCBKb2VsXCIsXCJUaG9tYXMsIEdlb3JnZSBCLlwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJXZWlyLCBNYXVyaWNlIEQuXCJ9IiwiYXV0aG9yX3MiOlsiV2VpciwgTWF1cmljZSBELiIsIkhhc3MsIEpvZWwiLCJUaG9tYXMsIEdlb3JnZSBCLiAoR2VvcmdlIEJyaW50b24pLCBKci4sIDE5MTQtMjAwNiJdLCJvcGVuc2VhcmNoX2Rpc3BsYXkiOlsiV2VpciwgTWF1cmljZSBELiIsIkhhc3MsIEpvZWwiLCJUaG9tYXMsIEdlb3JnZSBCLiAoR2VvcmdlIEJyaW50b24pLCBKci4sIDE5MTQtMjAwNiIsIlRob21hcycgY2FsY3VsdXMgOiBlYXJseSB0cmFuc2NlbmRlbnRhbHMgLyBiYXNlZCBvbiB0aGUgb3JpZ2luYWwgd29yayBieSBHZW9yZ2UgQi4gVGhvbWFzLCBKci4sIGFzIHJldmlzZWQgYnkgTWF1cmljZSBELiBXZWlyLCBKb2VsIEhhc3MuIiwiQ2FsY3VsdXMiLCJHZW9tZXRyeSwgQW5hbHl0aWMiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInRpdGxlX2Rpc3BsYXkiOiJUaG9tYXMnIGNhbGN1bHVzIDogZWFybHkgdHJhbnNjZW5kZW50YWxzIC8gYmFzZWQgb24gdGhlIG9yaWdpbmFsIHdvcmsgYnkgR2VvcmdlIEIuIFRob21hcywgSnIuLCBhcyByZXZpc2VkIGJ5IE1hdXJpY2UgRC4gV2VpciwgSm9lbCBIYXNzLiIsInRpdGxlX3QiOlsiVGhvbWFzJyBjYWxjdWx1cyA6IGVhcmx5IHRyYW5zY2VuZGVudGFscyAvIGJhc2VkIG9uIHRoZSBvcmlnaW5hbCB3b3JrIGJ5IEdlb3JnZSBCLiBUaG9tYXMsIEpyLiwgYXMgcmV2aXNlZCBieSBNYXVyaWNlIEQuIFdlaXIsIEpvZWwgSGFzcy4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJUaG9tYXMnIGNhbGN1bHVzIDogZWFybHkgdHJhbnNjZW5kZW50YWxzIC8iXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRob21hcycgY2FsY3VsdXMgOiBlYXJseSB0cmFuc2NlbmRlbnRhbHMgLyBiYXNlZCBvbiB0aGUgb3JpZ2luYWwgd29yayBieSBHZW9yZ2UgQi4gVGhvbWFzLCBKci4sIGFzIHJldmlzZWQgYnkgTWF1cmljZSBELiBXZWlyLCBKb2VsIEhhc3MuIl0sImVkaXRpb25fZGlzcGxheSI6WyIxMnRoIGVkLiJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIkJvc3RvbiA6IEFkZGlzb24tV2VzbGV5LCBjMjAxMC4iXSwicHViX2NyZWF0ZWRfcyI6WyJCb3N0b24gOiBBZGRpc29uLVdlc2xleSwgYzIwMTAuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIkJvc3RvbjogQWRkaXNvbi1XZXNsZXkiXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDEwIl0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTAsImNhdGFsb2dlZF90ZHQiOiIyMDEwLTA4LTA0VDE4OjA0OjQ1WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsieHZpLCAxMDA2LCBbMTMzXSBwLiA6IGlsbC4gKHNvbWUgY29sLikgOyAyOSBjbS4iXSwiZGVzY3JpcHRpb25fdCI6WyJ4dmksIDEwMDYsIFsxMzNdIHAuIDogaWxsLiAoc29tZSBjb2wuKSA7IDI5IGNtLiJdLCJub3Rlc19kaXNwbGF5IjpbIkluY2x1ZGVzIGluZGV4LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwic3ViamVjdF9kaXNwbGF5IjpbIkNhbGN1bHVz4oCUVGV4dGJvb2tzIiwiR2VvbWV0cnksIEFuYWx5dGlj4oCUVGV4dGJvb2tzIl0sInN1YmplY3RfZmFjZXQiOlsiQ2FsY3VsdXPigJRUZXh0Ym9va3MiLCJHZW9tZXRyeSwgQW5hbHl0aWPigJRUZXh0Ym9va3MiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJIYXNzLCBKb2VsXCIsXCJUaG9tYXMsIEdlb3JnZSBCLiAoR2VvcmdlIEJyaW50b24pLCBKci4sIDE5MTQtMjAwNlwiXX0iLCJvdGhlcl90aXRsZV8xZGlzcGxheSI6IntcIlBvcnRpb24gb2YgdGl0bGVcIjpbXCJDYWxjdWx1c1wiXX0iLCJpc2JuX2Rpc3BsYXkiOlsiOTc4MDMyMTU4ODc2MCIsIjAzMjE1ODg3NjIiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAwOTAyMzA3MCJdLCJsY2NuX3MiOlsiMjAwOTAyMzA3MCJdLCJpc2JuX3MiOlsiOTc4MDMyMTU4ODc2MCJdLCJpc2JuX3QiOlsiOTc4MDMyMTU4ODc2MCJdLCJvY2xjX3MiOlsiMzUxMzEyMzc2Il0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY24zNTEzMTIzNzYiLCI5NzgwMzIxNTg4NzYwIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiNjIxNDExMlwiOntcImxvY2F0aW9uXCI6XCJMZXdpcyBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJMZXdpcyBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJzY2lcIixcImNhbGxfbnVtYmVyXCI6XCJRQTMwMy4yIC5XNDUgMjAxMFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJRQTMwMy4yIC5XNDUgMjAxMFwifSxcIjYyMTg1OTBcIjp7XCJsb2NhdGlvblwiOlwiTGV3aXMgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTGV3aXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic2NpXCIsXCJjYWxsX251bWJlclwiOlwiUUEzMDMuMiAuVzQ1IDIwMTBcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiUUEzMDMuMiAuVzQ1IDIwMTBcIn0sXCI2MjE4NTkyXCI6e1wibG9jYXRpb25cIjpcIkxld2lzIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkxld2lzIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcInNjaVwiLFwiY2FsbF9udW1iZXJcIjpcIlFBMzAzLjIgLlc0NSAyMDEwXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIlFBMzAzLjIgLlc0NSAyMDEwXCJ9LFwiNjIxODU5NlwiOntcImxvY2F0aW9uXCI6XCJMZXdpcyBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJMZXdpcyBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJzY2lcIixcImNhbGxfbnVtYmVyXCI6XCJRQTMwMy4yIC5XNDUgMjAxMFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJRQTMwMy4yIC5XNDUgMjAxMFwifSxcIjYyMTg1OThcIjp7XCJsb2NhdGlvblwiOlwiTGV3aXMgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTGV3aXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic2NpXCIsXCJjYWxsX251bWJlclwiOlwiUUEzMDMuMiAuVzQ1IDIwMTBcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiUUEzMDMuMiAuVzQ1IDIwMTBcIn0sXCI2MjE4NTk5XCI6e1wibG9jYXRpb25cIjpcIkxld2lzIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkxld2lzIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcInNjaVwiLFwiY2FsbF9udW1iZXJcIjpcIlFBMzAzLjIgLlc0NSAyMDEwXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIlFBMzAzLjIgLlc0NSAyMDEwXCJ9LFwiNjIxODYwMFwiOntcImxvY2F0aW9uXCI6XCJMZXdpcyBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJMZXdpcyBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJzY2lcIixcImNhbGxfbnVtYmVyXCI6XCJRQTMwMy4yIC5XNDUgMjAxMFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJRQTMwMy4yIC5XNDUgMjAxMFwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsic2NpIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiTGV3aXMgTGlicmFyeSJdLCJsb2NhdGlvbiI6WyJMZXdpcyBMaWJyYXJ5Il0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUUEzMDMuMiAuVzQ1IDIwMTAiLCJRQTMwMy4yIC5XNDUgMjAxMCIsIlFBMzAzLjIgLlc0NSAyMDEwIiwiUUEzMDMuMiAuVzQ1IDIwMTAiLCJRQTMwMy4yIC5XNDUgMjAxMCIsIlFBMzAzLjIgLlc0NSAyMDEwIiwiUUEzMDMuMiAuVzQ1IDIwMTAiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiUUEzMDMuMiAuVzQ1IDIwMTAiXSwidGltZXN0YW1wIjoiMjAxNi0wNC0yNVQyMDozODo0Mi42OTJaIn19fQ==
-    http_version: 
-  recorded_at: Thu, 26 May 2016 17:13:25 GMT
-- request:
-    method: get
-    uri: https://bibdata.princeton.edu/locations/holding_locations/sci.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 26 May 2016 17:13:02 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Request-Method:
-      - GET
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Token
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 2b620f53-a6f0-4946-9ea6-97a0e48ca5e3
-      X-Runtime:
-      - '0.008784'
-      X-Powered-By:
-      - Phusion Passenger 4.0.59
-      Etag:
-      - W/"a5214a3c7610097e918f6d69a0d7875f"
-      Status:
-      - 200 OK
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"label":"","code":"sci","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Lewis
-        Library","code":"lewis"},"hours_location":{"label":"Lewis Library","code":"lewis"},"delivery_locations":[]}'
     http_version: 
   recorded_at: Thu, 26 May 2016 17:13:25 GMT
 - request:
@@ -12687,109 +12515,6 @@ http_interactions:
   recorded_at: Thu, 04 May 2017 19:56:11 GMT
 - request:
     method: get
-    uri: https://bibdata.princeton.edu/availability?id=8179402
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.12.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 May 2017 20:23:18 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Request-Method:
-      - GET
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Token
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - a9a11bba-bc8c-4b9a-a9a2-9ca7cb375aa4
-      X-Runtime:
-      - '0.084895'
-      X-Powered-By:
-      - Phusion Passenger 4.0.59
-      Etag:
-      - W/"ddf7212892892836d0abc8910c9e1eff"
-      Status:
-      - 200 OK
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"7946042":{"more_items":false,"location":"f","temp_loc":"resc","course_reserves":[{"reserve_list_id":915,"department_name":"African
-        American Studies","department_code":"AAS","course_name":"Creative Explorations
-        of Justice","course_number":"AAS 200","section_id":0,"instructor_first_name":"Christopher
-        L.","instructor_last_name":"Hedges"}],"copy_number":1,"item_id":6828086,"on_reserve":"Y","status":"Not
-        Charged","label":"Firestone Library - Circulation Desk (3 Hour Reserve)"}}'
-    http_version: 
-  recorded_at: Thu, 11 May 2017 20:23:48 GMT
-- request:
-    method: get
-    uri: https://bibdata.princeton.edu/availability?mfhd=7946042
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.12.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 11 May 2017 20:23:18 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Request-Method:
-      - GET
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Token
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - f45f704e-579f-4752-be84-38eb6a02f742
-      X-Runtime:
-      - '0.067939'
-      X-Powered-By:
-      - Phusion Passenger 4.0.59
-      Etag:
-      - W/"382377956f7fd3de674ed56d433b1cb7"
-      Status:
-      - 200 OK
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '[{"barcode":"32101089774630","id":6828086,"location":"f","on_reserve":"Y","temp_loc":"resc","copy_number":1,"item_sequence_number":1,"status":"Not
-        Charged","label":"Firestone Library - Circulation Desk (3 Hour Reserve)"}]'
-    http_version: 
-  recorded_at: Thu, 11 May 2017 20:23:48 GMT
-- request:
-    method: get
     uri: https://pulsearch.princeton.edu/catalog/8179402.json
     body:
       encoding: US-ASCII
@@ -13758,123 +13483,6 @@ http_interactions:
         eyJyZXNwb25zZSI6eyJkb2N1bWVudCI6eyJpZCI6IjczNTI5MzYiLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdfSIsInVuaWZvcm1fdGl0bGVfcyI6WyJQaXBhIChQbGFuby4gVGV4LikiXSwidGl0bGVfZGlzcGxheSI6IlBpcGEgOiB0aGUgbWFnYXppbmUgZm9yIENoaW5lc2Ugc3BlYWtpbmcga2lkcyBpbiBOb3J0aCBBbWVyaWNhLiIsInRpdGxlX3QiOlsiUGlwYSA6IHRoZSBtYWdhemluZSBmb3IgQ2hpbmVzZSBzcGVha2luZyBraWRzIGluIE5vcnRoIEFtZXJpY2EuIl0sIm9wZW5zZWFyY2hfZGlzcGxheSI6WyJQaXBhIDogdGhlIG1hZ2F6aW5lIGZvciBDaGluZXNlIHNwZWFraW5nIGtpZHMgaW4gTm9ydGggQW1lcmljYS4iLCJDaGluZXNlIGxhbmd1YWdlIiwiQ2hpbmVzZSBBbWVyaWNhbiBjaGlsZHJlbiIsIkNoaWxkcmVuJ3MgbGl0ZXJhdHVyZSwgQ2hpbmVzZSIsIlVuaXRlZCBTdGF0ZXMiLCJDaGluYSJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlBpcGEgOiB0aGUgbWFnYXppbmUgZm9yIENoaW5lc2Ugc3BlYWtpbmcga2lkcyBpbiBOb3J0aCBBbWVyaWNhLiJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiUGlwYSA6IHRoZSBtYWdhemluZSBmb3IgQ2hpbmVzZSBzcGVha2luZyBraWRzIGluIE5vcnRoIEFtZXJpY2EuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiUGxhbm8sIFRYIDogTm9ibGUgVHJlZSBQdWJsaXNoaW5nLCBJbmMuLCAyMDEzLSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBsYW5vLCBUWCA6IE5vYmxlIFRyZWUgUHVibGlzaGluZywgSW5jLiwgMjAxMy0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGxhbm8sIFRYOiBOb2JsZSBUcmVlIFB1Ymxpc2hpbmcsIEluYyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxMywicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDEzLTAzLTA3VDE4OjE2OjI0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImVsZWN0cm9uaWNfYWNjZXNzXzFkaXNwbGF5Ijoie1wiaHR0cDovL3d3dy5waXBhbWFnLm9yZ1wiOltcInd3dy5waXBhbWFnLm9yZ1wiXX0iLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInZvbHVtZXMgOiBjb2xvciBpbGx1c3RyYXRpb25zIDsgMjkgY20iLCJCZWdhbiB3aXRoOiBbVm9sdW1lIDEsIG51bWJlciAxXSAoMjAxMykuIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyA6IGNvbG9yIGlsbHVzdHJhdGlvbnMgOyAyOSBjbSIsIkJlZ2FuIHdpdGg6IFtWb2x1bWUgMSwgbnVtYmVyIDFdICgyMDEzKS4iLCJWb2wuIDEsIG5vLiA0IChPY3QuIDIwMTMpIGVycm9uZW91c2x5IG1hcmtlZCBhcyBuby4gMywgSnVseSAyMDEzLiIsIkZpcnN0IGlzc3VlIGlzIGNhbGxlZCBcIuivleWIiuWPtyxcIiB1bmRhdGVkIGFuZCBsYWNraW5nIG51bWJlcmluZy4iLCJWb2wuIDEsIG5vLiAyLTQgYWxzbyBjYWxsZWQgXCLmmKXlraPlj7csXCIgXCLlpI/lraPlj7csXCIgXCLnp4vlraPlj7dcIiJdLCJmcmVxdWVuY3lfZGlzcGxheSI6WyJCaW1vbnRobHksIDIwMTQtIl0sImZvcm1lcl9mcmVxdWVuY3lfZGlzcGxheSI6WyJRdWFydGVybHksIDIwMTMiXSwibm90ZXNfZGlzcGxheSI6WyJTdWJ0aXRsZSB2YXJpZXMgc2xpZ2h0bHkuIiwiXCJUaGUgbWFnYXppbmUgZm9yIENoaW5lc2Ugc3BlYWtpbmcga2lkcyBhbGwgb3ZlciB0aGUgd29ybGRcIi0tY292ZXIgb2YgVm9sLiAyLCBuby4gMyAoTWF5IDIwMTQpIiwiU29tZSBDaGluZXNlIGNoYXJhY3RlcnMgYXJlIGFjY29tcGFuaWVkIHdpdGggcHJvbnVuY2lhdGlvbiBndWlkZSBpbiBQaW55aW4uIiwiQ290c2VuIGNvcHkgaGFzIGVkaXRvci1pbi1jaGllZidzIGF1dG9ncmFwaCBpbiB0aGUgZmlyc3QgaXNzdWUuIiwiVGhlIGZpcnN0IGlzc3VlIG9mIFZvbHVtZXMgMi00IGlzIGluc2VydGVkIHdpdGggYSByZWQgcGFwZXItY3V0IG9mIGEgaG9yc2UsIHNoZWVwLCBhbmQgbW9ua2V5IHJlc3BlY3RpdmVseSwgem9kaWFjIGFuaW1hbHMgb2YgdGhlIHVwY29taW5nIENoaW5lc2UgTmV3IFllYXIuIl0sIm51bWJlcmluZ19wZWNfbm90ZXNfZGlzcGxheSI6WyJWb2wuIDEsIG5vLiA0IChPY3QuIDIwMTMpIGVycm9uZW91c2x5IG1hcmtlZCBhcyBuby4gMywgSnVseSAyMDEzLiIsIkZpcnN0IGlzc3VlIGlzIGNhbGxlZCBcIuivleWIiuWPtyxcIiB1bmRhdGVkIGFuZCBsYWNraW5nIG51bWJlcmluZy4iLCJWb2wuIDEsIG5vLiAyLTQgYWxzbyBjYWxsZWQgXCLmmKXlraPlj7csXCIgXCLlpI/lraPlj7csXCIgXCLnp4vlraPlj7dcIiJdLCJzb3VyY2VfZGVzY19ub3Rlc19kaXNwbGF5IjpbIkRlc2NyaXB0aW9uIGJhc2VkIG9uOiBbVm9sdW1lIDEsIG51bWJlciAxXSAoMjAxMyk7IHRpdGxlIGZyb20gY292ZXIuIiwiTGF0ZXN0IGlzc3VlIGNvbnN1bHRlZDogVm9sdW1lIDMsIG51bWJlciAxLCBpc3N1ZSBuby4gMTEgKEphbnVhcnkgMjAxNSkuIl0sImxhbmd1YWdlX2Rpc3BsYXkiOlsiQ2hpZWZseSBpbiBDaGluZXNlLCB3aXRoIHNvbWUgcGFyYWxsZWwgRW5nbGlzaCB0cmFuc2xhdGlvbnMuIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkNoaW5lc2UiLCJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJjaGkiLCJlbmciXSwic291cmNlX2FjcXVpc2l0aW9uX2Rpc3BsYXkiOlsiNTQxLTAwIOivleWIiuWPtyBHaWZ0OyBQdWJsaXNoZXI7IDIwMTMwMzAyLiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiQ2hpbmVzZSBsYW5ndWFnZeKAlFBlcmlvZGljYWxz4oCUSnV2ZW5pbGUgbGl0ZXJhdHVyZSIsIkNoaW5lc2UgQW1lcmljYW4gY2hpbGRyZW7igJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiLCJDaGlsZHJlbidzIGxpdGVyYXR1cmUsIENoaW5lc2XigJRVbml0ZWQgU3RhdGVz4oCUUGVyaW9kaWNhbHMiLCJDaGluYeKAlFBlcmlvZGljYWxz4oCUSnV2ZW5pbGUgbGl0ZXJhdHVyZSJdLCJzdWJqZWN0X3QiOlsiQ2hpbmVzZSBsYW5ndWFnZeKAlFBlcmlvZGljYWxz4oCUSnV2ZW5pbGUgbGl0ZXJhdHVyZSIsIkNoaW5lc2UgQW1lcmljYW4gY2hpbGRyZW7igJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiLCJDaGlsZHJlbidzIGxpdGVyYXR1cmUsIENoaW5lc2XigJRVbml0ZWQgU3RhdGVz4oCUUGVyaW9kaWNhbHMiLCJDaGluYeKAlFBlcmlvZGljYWxz4oCUSnV2ZW5pbGUgbGl0ZXJhdHVyZSJdLCJzdWJqZWN0X2ZhY2V0IjpbIkNoaW5lc2UgbGFuZ3VhZ2XigJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiLCJDaGluZXNlIEFtZXJpY2FuIGNoaWxkcmVu4oCUUGVyaW9kaWNhbHPigJRKdXZlbmlsZSBsaXRlcmF0dXJlIiwiQ2hpbGRyZW4ncyBsaXRlcmF0dXJlLCBDaGluZXNl4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIiwiQ2hpbmHigJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiXSwiZm9ybV9nZW5yZV9kaXNwbGF5IjpbIlBlcmlvZGljYWxzLiJdLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIlBpcGEgKFBsYW5vLiBUZXguKSIsIlhpYcyGbyBwacyBIHBhIiwiXCJYaWFvIHBpIHBhXCIgemEgemhpIiwiUGlwYSBtYWdhemluZSIsIlBpIHBhIiwi5bCP5p6H5p23IiwiXCLlsI/mnofmnbdcIuadguW/lyJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiWGlhzIZvIHBpzIEgcGEiLCJcIlhpYW8gcGkgcGFcIiB6YSB6aGkiLCJQaXBhIG1hZ2F6aW5lIiwiUGkgcGEiLCLlsI/mnofmnbciLCJcIuWwj+aeh+adt1wi5p2C5b+XIl0sImlzc25fZGlzcGxheSI6WyIyMzI2LTgxMzEiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxMzIwMDIxNyJdLCJsY2NuX3MiOlsiMjAxMzIwMDIxNyJdLCJpc3NuX3MiOlsiMjMyNjgxMzEiXSwib2NsY19zIjpbIjgyODE0NjE2NSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuODI4MTQ2MTY1IiwiMjMyNjgxMzEiLCIyMzI2ODE0WCIsIm9jbjgyODE0NjE3MSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjcxNzk0NjNcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIENvdHNlbiBDaGlsZHJlbidzIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImN0c25cIixcImNhbGxfbnVtYmVyXCI6XCJQYW1zIC8gTlIgLyBDaGluZXNlIC8gQm94IDQxIDE1MzUyMVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIxNTM1MjFcIixcImxvY2F0aW9uX2hhc1wiOltcIlZvbC4gMTogW25vLiAxXS1bbm8uIDRdIChbSmFuLl0gMjAxMyAtIFtPY3QuXSAyMDEzKVwiLFwiVm9sLiAyOiBuby4gMS02ICg9SXNzdWUgbm8uIDUtMTA7IEphbi4gMjAxNCAtIE5vdi4gMjAxNClcIixcIlZvbC4gMzogbm8uIDEtNiAoPUlzc3VlIG5vLiAxMS0xNjsgSmFuLiAyMDE1IC0gTm92LiAyMDE1KVwiLFwiVm9sLiA0OiBuby4gMS02ICg9SXNzdWUgbm8uIDE3LTIyOyBKYW4uIDIwMTYgLSBOb3YuIDIwMTYpXCIsXCJWb2wuIDU6IG5vLiAxLTQgKD1Jc3N1ZSBuby4gMjMtMjY7IEphbi4gMjAxNyAtIEp1bHkgMjAxNylcIl19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJjdHNuIl0sImxvY2F0aW9uIjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gQ290c2VuIENoaWxkcmVuJ3MgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImN0c24iLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUGFtcyAvIE5SIC8gQ2hpbmVzZSAvIEJveCA0MSAxNTM1MjEiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiMTUzNTIxIl0sInRpbWVzdGFtcCI6IjIwMTctMDctMjZUMDQ6NDE6MjcuNjY0WiJ9fX0=
     http_version: 
   recorded_at: Tue, 05 Sep 2017 15:17:17 GMT
-- request:
-    method: get
-    uri: https://bibdata.princeton.edu/availability?mfhd=7179463
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.13.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 05 Sep 2017 15:17:18 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Request-Method:
-      - GET
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Token
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - d841d194-f9bb-4b74-8761-c26a15709bba
-      X-Runtime:
-      - '0.377234'
-      X-Powered-By:
-      - Phusion Passenger 4.0.59
-      Etag:
-      - W/"4d9bbcdd8449dac26a5ecf0f1ee7581d"
-      Status:
-      - 200 OK
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '[{"barcode":"32101094417795","id":7572015,"location":"ctsn","copy_number":1,"item_sequence_number":5,"status":"On-Site","on_reserve":"N","enum":"Vol.
-        5: no. 1-6","chron":"Jan 2017 - Nov 2017","enum_display":"Vol. 5: no. 1-6
-        (Jan 2017 - Nov 2017)","label":"Rare Books and Special Collections - Cotsen
-        Children''s Library"},{"barcode":"32101091127959","id":7314885,"location":"ctsn","copy_number":1,"item_sequence_number":4,"status":"On-Site","on_reserve":"N","enum":"Vol.
-        4: no. 1 - 6","chron":"Jan 2016 - Nov 2016","enum_display":"Vol. 4: no. 1
-        - 6 (Jan 2016 - Nov 2016)","label":"Rare Books and Special Collections - Cotsen
-        Children''s Library"},{"barcode":"32101071686446","id":7166642,"location":"ctsn","copy_number":1,"item_sequence_number":3,"status":"On-Site","on_reserve":"N","enum":"Vol.
-        3: no. 1 - 6","chron":"Jan 2015 - Nov 2015","enum_display":"Vol. 3: no. 1
-        - 6 (Jan 2015 - Nov 2015)","label":"Rare Books and Special Collections - Cotsen
-        Children''s Library"},{"barcode":"32101071686438","id":7166635,"location":"ctsn","copy_number":1,"item_sequence_number":2,"status":"On-Site","on_reserve":"N","enum":"Vol.
-        2: no. 1 - 6","chron":"Jan 2014 - Nov 2014","enum_display":"Vol. 2: no. 1
-        - 6 (Jan 2014 - Nov 2014)","label":"Rare Books and Special Collections - Cotsen
-        Children''s Library"},{"barcode":"32101071302192","id":6559967,"location":"ctsn","copy_number":1,"item_sequence_number":1,"status":"On-Site","on_reserve":"N","enum":"Vol
-        1: no. 1 - 4","chron":"Jan 2013 - Oct 2013","enum_display":"Vol 1: no. 1 -
-        4 (Jan 2013 - Oct 2013)","label":"Rare Books and Special Collections - Cotsen
-        Children''s Library"}]'
-    http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:17:18 GMT
-- request:
-    method: get
-    uri: https://bibdata.princeton.edu/locations/holding_locations/ctsn.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.13.1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 05 Sep 2017 15:17:18 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Request-Method:
-      - GET
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Token
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - b631ef76-06c5-4e77-8813-aca20cb14edd
-      X-Runtime:
-      - '0.012542'
-      X-Powered-By:
-      - Phusion Passenger 4.0.59
-      Etag:
-      - W/"31fda0672f495884e17c7cfdabfa8fea"
-      Status:
-      - 200 OK
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-    body:
-      encoding: UTF-8
-      string: '{"label":"Cotsen Children''s Library","code":"ctsn","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"library":{"label":"Rare
-        Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone
-        Library - Cotsen Children''s Library - Research Collection","code":"cotsenresearch"},"delivery_locations":[{"label":"Rare
-        Books and Special Collections","address":"One Washington Rd. Princeton, NJ
-        08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true}]}'
-    http_version: 
-  recorded_at: Tue, 05 Sep 2017 15:17:18 GMT
 - request:
     method: get
     uri: https://pulsearch.princeton.edu/catalog/9168829.json
@@ -18397,114 +18005,6 @@ http_interactions:
   recorded_at: Thu, 27 Sep 2018 20:32:44 GMT
 - request:
     method: get
-    uri: https://catalog.princeton.edu/catalog/8179402/raw
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.4
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.17.3
-      Date:
-      - Mon, 16 Sep 2019 13:34:24 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Status:
-      - 200 OK
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Request-Id:
-      - 1c32ab8a-5511-4c57-9c2c-5d6b3aa02e90
-      X-Ua-Compatible:
-      - IE=edge,chrome=1
-      Etag:
-      - W/"f3e2cfa1a5d69e4436b79560e8631ee8"
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Runtime:
-      - '0.014993'
-      X-Content-Type-Options:
-      - nosniff
-      X-Powered-By:
-      - Phusion Passenger 6.0.2
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        eyJpZCI6IjgxNzk0MDIiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIk1vb3JlLCBMb3JyaWUiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTW9vcmUsIExvcnJpZSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIk1vb3JlLCBMb3JyaWVcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiTW9vcmUsIExvcnJpZVwifSIsImF1dGhvcl9zIjpbIk1vb3JlLCBMb3JyaWUiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJTaG9ydCBzdG9yaWVzLiBTZWxlY3Rpb25zIl0sInRpdGxlX2Rpc3BsYXkiOiJCYXJrIDogc3RvcmllcyAvIExvcnJpZSBNb29yZS4iLCJ0aXRsZV90IjpbIkJhcmsgOiBzdG9yaWVzIC8gTG9ycmllIE1vb3JlLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkJhcmsgOiBzdG9yaWVzIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJCYXJrIDogc3RvcmllcyAvIExvcnJpZSBNb29yZS4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIkZpcnN0IEVkaXRpb24uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBBbGZyZWQgQS4gS25vcGYsIDIwMTQuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBBbGZyZWQgQS4gS25vcGYsIDIwMTQuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBBbGZyZWQgQS4gS25vcGYiXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE0Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTQsImNhdGFsb2dlZF90ZHQiOiIyMDE0LTAzLTE5VDE4OjI5OjQ0WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTkyIHBhZ2VzIDsgMjIgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTkyIHBhZ2VzIDsgMjIgY20uIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjE5MiBwYWdlcyJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJzdW1tYXJ5X25vdGVfZGlzcGxheSI6WyJJbiB0aGVzZSBlaWdodCBtYXN0ZXJmdWwgc3RvcmllcywgTG9ycmllIE1vb3JlLCBpbiBhIHBlcmZlY3QgYmxlbmQgb2YgY3JhZnQgYW5kIGJld2l0Y2hlZCBzcGlyaXQsIGV4cGxvcmVzIHRoZSBwYXNzYWdlIG9mIHRpbWUgYW5kIHN1bW1vbnMgdXAgaXRzIGluZXZpdGFibGUgc29ycm93cyBhbmQgaGlsYXJpb3VzIHBpdGZhbGxzIHRvIHJldmVhbCBoZXIgb3duIGV4cXVpc2l0ZSwgc2luZ3VsYXIgd2lzZG9tLiBJbiBcIkRlYmFya2luZyxcIiBhIG5ld2x5IGRpdm9yY2VkIG1hbiB0cmllcyB0byBrZWVwIGhpcyB3aXRzIGFib3V0IGhpbSBhcyB0aGUgVW5pdGVkIFN0YXRlcyBwcmVwYXJlcyB0byBpbnZhZGUgSXJhcSwgYW5kIGFnYWluc3QgdGhpcyBvbWlub3VzIG1vbWVudCwgd2Ugc2VlLS1pbiBhbGwgaXRzIGlycmVzaXN0aWJsZSBoaWxhcml0eSBhbmQgZGFya25lc3MtLXRoZSBwZXJpbHMgb2YgZGl2b3JjZSBhbmQgd2hhdCBjYW4gZm9sbG93IGluIGl0cyB3YWtlLiBJbiBcIkZvZXMsXCIgYSBwb2xpdGljYWwgYXJndW1lbnQgZ29lcyBncm90ZXNxdWVseSBhd3J5IGFzIHRoZSBldmVudHMgb2YgOS8xMSB1bmV4cGVjdGVkbHkgbWFuaWZlc3QgYXQgYSBmdW5kLXJhaXNpbmcgZGlubmVyIGluIEdlb3JnZXRvd24uIEluIFwiVGhlIEp1bmlwZXIgVHJlZSxcIiBhIHRlYWNoZXIsIHZpc2l0ZWQgYnkgdGhlIGdob3N0IG9mIGhlciByZWNlbnRseSBkZWNlYXNlZCBmcmllbmQsIGlzIGZvcmNlZCB0byBzaW5nIFwiVGhlIFN0YXItU3BhbmdsZWQgQmFubmVyXCIgaW4gYSBraW5kIG9mIG5pZ2h0bWFyZSByZXVuaW9uLiBBbmQgaW4gXCJXaW5ncyxcIiB3ZSB3YXRjaCB0aGUgdW5yYXZlbGluZyBvZiB0d28gb25jZS1ob3BlZnVsIG11c2ljaWFucyB3aG8gbmVpdGhlciBoZWxkIGZhc3QgdG8gdGhlaXIgZHJlYW1zIG5vciBzdHJ1Y2sgb3V0IGFsb25nIG90aGVyIHBhdGhzIGFzIE1vb3JlIGRlZnRseSBkZXBpY3RzIHRoZSBpbnRyaWNhY2llcyBvZiBkZWFkIGVuZHMgYW5kIHRoZSB3b3JraW5ncyBvZiByZWdyZXQiXSwibm90ZXNfZGlzcGxheSI6WyJcIlRoaXMgaXMgYSBCb3J6b2kgQm9vay5cIiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sImNvbnRlbnRzX2Rpc3BsYXkiOlsiRGViYXJraW5nIC0tIFRoZSBqdW5pcGVyIHRyZWUgLS0gUGFwZXIgbG9zc2VzIC0tIEZvZXMgLS0gV2luZ3MgLS0gUmVmZXJlbnRpYWwgLS0gU3ViamVjdCB0byBzZWFyY2ggLS0gVGhhbmsgeW91IGZvciBoYXZpbmcgbWUuIl0sInN1YmplY3RfZGlzcGxheSI6WyJTaG9ydCBzdG9yaWVzLCBBbWVyaWNhbiIsIlVuaXRlZCBTdGF0ZXPigJRTb2NpYWwgbGlmZSBhbmQgY3VzdG9tc+KAlDIxc3QgY2VudHVyeeKAlEZpY3Rpb24iXSwic3ViamVjdF9mYWNldCI6WyJTaG9ydCBzdG9yaWVzLCBBbWVyaWNhbiIsIlVuaXRlZCBTdGF0ZXPigJRTb2NpYWwgbGlmZSBhbmQgY3VzdG9tc+KAlDIxc3QgY2VudHVyeeKAlEZpY3Rpb24iXSwiZm9ybV9nZW5yZV9kaXNwbGF5IjpbIlNob3J0IHN0b3JpZXMiXSwiY29udGFpbnNfMWRpc3BsYXkiOiJbW1wiTW9vcmUsIExvcnJpZS5cIixcIkRlYmFya2luZy5cIl1dIiwiaXNibl9kaXNwbGF5IjpbIjk3ODAzMDc1OTQxMzYgKGhhcmRjb3ZlciA6IGFsay4gcGFwZXIpIiwiMDMwNzU5NDEzMCAoaGFyZGNvdmVyIDogYWxrLiBwYXBlcikiLCIiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxMzAxNDc3NyJdLCJsY2NuX3MiOlsiMjAxMzAxNDc3NyJdLCJpc2JuX3MiOlsiOTc4MDMwNzU5NDEzNiJdLCJvY2xjX3MiOlsiODQwOTM3MjU1Il0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY244NDA5MzcyNTUiLCI5NzgwMzA3NTk0MTM2IiwiOTc4MDM4NTM1MTcxMyJdLCJzdWJqZWN0X2VyYV9mYWNldCI6WyIyMXN0IGNlbnR1cnkiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI3OTQ2MDQyXCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY2FsbF9udW1iZXJcIjpcIlBTMzU2My5PNjIyNSBCMzcgMjAxNFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJQUzM1NjMuTzYyMjUgQjM3IDIwMTRcIn19IiwiZm9ybV9nZW5yZV9yZW1haW5pbmdfZGlzcGxheSI6WyJTaG9ydCBzdG9yaWVzIl0sImxvY2F0aW9uX2NvZGVfcyI6WyJmIl0sImxvY2F0aW9uIjpbIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiRmlyZXN0b25lIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJmIiwiRmlyZXN0b25lIExpYnJhcnkiXSwibmFtZV91bmlmb3JtX3RpdGxlXzFkaXNwbGF5IjoiW1tcIk1vb3JlLCBMb3JyaWUuXCIsXCJTaG9ydCBzdG9yaWVzLlwiLFwiU2VsZWN0aW9uc1wiXV0iLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIk1vb3JlLCBMb3JyaWUuIERlYmFya2luZyIsIk1vb3JlLCBMb3JyaWUuIFNob3J0IHN0b3JpZXMiLCJNb29yZSwgTG9ycmllLiBTaG9ydCBzdG9yaWVzLiBTZWxlY3Rpb25zIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUFMzNTYzLk82MjI1IEIzNyAyMDE0Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIlBTMzU2My5PNjIyNSBCMzcgMjAxNCJdLCJfdmVyc2lvbl8iOjE2Mzk1NTEyNzI5NDgzMzQ1OTIsInRpbWVzdGFtcCI6IjIwMTktMDctMjBUMDQ6NDU6MzkuMzg2WiJ9
-    http_version: 
-  recorded_at: Mon, 16 Sep 2019 13:34:24 GMT
-- request:
-    method: get
-    uri: https://catalog.princeton.edu/catalog/7352936/raw
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.15.4
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.17.3
-      Date:
-      - Mon, 16 Sep 2019 13:34:25 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Status:
-      - 200 OK
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Request-Id:
-      - d516b99a-7961-4a09-b2a7-35d16a2d602b
-      X-Ua-Compatible:
-      - IE=edge,chrome=1
-      Etag:
-      - W/"c7ce56b6f89d3a564b0895b889ab9730"
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Runtime:
-      - '0.015457'
-      X-Content-Type-Options:
-      - nosniff
-      X-Powered-By:
-      - Phusion Passenger 6.0.2
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        eyJpZCI6IjczNTI5MzYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W10sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwidW5pZm9ybV90aXRsZV9zIjpbIlBpcGEgKFBsYW5vLiBUZXguKSJdLCJ0aXRsZV9kaXNwbGF5IjoiUGlwYSA6IHRoZSBtYWdhemluZSBmb3IgQ2hpbmVzZSBzcGVha2luZyBraWRzIGluIE5vcnRoIEFtZXJpY2EuIiwidGl0bGVfdCI6WyJQaXBhIDogdGhlIG1hZ2F6aW5lIGZvciBDaGluZXNlIHNwZWFraW5nIGtpZHMgaW4gTm9ydGggQW1lcmljYS4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJQaXBhIDogdGhlIG1hZ2F6aW5lIGZvciBDaGluZXNlIHNwZWFraW5nIGtpZHMgaW4gTm9ydGggQW1lcmljYSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiUGlwYSA6IHRoZSBtYWdhemluZSBmb3IgQ2hpbmVzZSBzcGVha2luZyBraWRzIGluIE5vcnRoIEFtZXJpY2EuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiUGxhbm8sIFRYIDogTm9ibGUgVHJlZSBQdWJsaXNoaW5nLCBJbmMuLCAyMDEzLSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBsYW5vLCBUWCA6IE5vYmxlIFRyZWUgUHVibGlzaGluZywgSW5jLiwgMjAxMy0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGxhbm8sIFRYOiBOb2JsZSBUcmVlIFB1Ymxpc2hpbmcsIEluYyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxMywicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDEzLTAzLTA3VDE4OjE2OjI0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImVsZWN0cm9uaWNfYWNjZXNzXzFkaXNwbGF5Ijoie1wiaHR0cDovL3d3dy5waXBhbWFnLm9yZ1wiOltcInd3dy5waXBhbWFnLm9yZ1wiXX0iLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInZvbHVtZXMgOiBjb2xvciBpbGx1c3RyYXRpb25zIDsgMjkgY20iLCJCZWdhbiB3aXRoOiBbVm9sdW1lIDEsIG51bWJlciAxXSAoMjAxMykuIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyA6IGNvbG9yIGlsbHVzdHJhdGlvbnMgOyAyOSBjbSIsIkJlZ2FuIHdpdGg6IFtWb2x1bWUgMSwgbnVtYmVyIDFdICgyMDEzKS4iLCJWb2wuIDEsIG5vLiA0IChPY3QuIDIwMTMpIGVycm9uZW91c2x5IG1hcmtlZCBhcyBuby4gMywgSnVseSAyMDEzLiIsIkZpcnN0IGlzc3VlIGlzIGNhbGxlZCBcIuivleWIiuWPtyxcIiB1bmRhdGVkIGFuZCBsYWNraW5nIG51bWJlcmluZy4iLCJWb2wuIDEsIG5vLiAyLTQgYWxzbyBjYWxsZWQgXCLmmKXlraPlj7csXCIgXCLlpI/lraPlj7csXCIgXCLnp4vlraPlj7dcIiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImZyZXF1ZW5jeV9kaXNwbGF5IjpbIkJpbW9udGhseSwgMjAxNC0iXSwiZm9ybWVyX2ZyZXF1ZW5jeV9kaXNwbGF5IjpbIlF1YXJ0ZXJseSwgMjAxMyJdLCJyZWxhdGVkX3JlY29yZF9pbmZvX2Rpc3BsYXkiOlsiT25saW5lIHZlcnNpb246Il0sIm5vdGVzX2Rpc3BsYXkiOlsiU3VidGl0bGUgdmFyaWVzIHNsaWdodGx5LiIsIlwiVGhlIG1hZ2F6aW5lIGZvciBDaGluZXNlIHNwZWFraW5nIGtpZHMgYWxsIG92ZXIgdGhlIHdvcmxkXCItLWNvdmVyIG9mIFZvbC4gMiwgbm8uIDMgKE1heSAyMDE0KSIsIlNvbWUgQ2hpbmVzZSBjaGFyYWN0ZXJzIGFyZSBhY2NvbXBhbmllZCB3aXRoIHByb251bmNpYXRpb24gZ3VpZGUgaW4gUGlueWluLiIsIkNvdHNlbiBjb3B5IGhhcyBlZGl0b3ItaW4tY2hpZWYncyBhdXRvZ3JhcGggaW4gdGhlIGZpcnN0IGlzc3VlLiIsIlRoZSBmaXJzdCBpc3N1ZSBvZiBWb2x1bWVzIDItNCBpcyBpbnNlcnRlZCB3aXRoIGEgcmVkIHBhcGVyLWN1dCBvZiBhIGhvcnNlLCBzaGVlcCwgYW5kIG1vbmtleSByZXNwZWN0aXZlbHksIHpvZGlhYyBhbmltYWxzIG9mIHRoZSB1cGNvbWluZyBDaGluZXNlIE5ldyBZZWFyLiJdLCJudW1iZXJpbmdfcGVjX25vdGVzX2Rpc3BsYXkiOlsiVm9sLiAxLCBuby4gNCAoT2N0LiAyMDEzKSBlcnJvbmVvdXNseSBtYXJrZWQgYXMgbm8uIDMsIEp1bHkgMjAxMy4iLCJGaXJzdCBpc3N1ZSBpcyBjYWxsZWQgXCLor5XliIrlj7csXCIgdW5kYXRlZCBhbmQgbGFja2luZyBudW1iZXJpbmcuIiwiVm9sLiAxLCBuby4gMi00IGFsc28gY2FsbGVkIFwi5pil5a2j5Y+3LFwiIFwi5aSP5a2j5Y+3LFwiIFwi56eL5a2j5Y+3XCIiXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbjogW1ZvbHVtZSAxLCBudW1iZXIgMV0gKDIwMTMpOyB0aXRsZSBmcm9tIGNvdmVyLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IFZvbHVtZSAzLCBudW1iZXIgMSwgaXNzdWUgbm8uIDExIChKYW51YXJ5IDIwMTUpLiJdLCJsYW5ndWFnZV9kaXNwbGF5IjpbIkNoaWVmbHkgaW4gQ2hpbmVzZSwgd2l0aCBzb21lIHBhcmFsbGVsIEVuZ2xpc2ggdHJhbnNsYXRpb25zLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJDaGluZXNlIiwiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiY2hpIiwiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJ6aCIsImVuIl0sInNvdXJjZV9hY3F1aXNpdGlvbl9kaXNwbGF5IjpbIjU0MS0wMCDor5XliIrlj7cgR2lmdDsgUHVibGlzaGVyOyAyMDEzMDMwMi4iXSwic3ViamVjdF9kaXNwbGF5IjpbIkNoaW5lc2UgbGFuZ3VhZ2XigJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiLCJDaGluZXNlIEFtZXJpY2FuIGNoaWxkcmVu4oCUUGVyaW9kaWNhbHPigJRKdXZlbmlsZSBsaXRlcmF0dXJlIiwiQ2hpbGRyZW4ncyBsaXRlcmF0dXJlLCBDaGluZXNl4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIiwiQ2hpbmHigJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiXSwic3ViamVjdF9mYWNldCI6WyJDaGluZXNlIGxhbmd1YWdl4oCUUGVyaW9kaWNhbHPigJRKdXZlbmlsZSBsaXRlcmF0dXJlIiwiQ2hpbmVzZSBBbWVyaWNhbiBjaGlsZHJlbuKAlFBlcmlvZGljYWxz4oCUSnV2ZW5pbGUgbGl0ZXJhdHVyZSIsIkNoaWxkcmVuJ3MgbGl0ZXJhdHVyZSwgQ2hpbmVzZeKAlFVuaXRlZCBTdGF0ZXPigJRQZXJpb2RpY2FscyIsIkNoaW5h4oCUUGVyaW9kaWNhbHPigJRKdXZlbmlsZSBsaXRlcmF0dXJlIl0sImZvcm1fZ2VucmVfZGlzcGxheSI6WyJQZXJpb2RpY2FscyJdLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIlBpcGEgKFBsYW5vLiBUZXguKSIsIlhpYcyGbyBwacyBIHBhIiwiXCJYaWFvIHBpIHBhXCIgemEgemhpIiwiUGlwYSBtYWdhemluZSIsIlBpIHBhIiwi5bCP5p6H5p23IiwiXCLlsI/mnofmnbdcIuadguW/lyJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiWGlhzIZvIHBpzIEgcGEiLCJcIlhpYW8gcGkgcGFcIiB6YSB6aGkiLCJQaXBhIG1hZ2F6aW5lIiwiUGkgcGEiLCLlsI/mnofmnbciLCJcIuWwj+aeh+adt1wi5p2C5b+XIl0sImlzc25fZGlzcGxheSI6WyIyMzI2LTgxMzEiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxMzIwMDIxNyJdLCJsY2NuX3MiOlsiMjAxMzIwMDIxNyJdLCJpc3NuX3MiOlsiMjMyNjgxMzEiXSwib2NsY19zIjpbIjgyODE0NjE2NSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuODI4MTQ2MTY1IiwiMjMyNjgxMzEiLCIyMzI2ODE0WCIsIm9jbjgyODE0NjE3MSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjcxNzk0NjNcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIENvdHNlbiBDaGlsZHJlbidzIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImN0c25cIixcImNhbGxfbnVtYmVyXCI6XCJQYW1zIC8gTlIgLyBDaGluZXNlIC8gQm94IDQxIDE1MzUyMVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIxNTM1MjFcIixcImxvY2F0aW9uX2hhc1wiOltcIlZvbC4gMTogW25vLiAxXS1bbm8uIDRdIChbSmFuLl0gMjAxMyAtIFtPY3QuXSAyMDEzKVwiLFwiVm9sLiAyOiBuby4gMS02ICg9SXNzdWUgbm8uIDUtMTA7IEphbi4gMjAxNCAtIE5vdi4gMjAxNClcIixcIlZvbC4gMzogbm8uIDEtNiAoPUlzc3VlIG5vLiAxMS0xNjsgSmFuLiAyMDE1IC0gTm92LiAyMDE1KVwiLFwiVm9sLiA0OiBuby4gMS02ICg9SXNzdWUgbm8uIDE3LTIyOyBKYW4uIDIwMTYgLSBOb3YuIDIwMTYpXCIsXCJWb2wuIDU6IG5vLiAxLTYgKD1Jc3N1ZSBuby4gMjMtMjg7IEphbi4gMjAxNyAtIE5vdi4gMjAxNylcIl19LFwiMTA0NDQ3MzFcIjp7XCJsb2NhdGlvblwiOlwiUmFyZSBCb29rcyBhbmQgU3BlY2lhbCBDb2xsZWN0aW9ucyAtIENvdHNlbiBDaGlsZHJlbidzIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImN0c25cIixcImNhbGxfbnVtYmVyXCI6XCJQYW1zIC8gTlIgLyBDaGluZXNlIC8gQm94IDEwMCA5MTEyOTI4NlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCI5MTEyOTI4NlwiLFwibG9jYXRpb25faGFzXCI6W1wiVm9sLiA2OiBuby4gMS02ICg9SXNzdWUgbm8uIDI5LTM0OyBKYW4uIDIwMTggLSBOb3YuIDIwMTgpXCJdfSxcIjEwODYzNDQ3XCI6e1wibG9jYXRpb25cIjpcIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMgLSBDb3RzZW4gQ2hpbGRyZW4ncyBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJjdHNuXCIsXCJjYWxsX251bWJlclwiOlwiUGFtcyAvIE5SIC8gQ2hpbmVzZSAvIEJveCA4NSA5MTEyOTI4NlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCI5MTEyOTI4NlwiLFwibG9jYXRpb25faGFzXCI6W1wiVm9sLiA3OiBuby4gMS00ICg9SXNzdWUgbm8uIDM1LTM4OyBKYW4uIDIwMTkgLSBKdWx5IDIwMTkpXCJdfX0iLCJmb3JtX2dlbnJlX3JlbWFpbmluZ19kaXNwbGF5IjpbIlBlcmlvZGljYWxzIl0sImxvY2F0aW9uX2NvZGVfcyI6WyJjdHNuIl0sImxvY2F0aW9uIjpbIlJhcmUgQm9va3MgYW5kIFNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIC0gQ290c2VuIENoaWxkcmVuJ3MgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImN0c24iLCJSYXJlIEJvb2tzIGFuZCBTcGVjaWFsIENvbGxlY3Rpb25zIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUGFtcyAvIE5SIC8gQ2hpbmVzZSAvIEJveCA0MSAxNTM1MjEiLCJQYW1zIC8gTlIgLyBDaGluZXNlIC8gQm94IDEwMCA5MTEyOTI4NiIsIlBhbXMgLyBOUiAvIENoaW5lc2UgLyBCb3ggODUgOTExMjkyODYiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiMTUzNTIxIiwiOTExMjkyODYiXSwiX3ZlcnNpb25fIjoxNjM5MTg4NjQ3Njk3NzExMTA0LCJ0aW1lc3RhbXAiOiIyMDE5LTA3LTE2VDA0OjQxOjUyLjk1N1oifQ==
-    http_version: 
-  recorded_at: Mon, 16 Sep 2019 13:34:25 GMT
-- request:
-    method: get
     uri: https://catalog.princeton.edu/catalog/foo/raw
     body:
       encoding: US-ASCII
@@ -20829,13 +20329,13 @@ http_interactions:
   recorded_at: Mon, 16 Sep 2019 14:02:44 GMT
 - request:
     method: get
-    uri: https://catalog.princeton.edu/catalog/3848872/raw
+    uri: https://catalog.princeton.edu/catalog/7617477/raw
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -20848,7 +20348,7 @@ http_interactions:
       Server:
       - nginx/1.17.6
       Date:
-      - Fri, 31 Jan 2020 07:23:42 GMT
+      - Tue, 17 Mar 2020 17:45:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -20862,15 +20362,652 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - 40a0c771-4a10-4154-9462-a0820f3d5619
+      - '059c3e1f-c102-404f-b016-26fb1a66d3a9'
       X-Ua-Compatible:
       - IE=edge,chrome=1
       Etag:
-      - W/"0a12d4f2a7a427d0c6fb9ece1e6f1f28"
+      - W/"a5244bbe569ec89121827d761a74615d"
       X-Frame-Options:
       - SAMEORIGIN
       X-Runtime:
-      - '0.014040'
+      - '0.022782'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6Ijc2MTc0NzciLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIk11cmFrYW1pLCBIYXJ1a2ksIDE5NDktIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIk11cmFrYW1pLCBIYXJ1a2kiLCJSdWJpbiwgSmF5IiwiR2FicmllbCwgUGhpbGlwIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiUnViaW4sIEpheVwiLFwiR2FicmllbCwgUGhpbGlwXCJdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIk11cmFrYW1pLCBIYXJ1a2lcIn0iLCJhdXRob3JfcyI6WyJNdXJha2FtaSwgSGFydWtpLCAxOTQ5LSIsIlJ1YmluLCBKYXksIDE5NDEtIiwiR2FicmllbCwgUGhpbGlwLCAxOTUzLSJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidW5pZm9ybV90aXRsZV9zIjpbIjFRODQuIEVuZ2xpc2giXSwidGl0bGVfZGlzcGxheSI6IjFRODQgW2VsZWN0cm9uaWMgcmVzb3VyY2VdIC8gSGFydWtpIE11cmFrYW1pIDsgdHJhbnNsYXRlZCBmcm9tIHRoZSBKYXBhbmVzZSBieSBKYXkgUnViaW4gYW5kIFBoaWxpcCBHYWJyaWVsLiIsInRpdGxlX3QiOlsiMVE4NCBbZWxlY3Ryb25pYyByZXNvdXJjZV0gLyBIYXJ1a2kgTXVyYWthbWkgOyB0cmFuc2xhdGVkIGZyb20gdGhlIEphcGFuZXNlIGJ5IEpheSBSdWJpbiBhbmQgUGhpbGlwIEdhYnJpZWwuIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiMVE4NCJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiMVE4NCBbZWxlY3Ryb25pYyByZXNvdXJjZV0gLyBIYXJ1a2kgTXVyYWthbWkgOyB0cmFuc2xhdGVkIGZyb20gdGhlIEphcGFuZXNlIGJ5IEpheSBSdWJpbiBhbmQgUGhpbGlwIEdhYnJpZWwuIl0sImVkaXRpb25fZGlzcGxheSI6WyJLaW5kbGUgZWQuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBBbGZyZWQgQS4gS25vcGYsIDIwMTEuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBBbGZyZWQgQS4gS25vcGYsIDIwMTEuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBBbGZyZWQgQS4gS25vcGYiXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDExIl0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTEsImZvcm1hdCI6WyJCb29rIl0sImVsZWN0cm9uaWNfYWNjZXNzXzFkaXNwbGF5Ijoie1wiaHR0cDovL2xpYmd1aWRlcy5wcmluY2V0b24uZWR1L2NvbnRlbnQucGhwP3BpZD0yOTU3MTdcdTAwMjZzaWQ9MjQyNzk4OVwiOltcImxpYmd1aWRlcy5wcmluY2V0b24uZWR1XCIsXCJBdmFpbGFibGUgb25seSBvbiBhIGxpYnJhcnkgaVBhZC4gQ2xpY2sgaGVyZSBmb3IgaW5mb3JtYXRpb24gYWJvdXQgaVBhZCBsZW5kaW5nIGF0IFByaW5jZXRvbiBVbml2ZXJzaXR5IExpYnJhcnlcIl0sXCJodHRwOi8vYW16bi50by90eUlNSkZcIjpbXCJBbWF6b24uY29tIGRlc2NyaXB0aW9uIG9mIGJvb2tcIl19IiwiZGVzY3JpcHRpb25fZGlzcGxheSI6WyIxIGVsZWN0cm9uaWMgYm9vayAoOTQ2IHAuKSJdLCJkZXNjcmlwdGlvbl90IjpbIjEgZWxlY3Ryb25pYyBib29rICg5NDYgcC4pIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEgZWxlY3Ryb25pYyBib29rICg5NDYgcC4pIl0sImdlb2NvZGVfZGlzcGxheSI6WyJKYXBhbiJdLCJyZWxhdGVkX3JlY29yZF9pbmZvX2Rpc3BsYXkiOlsiUHJpbnQgdmVyc2lvbjoiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiXCJUaGUgeWVhciBpcyAxOTg0IGFuZCB0aGUgY2l0eSBpcyBUb2t5by4gQSB5b3VuZyB3b21hbiBuYW1lZCBBb21hbWUgZm9sbG93cyBhIHRheGkgZHJpdmVyJ3MgZW5pZ21hdGljIHN1Z2dlc3Rpb24gYW5kIGJlZ2lucyB0byBub3RpY2UgcHV6emxpbmcgZGlzY3JlcGFuY2llcyBpbiB0aGUgd29ybGQgYXJvdW5kIGhlci4gU2hlIGhhcyBlbnRlcmVkLCBzaGUgcmVhbGl6ZXMsIGEgcGFyYWxsZWwgZXhpc3RlbmNlLCB3aGljaCBzaGUgY2FsbHMgMVE4NCAtLeKAnFEgaXMgZm9yICdxdWVzdGlvbiBtYXJrLicgQSB3b3JsZCB0aGF0IGJlYXJzIGEgcXVlc3Rpb24uXCIgTWVhbndoaWxlLCBhbiBhc3BpcmluZyB3cml0ZXIgbmFtZWQgVGVuZ28gdGFrZXMgb24gYSBzdXNwZWN0IGdob3N0d3JpdGluZyBwcm9qZWN0LiBIZSBiZWNvbWVzIHNvIHdyYXBwZWQgdXAgd2l0aCB0aGUgd29yayBhbmQgaXRzIHVudXN1YWwgYXV0aG9yIHRoYXQsIHNvb24sIGhpcyBwcmV2aW91c2x5IHBsYWNpZCBsaWZlIGJlZ2lucyB0byBjb21lIHVucmF2ZWxlZC4gQXMgQW9tYW1lJ3MgYW5kIFRlbmdvJ3MgbmFycmF0aXZlcyBjb252ZXJnZSBvdmVyIHRoZSBjb3Vyc2Ugb2YgdGhpcyBzaW5nbGUgeWVhciwgd2UgbGVhcm4gb2YgdGhlIHByb2ZvdW5kIGFuZCB0YW5nbGVkIGNvbm5lY3Rpb25zIHRoYXQgYmluZCB0aGVtIGV2ZXIgY2xvc2VyOiBhIGJlYXV0aWZ1bCwgZHlzbGV4aWMgdGVlbmFnZSBnaXJsIHdpdGggYSB1bmlxdWUgdmlzaW9uOyBhIG15c3RlcmlvdXMgcmVsaWdpb3VzIGN1bHQgdGhhdCBpbnN0aWdhdGVkIGEgc2hvb3Qtb3V0IHdpdGggdGhlIG1ldHJvcG9saXRhbiBwb2xpY2U7IGEgcmVjbHVzaXZlLCB3ZWFsdGh5IGRvd2FnZXIgd2hvIHJ1bnMgYSBzaGVsdGVyIGZvciBhYnVzZWQgd29tZW47IGEgaGlkZW91c2x5IHVnbHkgcHJpdmF0ZSBpbnZlc3RpZ2F0b3I7IGEgbWlsZC1tYW5uZXJlZCB5ZXQgcnV0aGxlc3NseSBlZmZpY2llbnQgYm9keWd1YXJkOyBhbmQgYSBwZWN1bGlhcmx5IGluc2lzdGVudCB0ZWxldmlzaW9uLWZlZSBjb2xsZWN0b3IuIEEgbG92ZSBzdG9yeSwgYSBteXN0ZXJ5LCBhIGZhbnRhc3ksIGEgbm92ZWwgb2Ygc2VsZi1kaXNjb3ZlcnksIGEgZHlzdG9waWEgdG8gcml2YWwgR2VvcmdlIE9yd2VsbCdzLS0xUTg0IGlzIEhhcnVraSBNdXJha2FtaSdzIG1vc3QgYW1iaXRpb3VzIHVuZGVydGFraW5nIHlldDogYW4gaW5zdGFudCBiZXN0IHNlbGxlciBpbiBoaXMgbmF0aXZlIEphcGFuLCBhbmQgYSB0cmVtZW5kb3VzIGZlYXQgb2YgaW1hZ2luYXRpb24gZnJvbSBvbmUgb2Ygb3VyIG1vc3QgcmV2ZXJlZCBjb250ZW1wb3Jhcnkgd3JpdGVycy4gVGhpcyBlQm9vayBlZGl0aW9uIGluY2x1ZGVzIGEgUmVhZGluZyBHcm91cCBHdWlkZS5cIiJdLCJub3Rlc19kaXNwbGF5IjpbIlNvbGQgYnk6IFJhbmRvbSBIb3VzZSBEaWdpdGFsLCBJbmMuIl0sInNvdXJjZV9kZXNjX25vdGVzX2Rpc3BsYXkiOlsiRGVzY3JpcHRpb24gYmFzZWQgb24gcHJpbnQgdmVyc2lvbiByZWNvcmQuIl0sImxhbmd1YWdlX2Rpc3BsYXkiOlsiSW4gRW5nbGlzaDsgdHJhbnNsYXRlZCBmcm9tIHRoZSBKYXBhbmVzZS4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJjb250ZW50c19kaXNwbGF5IjpbIkJvb2sgMS4gQXByaWwtSnVuZSAtLSBCb29rIDIuIEp1bHktU2VwdGVtYmVyIC0tIEJvb2sgMy4gT2N0b2Jlci1EZWNlbWJlci4iXSwic3ViamVjdF9kaXNwbGF5IjpbIk1hbi13b21hbiByZWxhdGlvbnNoaXBz4oCURmljdGlvbiIsIkphcGFu4oCURmljdGlvbiJdLCJsY19zdWJqZWN0X2Rpc3BsYXkiOlsiTWFuLXdvbWFuIHJlbGF0aW9uc2hpcHPigJRGaWN0aW9uIiwiSmFwYW7igJRGaWN0aW9uIl0sInN1YmplY3RfZmFjZXQiOlsiTWFuLXdvbWFuIHJlbGF0aW9uc2hpcHPigJRGaWN0aW9uIiwiSmFwYW7igJRGaWN0aW9uIl0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiUmVsYXRlZCBuYW1lXCI6W1wiUnViaW4sIEpheSwgMTk0MS1cIixcIkdhYnJpZWwsIFBoaWxpcCwgMTk1My1cIl19IiwiaXNibl9kaXNwbGF5IjpbIiJdLCJvdGhlcl92ZXJzaW9uX3MiOlsiOTc4MDMwNzU5MzMxMyIsIjk3ODE4NDY1NTY2OTIiLCJvY243MDEwMTc2ODgiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCI3NDI5ODA1XCI6e1wibG9jYXRpb25cIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwiZlwiLFwiY2FsbF9udW1iZXJcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5IGlQYWRzXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5IGlQYWRzXCIsXCJsb2NhdGlvbl9ub3RlXCI6W1wiVG8gYm9ycm93IHRoaXMgZWJvb2ssIHBsZWFzZSByZXF1ZXN0IGFuIGlQYWQgZnJvbSB0aGUgY2lyY3VsYXRpb24gZGVzayBhdCBGaXJlc3RvbmUgTGlicmFyeVwiXSxcImVsZWN0cm9uaWNfYWNjZXNzXCI6e1wiaHR0cDovL2NhdGFsb2cucHJpbmNldG9uLmVkdS9jZ2ktYmluL1B3ZWJyZWNvbi5jZ2k/QkJJRD03MDEwNjA3XCI6W1wiY2F0YWxvZy5wcmluY2V0b24uZWR1XCIsXCJDb25maXJtIGlQYWQgYXZhaWxhYmlsaXR5IGF0IEZpcmVzdG9uZSBMaWJyYXJ5XCJdfX0sXCI3NDI5ODA5XCI6e1wibG9jYXRpb25cIjpcIkxld2lzIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkxld2lzIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcInNjaVwiLFwiY2FsbF9udW1iZXJcIjpcIkxld2lzIExpYnJhcnkgaVBhZHNcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiTGV3aXMgTGlicmFyeSBpUGFkc1wiLFwibG9jYXRpb25fbm90ZVwiOltcIlRvIGJvcnJvdyB0aGlzIGVib29rLCBwbGVhc2UgcmVxdWVzdCBhbiBpUGFkIGZyb20gdGhlIGNpcmN1bGF0aW9uIGRlc2sgYXQgTGV3aXMgTGlicmFyeVwiXSxcImVsZWN0cm9uaWNfYWNjZXNzXCI6e1wiaHR0cDovL2NhdGFsb2cucHJpbmNldG9uLmVkdS9jZ2ktYmluL1B3ZWJyZWNvbi5jZ2k/QkJJRD03MDEwNjA3XCI6W1wiY2F0YWxvZy5wcmluY2V0b24uZWR1XCIsXCJDb25maXJtIGlQYWQgYXZhaWxhYmlsaXR5IGF0IExld2lzIExpYnJhcnlcIl19fSxcIjc0Mjk4MTFcIjp7XCJsb2NhdGlvblwiOlwiRW5naW5lZXJpbmcgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRW5naW5lZXJpbmcgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic3RcIixcImNhbGxfbnVtYmVyXCI6XCJFbmdpbmVlcmluZyBMaWJyYXJ5IGlQYWRzXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIkVuZ2luZWVyaW5nIExpYnJhcnkgaVBhZHNcIixcImxvY2F0aW9uX25vdGVcIjpbXCJUbyBib3Jyb3cgdGhpcyBlYm9vaywgcGxlYXNlIHJlcXVlc3QgYW4gaVBhZCBmcm9tIHRoZSBjaXJjdWxhdGlvbiBkZXNrIGF0IHRoZSBFbmdpbmVlcmluZyBMaWJyYXJ5XCJdLFwiZWxlY3Ryb25pY19hY2Nlc3NcIjp7XCJodHRwOi8vY2F0YWxvZy5wcmluY2V0b24uZWR1L2NnaS1iaW4vUHdlYnJlY29uLmNnaT9CQklEPTcwMTA2MDdcIjpbXCJjYXRhbG9nLnByaW5jZXRvbi5lZHVcIixcIkNvbmZpcm0gaVBhZCBhdmFpbGFiaWxpdHkgYXQgdGhlIEVuZ2luZWVyaW5nIExpYnJhcnlcIl19fX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiIsInNjaSIsInN0Il0sImxvY2F0aW9uIjpbIkZpcmVzdG9uZSBMaWJyYXJ5IiwiTGV3aXMgTGlicmFyeSIsIkVuZ2luZWVyaW5nIExpYnJhcnkiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSIsIkxld2lzIExpYnJhcnkiLCJFbmdpbmVlcmluZyBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiZiIsInNjaSIsInN0IiwiRmlyZXN0b25lIExpYnJhcnkiLCJMZXdpcyBMaWJyYXJ5IiwiRW5naW5lZXJpbmcgTGlicmFyeSJdLCJuYW1lX3VuaWZvcm1fdGl0bGVfMWRpc3BsYXkiOiJbW1wiTXVyYWthbWksIEhhcnVraSwgMTk0OS0uXCIsXCIxUTg0LlwiLFwiRW5nbGlzaFwiXV0iLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIk11cmFrYW1pLCBIYXJ1a2ksIDE5NDktLiAxUTg0IiwiTXVyYWthbWksIEhhcnVraSwgMTk0OS0uIDFRODQuIEVuZ2xpc2giXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSBpUGFkcyIsIkxld2lzIExpYnJhcnkgaVBhZHMiLCJFbmdpbmVlcmluZyBMaWJyYXJ5IGlQYWRzIl0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkZpcmVzdG9uZSBMaWJyYXJ5IGlQYWRzIiwiTGV3aXMgTGlicmFyeSBpUGFkcyIsIkVuZ2luZWVyaW5nIExpYnJhcnkgaVBhZHMiXSwiX3ZlcnNpb25fIjoxNjYwMjI3MzgwMDMwOTk2NDgwLCJ0aW1lc3RhbXAiOiIyMDIwLTAzLTA0VDEwOjAzOjMxLjY1NFoifQ==
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 17:45:49 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?id=7617477
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 17:45:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"9711094636d20f54cd59f3c121150e82"
+      X-Runtime:
+      - '0.060023'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 991d1fda-785f-4316-81db-f94b36725ec3
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"7429805":{"more_items":false,"location":"f","status":"On Shelf","label":"Firestone
+        Library"},"7429809":{"more_items":false,"location":"sci","status":"On Shelf","label":"Lewis
+        Library"},"7429811":{"more_items":false,"location":"st","status":"On Shelf","label":"Engineering
+        Library"}}'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 17:45:49 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=7429805
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 17:45:49 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 404 Not Found
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Runtime:
+      - '0.060904'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - f34aafe1-49bb-4f9e-bfd6-f066866450ab
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: 'Record: 7429805 not found.'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 17:45:49 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=7429809
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 17:45:50 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 404 Not Found
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Runtime:
+      - '0.051772'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 55185296-6595-4ae0-9f8a-a4a2e7e52659
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: 'Record: 7429809 not found.'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 17:45:50 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=7429811
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 17:45:50 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 404 Not Found
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Runtime:
+      - '0.058748'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 22b7b8cb-5f7f-4ce5-ab34-4bd608508d4e
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: 'Record: 7429811 not found.'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 17:45:50 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/locations/holding_locations/st.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 17:45:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"9b86281ae7a7119632d149672c142454"
+      X-Runtime:
+      - '0.007247'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 72d0dfea-a950-4d92-a80a-2ebc7367880d
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"label":"","code":"st","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Engineering
+        Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering
+        Library","code":"engineering"},"delivery_locations":[]}'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 17:45:50 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?id=491654
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 17:58:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"e8bcc7fcaed9bcc87448c3362cfc9594"
+      X-Runtime:
+      - '0.144308'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 6c2efe4e-2aae-4ee2-af70-6254381589c3
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"534137":{"more_items":true,"location":"rcppa","copy_number":1,"item_id":3059236,"on_reserve":"N","status":"Not
+        Charged","label":"ReCAP"},"534140":{"more_items":false,"location":"sci","copy_number":1,"item_id":3826440,"on_reserve":"N","status":"Not
+        Charged","label":"Lewis Library"}}'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 17:58:43 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=534137
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 17:58:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"66dce6a8e1567904436d445d97da3af5"
+      X-Runtime:
+      - '0.068529'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - f7922e74-d56b-41ac-9ba7-80b270b2f03a
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '[{"barcode":"32101065305326","id":4914696,"location":"rcppa","copy_number":1,"item_sequence_number":11,"status":"Not
+        Charged","on_reserve":"N","enum":"2007","chron":"14th ed.","enum_display":"2007
+        (14th ed.)","label":"ReCAP"},{"barcode":"32101044283008","id":3059236,"location":"rcppa","copy_number":1,"item_sequence_number":10,"status":"Not
+        Charged","on_reserve":"N","enum":"2000","chron":"13th ed.","enum_display":"2000
+        (13th ed.)","label":"ReCAP"},{"barcode":"32101094934252","id":3247423,"location":"rcppa","copy_number":1,"item_sequence_number":9,"status":"Not
+        Charged","on_reserve":"N","enum":"1994","enum_display":"1994","label":"ReCAP"},{"barcode":"32101094934237","id":4830395,"location":"rcppa","copy_number":1,"item_sequence_number":8,"status":"Not
+        Charged","on_reserve":"N","enum":"1988","enum_display":"1988","label":"ReCAP"},{"barcode":"32101094934245","id":3611431,"location":"rcppa","copy_number":1,"item_sequence_number":7,"status":"Not
+        Charged","on_reserve":"N","enum":"1983","enum_display":"1983","label":"ReCAP"},{"barcode":"32101094934302","id":7241292,"location":"rcppa","copy_number":1,"item_sequence_number":6,"status":"Not
+        Charged","on_reserve":"N","enum":"1977","enum_display":"1977","label":"ReCAP"},{"barcode":"32101094934310","id":7241334,"location":"rcppa","copy_number":1,"item_sequence_number":5,"status":"Not
+        Charged","on_reserve":"N","enum":"1972","enum_display":"1972","label":"ReCAP"},{"barcode":"32101094934328","id":7241332,"location":"rcppa","copy_number":1,"item_sequence_number":4,"status":"Not
+        Charged","on_reserve":"N","enum":"1967","enum_display":"1967","label":"ReCAP"},{"barcode":"32101094934336","id":7241320,"location":"rcppa","copy_number":1,"item_sequence_number":3,"status":"Not
+        Charged","on_reserve":"N","enum":"1962","enum_display":"1962","label":"ReCAP"},{"barcode":"32101082413400","id":6067274,"location":"rcppa","copy_number":1,"item_sequence_number":2,"status":"Not
+        Charged","on_reserve":"N","enum":"1956","enum_display":"1956","label":"ReCAP"},{"barcode":"32101094934260","id":3147971,"location":"rcppa","copy_number":1,"item_sequence_number":1,"status":"Not
+        Charged","on_reserve":"N","enum":"1947","enum_display":"1947","label":"ReCAP"}]'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 17:58:43 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/8179402/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:57:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - f682cde7-6d17-4577-aebb-65209b0be48a
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"f0d572d169178ce76c7988e9fa97f56f"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.034678'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6IjgxNzk0MDIiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIk1vb3JlLCBMb3JyaWUiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTW9vcmUsIExvcnJpZSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIk1vb3JlLCBMb3JyaWVcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiTW9vcmUsIExvcnJpZVwifSIsImF1dGhvcl9zIjpbIk1vb3JlLCBMb3JyaWUiXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJTaG9ydCBzdG9yaWVzLiBTZWxlY3Rpb25zIl0sInRpdGxlX2Rpc3BsYXkiOiJCYXJrIDogc3RvcmllcyAvIExvcnJpZSBNb29yZS4iLCJ0aXRsZV90IjpbIkJhcmsgOiBzdG9yaWVzIC8gTG9ycmllIE1vb3JlLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkJhcmsgOiBzdG9yaWVzIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJCYXJrIDogc3RvcmllcyAvIExvcnJpZSBNb29yZS4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIkZpcnN0IEVkaXRpb24uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiTmV3IFlvcmsgOiBBbGZyZWQgQS4gS25vcGYsIDIwMTQuIl0sInB1Yl9jcmVhdGVkX3MiOlsiTmV3IFlvcmsgOiBBbGZyZWQgQS4gS25vcGYsIDIwMTQuIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIk5ldyBZb3JrOiBBbGZyZWQgQS4gS25vcGYiXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE0Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTQsImNhdGFsb2dlZF90ZHQiOiIyMDE0LTAzLTE5VDE5OjI5OjQ0WiIsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTkyIHBhZ2VzIDsgMjIgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTkyIHBhZ2VzIDsgMjIgY20uIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjE5MiBwYWdlcyJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJzdW1tYXJ5X25vdGVfZGlzcGxheSI6WyJJbiB0aGVzZSBlaWdodCBtYXN0ZXJmdWwgc3RvcmllcywgTG9ycmllIE1vb3JlLCBpbiBhIHBlcmZlY3QgYmxlbmQgb2YgY3JhZnQgYW5kIGJld2l0Y2hlZCBzcGlyaXQsIGV4cGxvcmVzIHRoZSBwYXNzYWdlIG9mIHRpbWUgYW5kIHN1bW1vbnMgdXAgaXRzIGluZXZpdGFibGUgc29ycm93cyBhbmQgaGlsYXJpb3VzIHBpdGZhbGxzIHRvIHJldmVhbCBoZXIgb3duIGV4cXVpc2l0ZSwgc2luZ3VsYXIgd2lzZG9tLiBJbiBcIkRlYmFya2luZyxcIiBhIG5ld2x5IGRpdm9yY2VkIG1hbiB0cmllcyB0byBrZWVwIGhpcyB3aXRzIGFib3V0IGhpbSBhcyB0aGUgVW5pdGVkIFN0YXRlcyBwcmVwYXJlcyB0byBpbnZhZGUgSXJhcSwgYW5kIGFnYWluc3QgdGhpcyBvbWlub3VzIG1vbWVudCwgd2Ugc2VlLS1pbiBhbGwgaXRzIGlycmVzaXN0aWJsZSBoaWxhcml0eSBhbmQgZGFya25lc3MtLXRoZSBwZXJpbHMgb2YgZGl2b3JjZSBhbmQgd2hhdCBjYW4gZm9sbG93IGluIGl0cyB3YWtlLiBJbiBcIkZvZXMsXCIgYSBwb2xpdGljYWwgYXJndW1lbnQgZ29lcyBncm90ZXNxdWVseSBhd3J5IGFzIHRoZSBldmVudHMgb2YgOS8xMSB1bmV4cGVjdGVkbHkgbWFuaWZlc3QgYXQgYSBmdW5kLXJhaXNpbmcgZGlubmVyIGluIEdlb3JnZXRvd24uIEluIFwiVGhlIEp1bmlwZXIgVHJlZSxcIiBhIHRlYWNoZXIsIHZpc2l0ZWQgYnkgdGhlIGdob3N0IG9mIGhlciByZWNlbnRseSBkZWNlYXNlZCBmcmllbmQsIGlzIGZvcmNlZCB0byBzaW5nIFwiVGhlIFN0YXItU3BhbmdsZWQgQmFubmVyXCIgaW4gYSBraW5kIG9mIG5pZ2h0bWFyZSByZXVuaW9uLiBBbmQgaW4gXCJXaW5ncyxcIiB3ZSB3YXRjaCB0aGUgdW5yYXZlbGluZyBvZiB0d28gb25jZS1ob3BlZnVsIG11c2ljaWFucyB3aG8gbmVpdGhlciBoZWxkIGZhc3QgdG8gdGhlaXIgZHJlYW1zIG5vciBzdHJ1Y2sgb3V0IGFsb25nIG90aGVyIHBhdGhzIGFzIE1vb3JlIGRlZnRseSBkZXBpY3RzIHRoZSBpbnRyaWNhY2llcyBvZiBkZWFkIGVuZHMgYW5kIHRoZSB3b3JraW5ncyBvZiByZWdyZXQiXSwibm90ZXNfZGlzcGxheSI6WyJcIlRoaXMgaXMgYSBCb3J6b2kgQm9vay5cIiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sImNvbnRlbnRzX2Rpc3BsYXkiOlsiRGViYXJraW5nIC0tIFRoZSBqdW5pcGVyIHRyZWUgLS0gUGFwZXIgbG9zc2VzIC0tIEZvZXMgLS0gV2luZ3MgLS0gUmVmZXJlbnRpYWwgLS0gU3ViamVjdCB0byBzZWFyY2ggLS0gVGhhbmsgeW91IGZvciBoYXZpbmcgbWUuIl0sInN1YmplY3RfZGlzcGxheSI6WyJTaG9ydCBzdG9yaWVzLCBBbWVyaWNhbiIsIlVuaXRlZCBTdGF0ZXPigJRTb2NpYWwgbGlmZSBhbmQgY3VzdG9tc+KAlDIxc3QgY2VudHVyeeKAlEZpY3Rpb24iXSwibGNfc3ViamVjdF9kaXNwbGF5IjpbIlNob3J0IHN0b3JpZXMsIEFtZXJpY2FuIiwiVW5pdGVkIFN0YXRlc+KAlFNvY2lhbCBsaWZlIGFuZCBjdXN0b21z4oCUMjFzdCBjZW50dXJ54oCURmljdGlvbiJdLCJzdWJqZWN0X2ZhY2V0IjpbIlNob3J0IHN0b3JpZXMsIEFtZXJpY2FuIiwiVW5pdGVkIFN0YXRlc+KAlFNvY2lhbCBsaWZlIGFuZCBjdXN0b21z4oCUMjFzdCBjZW50dXJ54oCURmljdGlvbiJdLCJjb250YWluc18xZGlzcGxheSI6IltbXCJNb29yZSwgTG9ycmllLlwiLFwiRGViYXJraW5nLlwiXV0iLCJpc2JuX2Rpc3BsYXkiOlsiOTc4MDMwNzU5NDEzNiAoaGFyZGNvdmVyIDogYWxrLiBwYXBlcikiLCIwMzA3NTk0MTMwIChoYXJkY292ZXIgOiBhbGsuIHBhcGVyKSIsIiJdLCJsY2NuX2Rpc3BsYXkiOlsiICAyMDEzMDE0Nzc3Il0sImxjY25fcyI6WyIyMDEzMDE0Nzc3Il0sImlzYm5fcyI6WyI5NzgwMzA3NTk0MTM2Il0sIm9jbGNfcyI6WyI4NDA5MzcyNTUiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbjg0MDkzNzI1NSIsIjk3ODAzMDc1OTQxMzYiLCI5NzgwMzg1MzUxNzEzIl0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjIxc3QgY2VudHVyeSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjc5NDYwNDJcIjp7XCJsb2NhdGlvblwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIkZpcmVzdG9uZSBMaWJyYXJ5XCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJmXCIsXCJjYWxsX251bWJlclwiOlwiUFMzNTYzLk82MjI1IEIzNyAyMDE0XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIlBTMzU2My5PNjIyNSBCMzcgMjAxNFwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiZiJdLCJsb2NhdGlvbiI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIkZpcmVzdG9uZSBMaWJyYXJ5Il0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsiZiIsIkZpcmVzdG9uZSBMaWJyYXJ5Il0sIm5hbWVfdW5pZm9ybV90aXRsZV8xZGlzcGxheSI6IltbXCJNb29yZSwgTG9ycmllLlwiLFwiU2hvcnQgc3Rvcmllcy5cIixcIlNlbGVjdGlvbnNcIl1dIiwibmFtZV90aXRsZV9icm93c2VfcyI6WyJNb29yZSwgTG9ycmllLiBEZWJhcmtpbmciLCJNb29yZSwgTG9ycmllLiBTaG9ydCBzdG9yaWVzIiwiTW9vcmUsIExvcnJpZS4gU2hvcnQgc3Rvcmllcy4gU2VsZWN0aW9ucyJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIlBTMzU2My5PNjIyNSBCMzcgMjAxNCJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyJQUzM1NjMuTzYyMjUgQjM3IDIwMTQiXSwiX3ZlcnNpb25fIjoxNjYwMjI5ODc3NTkxMTc5MjY0LCJ0aW1lc3RhbXAiOiIyMDIwLTAzLTA0VDEwOjQzOjEzLjQ0OFoifQ==
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:57:57 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?id=8179402
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:57:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"02cac7ac8d788c50c502d87f9e61a03a"
+      X-Runtime:
+      - '0.108709'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 32705e23-6011-483d-b129-6cade847f149
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"7946042":{"more_items":false,"location":"f","copy_number":1,"item_id":6828086,"on_reserve":"Y","status":"Not
+        Charged","label":"Firestone Library"}}'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:57:57 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=7946042
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:57:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"32413bb5421c7dac3d600e48388fef3e"
+      X-Runtime:
+      - '0.064594'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 9e4d1ec6-e02c-4556-9ae5-850f6437055c
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '[{"barcode":"32101089774630","id":6828086,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Not
+        Charged","on_reserve":"Y","label":"Firestone Library"}]'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:57:57 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/locations/holding_locations/f.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:57:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"250b12294d5b9710e9827751c996ca99"
+      X-Runtime:
+      - '0.008161'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 856dc556-b19c-4f1e-bae9-ce0c8dee3c3d
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"label":"","code":"f","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"library":{"label":"Firestone
+        Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone
+        Library - Building and Circulation/Reserves Hours","code":"firestone"},"delivery_locations":[{"label":"Firestone
+        Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true}]}'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:57:58 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/3848872/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:57:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - d6f8653a-b0b6-4c48-8312-7bcb9ed766c9
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"66dd9e37532ed8efbeb6e56e0d02c168"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.015026'
       X-Content-Type-Options:
       - nosniff
       X-Powered-By:
@@ -20897,9 +21034,9 @@ http_interactions:
         .R93 2003\",\"call_number_browse\":\"QB981 .R93 2003\"}}","location_code_s":["sci"],"location":["Lewis
         Library"],"location_display":["Lewis Library"],"advanced_location_s":["sci","Lewis
         Library"],"name_title_browse_s":["Ryden, Barbara Sue. Introduction to cosmology"],"call_number_display":["QB981
-        .R93 2003"],"call_number_browse_s":["QB981 .R93 2003"],"_version_":1656005504420282368,"timestamp":"2020-01-17T19:38:37.393Z"}'
+        .R93 2003"],"call_number_browse_s":["QB981 .R93 2003"],"_version_":1660213085650026496,"timestamp":"2020-03-04T06:16:19.490Z"}'
     http_version: 
-  recorded_at: Fri, 31 Jan 2020 07:23:41 GMT
+  recorded_at: Tue, 17 Mar 2020 18:57:59 GMT
 - request:
     method: get
     uri: https://bibdata.princeton.edu/availability?id=3848872
@@ -20908,7 +21045,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -20921,7 +21058,7 @@ http_interactions:
       Server:
       - nginx/1.17.6
       Date:
-      - Fri, 31 Jan 2020 07:23:42 GMT
+      - Tue, 17 Mar 2020 18:57:59 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -20937,23 +21074,23 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Etag:
-      - W/"309e1f8a12f16b7be39bac4d55e59a06"
+      - W/"337b4f37604d4d4732e1d5c78f0c8c6d"
       X-Runtime:
-      - '0.188573'
+      - '0.236383'
       Access-Control-Request-Method:
       - GET
       X-Request-Id:
-      - 1a5dfb9b-36a5-4b6c-b0e9-ae4eed717ced
+      - 6b66db2a-afe8-48a0-ba97-3abef64d02fd
       X-Powered-By:
       - Phusion Passenger 6.0.4
     body:
       encoding: UTF-8
-      string: '{"4151880":{"more_items":false,"location":"sci","copy_number":1,"item_id":3399747,"on_reserve":"N","due_date":"2/15/2020","status":"Renewed","label":"Lewis
-        Library"},"4364328":{"more_items":false,"location":"sci","copy_number":2,"item_id":3636476,"on_reserve":"N","status":"On
-        Hold","label":"Lewis Library"},"6153968":{"more_items":false,"location":"sci","copy_number":3,"item_id":5747528,"on_reserve":"N","status":"Not
+      string: '{"4151880":{"more_items":false,"location":"sci","copy_number":1,"item_id":3399747,"on_reserve":"N","due_date":"6/15/2020","status":"Renewed","label":"Lewis
+        Library"},"4364328":{"more_items":false,"location":"sci","copy_number":2,"item_id":3636476,"on_reserve":"N","due_date":"6/15/2020","status":"Charged","label":"Lewis
+        Library"},"6153968":{"more_items":false,"location":"sci","copy_number":3,"item_id":5747528,"on_reserve":"N","status":"Not
         Charged","label":"Lewis Library"}}'
     http_version: 
-  recorded_at: Fri, 31 Jan 2020 07:23:42 GMT
+  recorded_at: Tue, 17 Mar 2020 18:57:59 GMT
 - request:
     method: get
     uri: https://bibdata.princeton.edu/availability?mfhd=4151880
@@ -20962,7 +21099,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -20975,7 +21112,7 @@ http_interactions:
       Server:
       - nginx/1.17.6
       Date:
-      - Fri, 31 Jan 2020 07:23:43 GMT
+      - Tue, 17 Mar 2020 18:58:00 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -20991,21 +21128,21 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Etag:
-      - W/"c898310da74ccf8c8d9529372b61b6d6"
+      - W/"0c1d68994d93dc748f5bb3d5721400b2"
       X-Runtime:
-      - '0.060846'
+      - '0.053652'
       Access-Control-Request-Method:
       - GET
       X-Request-Id:
-      - 6fbf9fc6-cc6f-49f6-b00b-81b4e7d25ced
+      - 3df752ee-afd5-4b28-abfd-6a8cf6248109
       X-Powered-By:
       - Phusion Passenger 6.0.4
     body:
       encoding: UTF-8
-      string: '[{"barcode":"32101048628455","id":3399747,"location":"sci","copy_number":1,"item_sequence_number":1,"status":"Renewed","on_reserve":"N","due_date":"2/15/2020","label":"Lewis
+      string: '[{"barcode":"32101048628455","id":3399747,"location":"sci","copy_number":1,"item_sequence_number":1,"status":"Renewed","on_reserve":"N","due_date":"6/15/2020","label":"Lewis
         Library"}]'
     http_version: 
-  recorded_at: Fri, 31 Jan 2020 07:23:42 GMT
+  recorded_at: Tue, 17 Mar 2020 18:58:00 GMT
 - request:
     method: get
     uri: https://bibdata.princeton.edu/availability?mfhd=4364328
@@ -21014,7 +21151,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21027,7 +21164,7 @@ http_interactions:
       Server:
       - nginx/1.17.6
       Date:
-      - Fri, 31 Jan 2020 07:23:43 GMT
+      - Tue, 17 Mar 2020 18:58:00 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -21043,21 +21180,21 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Etag:
-      - W/"55e9d421ced93080f110c9ac182fb8b9"
+      - W/"2c27c719d028ad68ceda88daabee9f20"
       X-Runtime:
-      - '0.049520'
+      - '0.061200'
       Access-Control-Request-Method:
       - GET
       X-Request-Id:
-      - 8c31fd45-d11f-4f64-97a3-80347d4ca1ee
+      - 2d1f5eee-f1ee-41a3-a407-6bc21593c013
       X-Powered-By:
       - Phusion Passenger 6.0.4
     body:
       encoding: UTF-8
-      string: '[{"barcode":"32101050539475","id":3636476,"location":"sci","copy_number":2,"item_sequence_number":1,"status":"On
-        Hold","on_reserve":"N","label":"Lewis Library"}]'
+      string: '[{"barcode":"32101050539475","id":3636476,"location":"sci","copy_number":2,"item_sequence_number":1,"status":"Charged","on_reserve":"N","due_date":"6/15/2020","label":"Lewis
+        Library"}]'
     http_version: 
-  recorded_at: Fri, 31 Jan 2020 07:23:42 GMT
+  recorded_at: Tue, 17 Mar 2020 18:58:00 GMT
 - request:
     method: get
     uri: https://bibdata.princeton.edu/availability?mfhd=6153968
@@ -21066,7 +21203,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v1.0.0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21079,7 +21216,7 @@ http_interactions:
       Server:
       - nginx/1.17.6
       Date:
-      - Fri, 31 Jan 2020 07:23:43 GMT
+      - Tue, 17 Mar 2020 18:58:00 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -21097,11 +21234,11 @@ http_interactions:
       Etag:
       - W/"a9caeb2e1e71d1ee55e841a62daa1ae4"
       X-Runtime:
-      - '0.056473'
+      - '0.051566'
       Access-Control-Request-Method:
       - GET
       X-Request-Id:
-      - 1366e22e-a7c5-4878-b90e-7e0d651aabb5
+      - 13438340-ff7a-46c4-bc49-98be98f315be
       X-Powered-By:
       - Phusion Passenger 6.0.4
     body:
@@ -21109,5 +21246,721 @@ http_interactions:
       string: '[{"barcode":"32101078062997","id":5747528,"location":"sci","copy_number":3,"item_sequence_number":1,"status":"Not
         Charged","on_reserve":"N","label":"Lewis Library"}]'
     http_version: 
-  recorded_at: Fri, 31 Jan 2020 07:23:42 GMT
-recorded_with: VCR 5.0.0
+  recorded_at: Tue, 17 Mar 2020 18:58:00 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/491654/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:58:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 763b3a0b-4af5-4b42-8b5e-8d83d657661c
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"1fef11448baed99dc46df137ae98209c"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.015227'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6IjQ5MTY1NCIsIm51bWVyaWNfaWRfYiI6dHJ1ZSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiVW5pdGVkIFN0YXRlcyJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIlVuaXRlZCBTdGF0ZXNcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwiYXV0aG9yX3MiOlsiVW5pdGVkIFN0YXRlcy4gQnVyZWF1IG9mIHRoZSBDZW5zdXMiXSwidGl0bGVfZGlzcGxheSI6IkNvdW50eSBhbmQgY2l0eSBkYXRhIGJvb2suIiwidGl0bGVfdCI6WyJDb3VudHkgYW5kIGNpdHkgZGF0YSBib29rLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkNvdW50eSBhbmQgY2l0eSBkYXRhIGJvb2siXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkNvdW50eSBhbmQgY2l0eSBkYXRhIGJvb2suIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiW1dhc2hpbmd0b24sIEQuQy5dIDogVS5TLiBEZXB0LiBvZiBDb21tZXJjZSwgQnVyZWF1IG9mIHRoZSBDZW5zdXMgOiBbRm9yIHNhbGUgYnkgdGhlIFN1cHQuIG9mIERvY3MuLCBVLlMuIEcuUC5PLl0sIDE5NTItMjAwNyJdLCJwdWJfY3JlYXRlZF9zIjpbIltXYXNoaW5ndG9uLCBELkMuXSA6IFUuUy4gRGVwdC4gb2YgQ29tbWVyY2UsIEJ1cmVhdSBvZiB0aGUgQ2Vuc3VzIDogW0ZvciBzYWxlIGJ5IHRoZSBTdXB0LiBvZiBEb2NzLiwgVS5TLiBHLlAuTy5dLCAxOTUyLSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJXYXNoaW5ndG9uLCBELkMuOiBGb3Igc2FsZSBieSB0aGUgU3VwdC4gb2YgRG9jcy4sIFUuUy4gRy5QLk8uIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMTk0OSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoxOTQ5LCJwdWJfZGF0ZV9lbmRfc29ydCI6MjAwNywiY2F0YWxvZ2VkX3RkdCI6IjIwMDItMDQtMjJUMTY6MTU6MjRaIiwiZm9ybWF0IjpbIkpvdXJuYWwiXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vcHVybC5hY2Nlc3MuZ3BvLmdvdi9HUE8vTFBTMjk5MzJcIjpbXCJwdXJsLmFjY2Vzcy5ncG8uZ292XCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsidi4gOiBpbGwuIDsgMjkgY20uIiwiWzFzdCBlZC5dICgxOTQ5KS0xNHRoIGVkLiAoMjAwNykuIl0sImRlc2NyaXB0aW9uX3QiOlsidi4gOiBpbGwuIDsgMjkgY20uIiwiWzFzdCBlZC5dICgxOTQ5KS0xNHRoIGVkLiAoMjAwNykuIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbInYuIl0sImdlb2NvZGVfZGlzcGxheSI6WyJVbml0ZWQgU3RhdGVzIl0sImZyZXF1ZW5jeV9kaXNwbGF5IjpbIklycmVndWxhciJdLCJsaW5raW5nX25vdGVzX2Rpc3BsYXkiOlsiQ29udGludWVzIGluIHBhcnQ6IENpdGllcyBzdXBwbGVtZW50LCBhbmQgYWxzbyBjb250aW51ZXMgaW4gcGFydDogQ291bnR5IGRhdGFib29rLiJdLCJub3Rlc19kaXNwbGF5IjpbIlwiQSBzdGF0aXN0aWNhbCBhYnN0cmFjdCBzdXBwbGVtZW50LlwiIl0sImxhbmd1YWdlX2ZhY2V0IjpbIkVuZ2xpc2giXSwibGFuZ3VhZ2VfY29kZV9zIjpbImVuZyJdLCJsYW5ndWFnZV9pYW5hX3MiOlsiZW4iXSwib3RoZXJfZm9ybWF0X2Rpc3BsYXkiOlsiQWxzbyBpc3N1ZWQgb24gQ0QtUk9NIHdpdGggdGl0bGU6IENvdW50eSBcdTAwMjYgY2l0eSBkYXRhIGJvb2suIiwiQWxzbyBhdmFpbGFibGUgdmlhIEludGVybmV0IGZyb20gdGhlIENlbnN1cyBCdXJlYXUgd2ViIHNpdGUuIEFkZHJlc3MgYXMgb2YgNi8xMy8wMzogaHR0cDovL3d3dy5jZW5zdXMuZ292IC9zdGF0YWIvd3d3L2NjZGIuaHRtbDsgY3VycmVudCBhY2Nlc3MgaXMgYXZhaWxhYmxlIHZpYSBQVVJMLiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiQ2l0aWVzIGFuZCB0b3duc+KAlFVuaXRlZCBTdGF0ZXPigJRTdGF0aXN0aWNz4oCUUGVyaW9kaWNhbHMiLCJVbml0ZWQgU3RhdGVz4oCUU3RhdGlzdGljc+KAlFBlcmlvZGljYWxzIl0sImxjX3N1YmplY3RfZGlzcGxheSI6WyJDaXRpZXMgYW5kIHRvd25z4oCUVW5pdGVkIFN0YXRlc+KAlFN0YXRpc3RpY3PigJRQZXJpb2RpY2FscyIsIlVuaXRlZCBTdGF0ZXPigJRTdGF0aXN0aWNz4oCUUGVyaW9kaWNhbHMiXSwic3ViamVjdF9mYWNldCI6WyJDaXRpZXMgYW5kIHRvd25z4oCUVW5pdGVkIFN0YXRlc+KAlFN0YXRpc3RpY3PigJRQZXJpb2RpY2FscyIsIlVuaXRlZCBTdGF0ZXPigJRTdGF0aXN0aWNz4oCUUGVyaW9kaWNhbHMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJVbml0ZWQgU3RhdGVzLiBCdXJlYXUgb2YgdGhlIENlbnN1c1wiXX0iLCJvdGhlcl90aXRsZV9kaXNwbGF5IjpbIkN0eS4gY2l0eSBkYXRhIGJvb2siLCJDb3VudHkgYW5kIGNpdHkgZGF0YSBib29rIiwiU3RhdGlzdGljYWwgYWJzdHJhY3Qgb2YgdGhlIFVuaXRlZCBTdGF0ZXMuIl0sImlzc25fZGlzcGxheSI6WyIwMDgyLTk0NTUiXSwic3Vkb2Nfbm9fZGlzcGxheSI6WyJDIDU2LjI0My8yOkMgODMvIiwiQyAzLjEzNC8yOkMgODMvMi8iXSwibGNjbl9kaXNwbGF5IjpbIiAgIDUyMDA0NTc2IC8vcjg0ICJdLCJsY2NuX3MiOlsiNTIwMDQ1NzYiXSwiaXNzbl9zIjpbIjAwODI5NDU1Il0sIm9jbGNfcyI6WyIxMTg0OTQwIl0sIm90aGVyX3ZlcnNpb25fcyI6WyIwMDgyOTQ1NSIsIm9jbTAxMTg0OTQwIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiNTM0MTM3XCI6e1wibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwibG9jYXRpb25fY29kZVwiOlwicmNwcGFcIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiSEEyMDIgLlU1ODFcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSEEyMDIgLlU1ODFcIixcImxvY2F0aW9uX2hhc1wiOltcIjE5NDcsIDE5NDksIDE5NTIsIDE5NTYsIDE5NjIsIDE5NjcsIDE5NzIsIDE5NzcsIDE5ODMsIDE5ODgsIDE5OTQsIDIwMDAsIDIwMDdcIixcIkNVUlJFTlQgVk9MVU1FIElOOiBUcnVzdGVlIFJlYWRpbmcgUm9vbSBSZWZlcmVuY2UgKERSKSBSZWFkeSBSZWZlcmVuY2UuIEZpcmVzdG9uZVwiXX0sXCI1MzQxNDBcIjp7XCJsb2NhdGlvblwiOlwiTGV3aXMgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTGV3aXMgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic2NpXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIkhBMjAyIC5BMzZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiSEEyMDIgLkEzNlwiLFwibG9jYXRpb25faGFzXCI6W1wiMTk2N1wiXX19IiwibG9jYXRpb25fY29kZV9zIjpbInJjcHBhIiwic2NpIl0sImxvY2F0aW9uIjpbIlJlQ0FQIiwiTGV3aXMgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJlQ0FQIiwiTGV3aXMgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInJjcHBhIiwic2NpIiwiUmVDQVAiLCJMZXdpcyBMaWJyYXJ5Il0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiSEEyMDIgLlU1ODEiLCJIQTIwMiAuQTM2Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIkhBMjAyIC5VNTgxIiwiSEEyMDIgLkEzNiJdLCJfdmVyc2lvbl8iOjE2NjAxOTc1MzE5ODkwNDkzNDQsInRpbWVzdGFtcCI6IjIwMjAtMDMtMDRUMDI6MDk6MDYuMzU3WiJ9
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:58:02 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=534140
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:58:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"63182e27f02bb3aabe772b5b745a1339"
+      X-Runtime:
+      - '0.058680'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - fa7027b2-6b5c-4f25-ae29-a01a29f2389a
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '[{"barcode":"32101016113563","id":3826440,"location":"sci","copy_number":1,"item_sequence_number":0,"status":"Not
+        Charged","on_reserve":"N","label":"Lewis Library"}]'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:58:02 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/locations/holding_locations/rcppa.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:58:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"c9a10753a3def7b22c59736cb611896a"
+      X-Runtime:
+      - '0.013422'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 44fcebfb-7428-4ca5-92dd-6fcc6a8bab3c
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"label":"","code":"rcppa","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"ReCAP","code":"recap","order":3},"holding_library":null,"hours_location":null,"delivery_locations":[{"label":"Plasma
+        Physics Library","address":"Forrestal Campus Princeton, NJ 08544","phone_number":"609-243-3565","contact_email":"ppllib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Architecture
+        Library","address":"School of Architecture Building, Second Floor Princeton,
+        NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"East
+        Asian Library","address":"Frist Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Engineering
+        Library","address":"Friend Center for Engineering Education Princeton, NJ
+        08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Marquand
+        Library of Art and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Mendel
+        Music Library","address":"Woolworth Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Stokes
+        Library","address":"Wallace Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Lewis
+        Library","address":"Washington Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Firestone
+        Library","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true},{"label":"Firestone
+        Library, Resource Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
+        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Preservation","address":"One
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"Technical
+        Services HMT","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":false,"digital_location":false},{"label":"ReCAP
+        ILL","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false}]}'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:58:02 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/locations/holding_locations/sci.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:58:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"5849f9ec6d375820f0ba257493af4654"
+      X-Runtime:
+      - '0.014701'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 357f0a2f-436e-4d52-a64c-e5cc2981c0c1
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"label":"","code":"sci","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"library":{"label":"Lewis
+        Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis
+        Library","code":"lewis"},"delivery_locations":[{"label":"Lewis Library","address":"Washington
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true}]}'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:58:03 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/7352936/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:58:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - fef816c2-e58c-45d0-b087-2a5a8d5e4eee
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"7f31d455b1f9824646397e9fd3ac681d"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.015723'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6IjczNTI5MzYiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W10sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwidW5pZm9ybV90aXRsZV9zIjpbIlBpcGEgKFBsYW5vLiBUZXguKSJdLCJ0aXRsZV9kaXNwbGF5IjoiUGlwYSA6IHRoZSBtYWdhemluZSBmb3IgQ2hpbmVzZSBzcGVha2luZyBraWRzIGluIE5vcnRoIEFtZXJpY2EuIiwidGl0bGVfdCI6WyJQaXBhIDogdGhlIG1hZ2F6aW5lIGZvciBDaGluZXNlIHNwZWFraW5nIGtpZHMgaW4gTm9ydGggQW1lcmljYS4iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJQaXBhIDogdGhlIG1hZ2F6aW5lIGZvciBDaGluZXNlIHNwZWFraW5nIGtpZHMgaW4gTm9ydGggQW1lcmljYSJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiUGlwYSA6IHRoZSBtYWdhemluZSBmb3IgQ2hpbmVzZSBzcGVha2luZyBraWRzIGluIE5vcnRoIEFtZXJpY2EuIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiUGxhbm8sIFRYIDogTm9ibGUgVHJlZSBQdWJsaXNoaW5nLCBJbmMuLCAyMDEzLSJdLCJwdWJfY3JlYXRlZF9zIjpbIlBsYW5vLCBUWCA6IE5vYmxlIFRyZWUgUHVibGlzaGluZywgSW5jLiwgMjAxMy0iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiUGxhbm8sIFRYOiBOb2JsZSBUcmVlIFB1Ymxpc2hpbmcsIEluYyJdLCJwdWJfZGF0ZV9kaXNwbGF5IjpbIjIwMTMiXSwicHViX2RhdGVfc3RhcnRfc29ydCI6MjAxMywicHViX2RhdGVfZW5kX3NvcnQiOjk5OTksImNhdGFsb2dlZF90ZHQiOiIyMDEzLTAzLTA3VDE5OjE2OjI0WiIsImZvcm1hdCI6WyJKb3VybmFsIl0sImVsZWN0cm9uaWNfYWNjZXNzXzFkaXNwbGF5Ijoie1wiaHR0cDovL3d3dy5waXBhbWFnLm9yZ1wiOltcInd3dy5waXBhbWFnLm9yZ1wiXX0iLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbInZvbHVtZXMgOiBjb2xvciBpbGx1c3RyYXRpb25zIDsgMjkgY20iLCJCZWdhbiB3aXRoOiBbVm9sdW1lIDEsIG51bWJlciAxXSAoMjAxMykuIl0sImRlc2NyaXB0aW9uX3QiOlsidm9sdW1lcyA6IGNvbG9yIGlsbHVzdHJhdGlvbnMgOyAyOSBjbSIsIkJlZ2FuIHdpdGg6IFtWb2x1bWUgMSwgbnVtYmVyIDFdICgyMDEzKS4iLCJWb2wuIDEsIG5vLiA0IChPY3QuIDIwMTMpIGVycm9uZW91c2x5IG1hcmtlZCBhcyBuby4gMywgSnVseSAyMDEzLiIsIkZpcnN0IGlzc3VlIGlzIGNhbGxlZCBcIuivleWIiuWPtyxcIiB1bmRhdGVkIGFuZCBsYWNraW5nIG51bWJlcmluZy4iLCJWb2wuIDEsIG5vLiAyLTQgYWxzbyBjYWxsZWQgXCLmmKXlraPlj7csXCIgXCLlpI/lraPlj7csXCIgXCLnp4vlraPlj7dcIiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyJ2b2x1bWVzIl0sImZyZXF1ZW5jeV9kaXNwbGF5IjpbIkJpbW9udGhseSwgMjAxNC0iXSwiZm9ybWVyX2ZyZXF1ZW5jeV9kaXNwbGF5IjpbIlF1YXJ0ZXJseSwgMjAxMyJdLCJyZWxhdGVkX3JlY29yZF9pbmZvX2Rpc3BsYXkiOlsiT25saW5lIHZlcnNpb246Il0sIm5vdGVzX2Rpc3BsYXkiOlsiU3VidGl0bGUgdmFyaWVzIHNsaWdodGx5LiIsIlwiVGhlIG1hZ2F6aW5lIGZvciBDaGluZXNlIHNwZWFraW5nIGtpZHMgYWxsIG92ZXIgdGhlIHdvcmxkXCItLWNvdmVyIG9mIFZvbC4gMiwgbm8uIDMgKE1heSAyMDE0KSIsIlNvbWUgQ2hpbmVzZSBjaGFyYWN0ZXJzIGFyZSBhY2NvbXBhbmllZCB3aXRoIHByb251bmNpYXRpb24gZ3VpZGUgaW4gUGlueWluLiIsIkNvdHNlbiBjb3B5IGhhcyBlZGl0b3ItaW4tY2hpZWYncyBhdXRvZ3JhcGggaW4gdGhlIGZpcnN0IGlzc3VlLiIsIlRoZSBmaXJzdCBpc3N1ZSBvZiBWb2x1bWVzIDItNCBpcyBpbnNlcnRlZCB3aXRoIGEgcmVkIHBhcGVyLWN1dCBvZiBhIGhvcnNlLCBzaGVlcCwgYW5kIG1vbmtleSByZXNwZWN0aXZlbHksIHpvZGlhYyBhbmltYWxzIG9mIHRoZSB1cGNvbWluZyBDaGluZXNlIE5ldyBZZWFyLiJdLCJudW1iZXJpbmdfcGVjX25vdGVzX2Rpc3BsYXkiOlsiVm9sLiAxLCBuby4gNCAoT2N0LiAyMDEzKSBlcnJvbmVvdXNseSBtYXJrZWQgYXMgbm8uIDMsIEp1bHkgMjAxMy4iLCJGaXJzdCBpc3N1ZSBpcyBjYWxsZWQgXCLor5XliIrlj7csXCIgdW5kYXRlZCBhbmQgbGFja2luZyBudW1iZXJpbmcuIiwiVm9sLiAxLCBuby4gMi00IGFsc28gY2FsbGVkIFwi5pil5a2j5Y+3LFwiIFwi5aSP5a2j5Y+3LFwiIFwi56eL5a2j5Y+3XCIiXSwic291cmNlX2Rlc2Nfbm90ZXNfZGlzcGxheSI6WyJEZXNjcmlwdGlvbiBiYXNlZCBvbjogW1ZvbHVtZSAxLCBudW1iZXIgMV0gKDIwMTMpOyB0aXRsZSBmcm9tIGNvdmVyLiIsIkxhdGVzdCBpc3N1ZSBjb25zdWx0ZWQ6IFZvbHVtZSAzLCBudW1iZXIgMSwgaXNzdWUgbm8uIDExIChKYW51YXJ5IDIwMTUpLiJdLCJsYW5ndWFnZV9kaXNwbGF5IjpbIkNoaWVmbHkgaW4gQ2hpbmVzZSwgd2l0aCBzb21lIHBhcmFsbGVsIEVuZ2xpc2ggdHJhbnNsYXRpb25zLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJDaGluZXNlIiwiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiY2hpIiwiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJ6aCIsImVuIl0sInNvdXJjZV9hY3F1aXNpdGlvbl9kaXNwbGF5IjpbIjU0MS0wMCDor5XliIrlj7cgR2lmdDsgUHVibGlzaGVyOyAyMDEzMDMwMi4iXSwic3ViamVjdF9kaXNwbGF5IjpbIkNoaW5lc2UgbGFuZ3VhZ2XigJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiLCJDaGluZXNlIEFtZXJpY2FuIGNoaWxkcmVu4oCUUGVyaW9kaWNhbHPigJRKdXZlbmlsZSBsaXRlcmF0dXJlIiwiQ2hpbGRyZW4ncyBsaXRlcmF0dXJlLCBDaGluZXNl4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIiwiQ2hpbmHigJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiXSwibGNfc3ViamVjdF9kaXNwbGF5IjpbIkNoaW5lc2UgbGFuZ3VhZ2XigJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiLCJDaGluZXNlIEFtZXJpY2FuIGNoaWxkcmVu4oCUUGVyaW9kaWNhbHPigJRKdXZlbmlsZSBsaXRlcmF0dXJlIiwiQ2hpbGRyZW4ncyBsaXRlcmF0dXJlLCBDaGluZXNl4oCUVW5pdGVkIFN0YXRlc+KAlFBlcmlvZGljYWxzIiwiQ2hpbmHigJRQZXJpb2RpY2Fsc+KAlEp1dmVuaWxlIGxpdGVyYXR1cmUiXSwic3ViamVjdF9mYWNldCI6WyJDaGluZXNlIGxhbmd1YWdl4oCUUGVyaW9kaWNhbHPigJRKdXZlbmlsZSBsaXRlcmF0dXJlIiwiQ2hpbmVzZSBBbWVyaWNhbiBjaGlsZHJlbuKAlFBlcmlvZGljYWxz4oCUSnV2ZW5pbGUgbGl0ZXJhdHVyZSIsIkNoaWxkcmVuJ3MgbGl0ZXJhdHVyZSwgQ2hpbmVzZeKAlFVuaXRlZCBTdGF0ZXPigJRQZXJpb2RpY2FscyIsIkNoaW5h4oCUUGVyaW9kaWNhbHPigJRKdXZlbmlsZSBsaXRlcmF0dXJlIl0sIm90aGVyX3RpdGxlX2Rpc3BsYXkiOlsiUGlwYSAoUGxhbm8uIFRleC4pIiwiWGlhzIZvIHBpzIEgcGEiLCJcIlhpYW8gcGkgcGFcIiB6YSB6aGkiLCJQaXBhIG1hZ2F6aW5lIiwiUGkgcGEiLCLlsI/mnofmnbciLCJcIuWwj+aeh+adt1wi5p2C5b+XIl0sImFsdF90aXRsZV8yNDZfZGlzcGxheSI6WyJYaWHMhm8gcGnMgSBwYSIsIlwiWGlhbyBwaSBwYVwiIHphIHpoaSIsIlBpcGEgbWFnYXppbmUiLCJQaSBwYSIsIuWwj+aeh+adtyIsIlwi5bCP5p6H5p23XCLmnYLlv5ciXSwiaXNzbl9kaXNwbGF5IjpbIjIzMjYtODEzMSJdLCJsY2NuX2Rpc3BsYXkiOlsiICAyMDEzMjAwMjE3Il0sImxjY25fcyI6WyIyMDEzMjAwMjE3Il0sImlzc25fcyI6WyIyMzI2ODEzMSJdLCJvY2xjX3MiOlsiODI4MTQ2MTY1Il0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY244MjgxNDYxNjUiLCIyMzI2ODEzMSIsIjIzMjY4MTRYIiwib2NuODI4MTQ2MTcxIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiNzE3OTQ2M1wiOntcImxvY2F0aW9uXCI6XCJTcGVjaWFsIENvbGxlY3Rpb25zIC0gQ290c2VuIENoaWxkcmVuJ3MgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiY3RzblwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJQYW1zIC8gTlIgLyBDaGluZXNlIC8gQm94IDQxIDE1MzUyMVwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCIxNTM1MjFcIixcImxvY2F0aW9uX2hhc1wiOltcIlZvbC4gMTogW25vLiAxXS1bbm8uIDRdIChbSmFuLl0gMjAxMyAtIFtPY3QuXSAyMDEzKVwiLFwiVm9sLiAyOiBuby4gMS02ICg9SXNzdWUgbm8uIDUtMTA7IEphbi4gMjAxNCAtIE5vdi4gMjAxNClcIixcIlZvbC4gMzogbm8uIDEtNiAoPUlzc3VlIG5vLiAxMS0xNjsgSmFuLiAyMDE1IC0gTm92LiAyMDE1KVwiLFwiVm9sLiA0OiBuby4gMS02ICg9SXNzdWUgbm8uIDE3LTIyOyBKYW4uIDIwMTYgLSBOb3YuIDIwMTYpXCIsXCJWb2wuIDU6IG5vLiAxLTYgKD1Jc3N1ZSBuby4gMjMtMjg7IEphbi4gMjAxNyAtIE5vdi4gMjAxNylcIl19LFwiMTA0NDQ3MzFcIjp7XCJsb2NhdGlvblwiOlwiU3BlY2lhbCBDb2xsZWN0aW9ucyAtIENvdHNlbiBDaGlsZHJlbidzIExpYnJhcnlcIixcImxpYnJhcnlcIjpcIlNwZWNpYWwgQ29sbGVjdGlvbnNcIixcImxvY2F0aW9uX2NvZGVcIjpcImN0c25cIixcImNvcHlfbnVtYmVyXCI6XCIxXCIsXCJjYWxsX251bWJlclwiOlwiUGFtcyAvIE5SIC8gQ2hpbmVzZSAvIEJveCAxMDAgOTExMjkyODZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiOTExMjkyODZcIixcImxvY2F0aW9uX2hhc1wiOltcIlZvbC4gNjogbm8uIDEtNiAoPUlzc3VlIG5vLiAyOS0zNDsgSmFuLiAyMDE4IC0gTm92LiAyMDE4KSBQcmluY2V0b24gY29weSAxXCJdfSxcIjEwODYzNDQ3XCI6e1wibG9jYXRpb25cIjpcIlNwZWNpYWwgQ29sbGVjdGlvbnMgLSBDb3RzZW4gQ2hpbGRyZW4ncyBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJjdHNuXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIlBhbXMgLyBOUiAvIENoaW5lc2UgLyBCb3ggODUgOTExMjkyODZcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiOTExMjkyODZcIixcImxvY2F0aW9uX2hhc1wiOltcIlZvbC4gNzogbm8uIDEtNiAoPUlzc3VlIG5vLiAzNS00MDsgSmFuLiAyMDE5IC0gTm92LiAyMDE5KSBQcmluY2V0b24gY29weSAxXCJdfSxcIjExNDk4MzYyXCI6e1wibG9jYXRpb25cIjpcIlNwZWNpYWwgQ29sbGVjdGlvbnMgLSBDb3RzZW4gQ2hpbGRyZW4ncyBMaWJyYXJ5XCIsXCJsaWJyYXJ5XCI6XCJTcGVjaWFsIENvbGxlY3Rpb25zXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJjdHNuXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2FsbF9udW1iZXJcIjpcIlBhbXMgLyBOUiAvIENoaW5lc2UgLyBCb3ggMjI3IDkxMTI5Mjg2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIjkxMTI5Mjg2XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJWb2wuIDg6IG5vLiAxICg9SXNzdWUgbm8uIDQxOyBKYW4uIDIwMjApIFByaW5jZXRvbiBjb3B5IDFcIl19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJjdHNuIl0sImxvY2F0aW9uIjpbIlNwZWNpYWwgQ29sbGVjdGlvbnMiXSwibG9jYXRpb25fZGlzcGxheSI6WyJTcGVjaWFsIENvbGxlY3Rpb25zIC0gQ290c2VuIENoaWxkcmVuJ3MgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImN0c24iLCJTcGVjaWFsIENvbGxlY3Rpb25zIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiUGFtcyAvIE5SIC8gQ2hpbmVzZSAvIEJveCA0MSAxNTM1MjEiLCJQYW1zIC8gTlIgLyBDaGluZXNlIC8gQm94IDEwMCA5MTEyOTI4NiIsIlBhbXMgLyBOUiAvIENoaW5lc2UgLyBCb3ggODUgOTExMjkyODYiLCJQYW1zIC8gTlIgLyBDaGluZXNlIC8gQm94IDIyNyA5MTEyOTI4NiJdLCJjYWxsX251bWJlcl9icm93c2VfcyI6WyIxNTM1MjEiLCI5MTEyOTI4NiJdLCJfdmVyc2lvbl8iOjE2NjA5Njc1MTAyMTQ3MDUxNTIsInRpbWVzdGFtcCI6IjIwMjAtMDMtMTJUMTQ6MDc6MzQuODUwWiJ9
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:58:08 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=7179463
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:58:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"85a60d15946ebcb46531a9cd9459a89c"
+      X-Runtime:
+      - '0.058613'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - ca5bf617-0b05-40bb-8334-ed14b34afc50
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '[{"barcode":"32101094417795","id":7572015,"location":"ctsn","copy_number":1,"item_sequence_number":5,"status":"On-Site","on_reserve":"N","enum":"Vol.
+        5: no. 1-6","chron":"Jan 2017 - Nov 2017","enum_display":"Vol. 5: no. 1-6
+        (Jan 2017 - Nov 2017)","label":"Special Collections - Cotsen Children''s Library"},{"barcode":"32101091127959","id":7314885,"location":"ctsn","copy_number":1,"item_sequence_number":4,"status":"On-Site","on_reserve":"N","enum":"Vol.
+        4: no. 1 - 6","chron":"Jan 2016 - Nov 2016","enum_display":"Vol. 4: no. 1
+        - 6 (Jan 2016 - Nov 2016)","label":"Special Collections - Cotsen Children''s
+        Library"},{"barcode":"32101071686446","id":7166642,"location":"ctsn","copy_number":1,"item_sequence_number":3,"status":"On-Site","on_reserve":"N","enum":"Vol.
+        3: no. 1 - 6","chron":"Jan 2015 - Nov 2015","enum_display":"Vol. 3: no. 1
+        - 6 (Jan 2015 - Nov 2015)","label":"Special Collections - Cotsen Children''s
+        Library"},{"barcode":"32101071686438","id":7166635,"location":"ctsn","copy_number":1,"item_sequence_number":2,"status":"On-Site","on_reserve":"N","enum":"Vol.
+        2: no. 1 - 6","chron":"Jan 2014 - Nov 2014","enum_display":"Vol. 2: no. 1
+        - 6 (Jan 2014 - Nov 2014)","label":"Special Collections - Cotsen Children''s
+        Library"},{"barcode":"32101071302192","id":6559967,"location":"ctsn","copy_number":1,"item_sequence_number":1,"status":"On-Site","on_reserve":"N","enum":"Vol
+        1: no. 1 - 4","chron":"Jan 2013 - Oct 2013","enum_display":"Vol 1: no. 1 -
+        4 (Jan 2013 - Oct 2013)","label":"Special Collections - Cotsen Children''s
+        Library"}]'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:58:09 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/locations/holding_locations/ctsn.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Tue, 17 Mar 2020 18:58:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"b04d4ef9198621de2732f3ac2ea9b9a1"
+      X-Runtime:
+      - '0.007721'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - ab728a13-96be-4ec5-b3ba-9be050274b89
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"label":"Cotsen Children''s Library","code":"ctsn","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"library":{"label":"Special
+        Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone
+        Library - Cotsen Children''s Library - Research Collection","code":"cotsenresearch"},"delivery_locations":[{"label":"Special
+        Collections","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true}]}'
+    http_version: 
+  recorded_at: Tue, 17 Mar 2020 18:58:09 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/9222024/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Wed, 18 Mar 2020 14:35:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - cc769362-27db-4fee-a0dd-ed9476f748e9
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"9e52b2a5724bc127c4dfe2513f3154a7"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.019752'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6IjkyMjIwMjQiLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIlBpZXRyenlrLCBMZXNsaWUsIDE5NjEtIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlBpZXRyenlrLCBMZXNsaWUiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJQaWV0cnp5aywgTGVzbGllXCJ9IiwiYXV0aG9yX3MiOlsiUGlldHJ6eWssIExlc2xpZSwgMTk2MS0iXSwibWFyY19yZWxhdG9yX2Rpc3BsYXkiOlsiQXV0aG9yIl0sInVuaWZvcm1fdGl0bGVfcyI6WyJTaG9ydCBzdG9yaWVzLiBTZWxlY3Rpb25zIl0sInRpdGxlX2Rpc3BsYXkiOiJUaGlzIGFuZ2VsIG9uIG15IGNoZXN0IDogc3RvcmllcyAvIExlc2xpZSBQaWV0cnp5ay4iLCJ0aXRsZV90IjpbIlRoaXMgYW5nZWwgb24gbXkgY2hlc3QgOiBzdG9yaWVzIC8gTGVzbGllIFBpZXRyenlrLiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlRoaXMgYW5nZWwgb24gbXkgY2hlc3QgOiBzdG9yaWVzIl0sImNvbXBpbGVkX2NyZWF0ZWRfdCI6WyJUaGlzIGFuZ2VsIG9uIG15IGNoZXN0IDogc3RvcmllcyAvIExlc2xpZSBQaWV0cnp5ay4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJQaXR0c2J1cmdoLCBQQSA6IFVuaXZlcnNpdHkgb2YgUGl0dHNidXJnaCBQcmVzcywgWzIwMTVdIl0sInB1Yl9jcmVhdGVkX3MiOlsiUGl0dHNidXJnaCwgUEEgOiBVbml2ZXJzaXR5IG9mIFBpdHRzYnVyZ2ggUHJlc3MsIFsyMDE1XSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQaXR0c2J1cmdoLCBQQTogVW5pdmVyc2l0eSBvZiBQaXR0c2J1cmdoIFByZXNzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxNSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE1LCJjYXRhbG9nZWRfdGR0IjoiMjAxNS0xMS0yM1QxNDozMjoxM1oiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjIxNiBwYWdlcyA7IDIyIGNtIl0sImRlc2NyaXB0aW9uX3QiOlsiMjE2IHBhZ2VzIDsgMjIgY20iXSwibnVtYmVyX29mX3BhZ2VzX2NpdGF0aW9uX2Rpc3BsYXkiOlsiMjE2IHBhZ2VzIl0sInN1bW1hcnlfbm90ZV9kaXNwbGF5IjpbIlRoaXMgQW5nZWwgb24gTXkgQ2hlc3QgaXMgYSBjb2xsZWN0aW9uIG9mIHVuY29udmVudGlvbmFsbHkgbGlua2VkIHN0b3JpZXMsIGVhY2ggYWJvdXQgYSBkaWZmZXJlbnQgeW91bmcgd29tYW4gd2hvc2UgaHVzYmFuZCBkaWVzIHN1ZGRlbmx5IGFuZCB1bmV4cGVjdGVkbHkuIl0sIm5vdGVzX2Rpc3BsYXkiOlsiXCJEcnVlIEhlaW56IExpdGVyYXR1cmUgUHJpemVcIiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sImNvbnRlbnRzX2Rpc3BsYXkiOlsiVGVuIHRoaW5ncyAtLSBBY3F1aWVzY2VuY2UgLS0gQSBxdWl6IC0tIEhlYXQgLS0gSW4gYSBkcmVhbSAtLSBPbmUgYXJ0IC0tIERvIHlvdSBiZWxpZXZlIGluIGdob3N0cz8gLS0gU2x1dCAtLSBJIGFtIHRoZSB3aWRvdyAtLSBPbmUgdHJ1ZSB0aGluZyAtLSBTb21lb25lIGluIE5lYnJhc2thIC0tIFdoYXQgSSBjb3VsZCBidXkgLS0gVHJ1dGgtdGVsbGluZyBmb3IgYWR1bHRzIC0tIENoYXB0ZXIgdGVuOiBhbiBpbmRleCBvZiBmb29kIChkcmFmdCkgLS0gVGhlIGNpcmNsZSAtLSBQcmVzZW50IHRlbnNlLiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiU3VkZGVuIGRlYXRo4oCURmljdGlvbiIsIkxvc3MgKFBzeWNob2xvZ3kp4oCURmljdGlvbiIsIkdyaWVm4oCURmljdGlvbiJdLCJsY19zdWJqZWN0X2Rpc3BsYXkiOlsiU3VkZGVuIGRlYXRo4oCURmljdGlvbiIsIkxvc3MgKFBzeWNob2xvZ3kp4oCURmljdGlvbiIsIkdyaWVm4oCURmljdGlvbiJdLCJzdWJqZWN0X2ZhY2V0IjpbIlN1ZGRlbiBkZWF0aOKAlEZpY3Rpb24iLCJMb3NzIChQc3ljaG9sb2d5KeKAlEZpY3Rpb24iLCJHcmllZuKAlEZpY3Rpb24iXSwiaXNibl9kaXNwbGF5IjpbIjk3ODA4MjI5NDQ0MjMgKGhhcmRjb3ZlciA6IGFsay4gcGFwZXIpIiwiMDgyMjk0NDQyMSAoaGFyZGNvdmVyIDogYWxrLiBwYXBlcikiXSwibGNjbl9kaXNwbGF5IjpbIiAgMjAxNTAyNTM2NiJdLCJsY2NuX3MiOlsiMjAxNTAyNTM2NiJdLCJpc2JuX3MiOlsiOTc4MDgyMjk0NDQyMyJdLCJvY2xjX3MiOlsiOTEwMzM0NDQzIl0sIm90aGVyX3ZlcnNpb25fcyI6WyJvY245MTAzMzQ0NDMiLCI5NzgwODIyOTQ0NDIzIl0sImhvbGRpbmdzXzFkaXNwbGF5Ijoie1wiOTA5MjgyN1wiOntcImxvY2F0aW9uXCI6XCJGaXJlc3RvbmUgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiRmlyZXN0b25lIExpYnJhcnlcIixcImxvY2F0aW9uX2NvZGVcIjpcImZcIixcImNhbGxfbnVtYmVyXCI6XCJQUzM1NjYuSTQyOCBBNiAyMDE1XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIlBTMzU2Ni5JNDI4IEE2IDIwMTVcIn19IiwibG9jYXRpb25fY29kZV9zIjpbImYiXSwibG9jYXRpb24iOlsiRmlyZXN0b25lIExpYnJhcnkiXSwibG9jYXRpb25fZGlzcGxheSI6WyJGaXJlc3RvbmUgTGlicmFyeSJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbImYiLCJGaXJlc3RvbmUgTGlicmFyeSJdLCJuYW1lX3VuaWZvcm1fdGl0bGVfMWRpc3BsYXkiOiJbW1wiUGlldHJ6eWssIExlc2xpZSwgMTk2MS0uXCIsXCJTaG9ydCBzdG9yaWVzLlwiLFwiU2VsZWN0aW9uc1wiXV0iLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIlBpZXRyenlrLCBMZXNsaWUsIDE5NjEtLiBTaG9ydCBzdG9yaWVzIiwiUGlldHJ6eWssIExlc2xpZSwgMTk2MS0uIFNob3J0IHN0b3JpZXMuIFNlbGVjdGlvbnMiXSwiY2FsbF9udW1iZXJfZGlzcGxheSI6WyJQUzM1NjYuSTQyOCBBNiAyMDE1Il0sImNhbGxfbnVtYmVyX2Jyb3dzZV9zIjpbIlBTMzU2Ni5JNDI4IEE2IDIwMTUiXSwiX3ZlcnNpb25fIjoxNjYwMjMzNTM1Nzk0OTcwNjI0LCJ0aW1lc3RhbXAiOiIyMDIwLTAzLTA0VDExOjQxOjIyLjIyNVoifQ==
+    http_version: 
+  recorded_at: Wed, 18 Mar 2020 14:35:30 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?id=9222024
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Wed, 18 Mar 2020 14:35:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"197995b692ad75c2244bdf11e0206c10"
+      X-Runtime:
+      - '0.100372'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - ba16fc6e-8728-4641-b186-7814ed0cff9d
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"9092827":{"more_items":false,"location":"f","copy_number":1,"item_id":7267874,"on_reserve":"N","status":"Not
+        Charged","label":"Firestone Library"}}'
+    http_version: 
+  recorded_at: Wed, 18 Mar 2020 14:35:31 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=9092827
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Wed, 18 Mar 2020 14:35:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"6b4b39da0e868eb7a6453ca5282ffa36"
+      X-Runtime:
+      - '0.059892'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - aee36f7e-5f6b-4747-8bfe-0abecef363f5
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '[{"barcode":"32101096297443","id":7267874,"location":"f","copy_number":1,"item_sequence_number":1,"status":"Not
+        Charged","on_reserve":"N","label":"Firestone Library"}]'
+    http_version: 
+  recorded_at: Wed, 18 Mar 2020 14:35:31 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/11453340/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Wed, 18 Mar 2020 14:35:32 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - ce69d661-29d9-43f5-9756-2a1ccaef1cd1
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"fdb2cc6e048b5bde9623937fc7ef6e9f"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.019199'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6IjExNDUzMzQwIiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJNYWNLYXksIEVsbHkiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiTWFjS2F5LCBFbGx5Il0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W10sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W10sXCJwcmltYXJ5X2F1dGhvclwiOlwiTWFjS2F5LCBFbGx5XCJ9IiwiYXV0aG9yX3MiOlsiTWFjS2F5LCBFbGx5Il0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiVGhlIHRhbGxlc3QgdHJlZSBob3VzZSAvIEVsbHkgTWFjS2F5LiIsInRpdGxlX3QiOlsiVGhlIHRhbGxlc3QgdHJlZSBob3VzZSAvIEVsbHkgTWFjS2F5LiJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIlRoZSB0YWxsZXN0IHRyZWUgaG91c2UiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlRoZSB0YWxsZXN0IHRyZWUgaG91c2UgLyBFbGx5IE1hY0theS4iXSwiZWRpdGlvbl9kaXNwbGF5IjpbIkZpcnN0IGVkaXRpb24uIl0sInB1Yl9jcmVhdGVkX2Rpc3BsYXkiOlsiUGhpbGFkZWxwaGlhIDogUlAgS2lkcywgMjAxOS4iLCLCqTIwMTkiXSwicHViX2NyZWF0ZWRfcyI6WyJQaGlsYWRlbHBoaWEgOiBSUCBLaWRzLCAyMDE5LiIsIsKpMjAxOSJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQaGlsYWRlbHBoaWE6IFJQIEtpZHMiXSwicHViX2RhdGVfZGlzcGxheSI6WyIyMDE5Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjIwMTksInB1Yl9kYXRlX2VuZF9zb3J0IjoyMDE5LCJjYXRhbG9nZWRfdGR0IjoiMjAxOS0wNi0yN1QyMTo1NzoxMVoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjEgdm9sdW1lICh1bnBhZ2VkKSA6IGNvbG9yIGlsbHVzdHJhdGlvbnMgOyAyOSBjbSJdLCJkZXNjcmlwdGlvbl90IjpbIjEgdm9sdW1lICh1bnBhZ2VkKSA6IGNvbG9yIGlsbHVzdHJhdGlvbnMgOyAyOSBjbSJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIxIHZvbHVtZSAodW5wYWdlZCkiXSwic3VtbWFyeV9ub3RlX2Rpc3BsYXkiOlsiV2hlbiBNaXAgYW5kIFBpcCBhZ3JlZSB0byBhIGNvbnRlc3QgdG8gc2VlIHdobyBjYW4gYnVpbGQgdGhlIHRhbGxlc3QgdHJlZSBob3VzZSBieSBzdW5kb3duLCBNaXAgc2VlbXMgdG8gYmUgd2lubmluZyB1bnRpbCBhIHN0b3JtIGJsb3dzIHRocm91Z2ggdGhlIGZvcmVzdC4iXSwibGFuZ3VhZ2VfZmFjZXQiOlsiRW5nbGlzaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsiZW5nIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJlbiJdLCJzdWJqZWN0X2Rpc3BsYXkiOlsiRmFpcmllc+KAlEp1dmVuaWxlIGZpY3Rpb24iLCJUcmVlIGhvdXNlc+KAlEp1dmVuaWxlIGZpY3Rpb24iLCJGcmllbmRzaGlw4oCUSnV2ZW5pbGUgZmljdGlvbiIsIkNvbXBldGl0aW9u4oCUSnV2ZW5pbGUgZmljdGlvbiJdLCJsY19zdWJqZWN0X2Rpc3BsYXkiOlsiRmFpcmllc+KAlEp1dmVuaWxlIGZpY3Rpb24iLCJUcmVlIGhvdXNlc+KAlEp1dmVuaWxlIGZpY3Rpb24iLCJGcmllbmRzaGlw4oCUSnV2ZW5pbGUgZmljdGlvbiIsIkNvbXBldGl0aW9u4oCUSnV2ZW5pbGUgZmljdGlvbiJdLCJzdWJqZWN0X2ZhY2V0IjpbIkZhaXJpZXPigJRKdXZlbmlsZSBmaWN0aW9uIiwiVHJlZSBob3VzZXPigJRKdXZlbmlsZSBmaWN0aW9uIiwiRnJpZW5kc2hpcOKAlEp1dmVuaWxlIGZpY3Rpb24iLCJDb21wZXRpdGlvbuKAlEp1dmVuaWxlIGZpY3Rpb24iLCJQaWN0dXJlIGJvb2tzIl0sImxjZ2Z0X3MiOlsiUGljdHVyZSBib29rcyJdLCJpc2JuX2Rpc3BsYXkiOlsiOTc4MDc2MjQ2Mjk5NSIsIjA3NjI0NjI5OVgiXSwiaXNibl9zIjpbIjk3ODA3NjI0NjI5OTUiXSwib2NsY19zIjpbIjEwOTYzMjY2NzEiXSwib3RoZXJfdmVyc2lvbl9zIjpbIjk3ODA3NjI0NjI5OTUiLCJvbjEwOTYzMjY2NzEiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIxMTE0MzI2OFwiOntcImxvY2F0aW9uXCI6XCJTcGVjaWFsIENvbGxlY3Rpb25zIC0gQ290c2VuIENoaWxkcmVuJ3MgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiU3BlY2lhbCBDb2xsZWN0aW9uc1wiLFwibG9jYXRpb25fY29kZVwiOlwiY3RzblwiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNhbGxfbnVtYmVyXCI6XCJFbmcgMjFRIFEtMDAwNzU2XCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIlEtMDAwNzU2XCIsXCJsb2NhdGlvbl9oYXNcIjpbXCJQcmluY2V0b24gY29weSAxXCJdfX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsiY3RzbiJdLCJsb2NhdGlvbiI6WyJTcGVjaWFsIENvbGxlY3Rpb25zIl0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiU3BlY2lhbCBDb2xsZWN0aW9ucyAtIENvdHNlbiBDaGlsZHJlbidzIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJjdHNuIiwiU3BlY2lhbCBDb2xsZWN0aW9ucyJdLCJuYW1lX3RpdGxlX2Jyb3dzZV9zIjpbIk1hY0theSwgRWxseS4gVGhlIHRhbGxlc3QgdHJlZSBob3VzZSJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkVuZyAyMVEgUS0wMDA3NTYiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiUS0wMDA3NTYiXSwiX3ZlcnNpb25fIjoxNjYwMjQzNjY0MDE5OTE0NzUyLCJ0aW1lc3RhbXAiOiIyMDIwLTAzLTA0VDE0OjIyOjIxLjI4OFoifQ==
+    http_version: 
+  recorded_at: Wed, 18 Mar 2020 14:35:32 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?id=11453340
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Wed, 18 Mar 2020 14:35:32 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"10aa2277314e85efcc7fa51a9bbdbb30"
+      X-Runtime:
+      - '0.097106'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - a30543ec-955b-4377-8d12-7c1c8779a568
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '{"11143268":{"more_items":false,"location":"ctsn","copy_number":1,"item_id":8136889,"on_reserve":"N","status":"On-Site","label":"Special
+        Collections - Cotsen Children''s Library"}}'
+    http_version: 
+  recorded_at: Wed, 18 Mar 2020 14:35:32 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=11143268
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.17.6
+      Date:
+      - Wed, 18 Mar 2020 14:35:32 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"203e6a97a9d37857ea3b5e9ed31bd8d3"
+      X-Runtime:
+      - '0.056634'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - ca474904-92fc-4ba8-804e-87bc44f92a83
+      X-Powered-By:
+      - Phusion Passenger 6.0.4
+    body:
+      encoding: UTF-8
+      string: '[{"barcode":"32101097271033","id":8136889,"location":"ctsn","copy_number":1,"item_sequence_number":1,"status":"On-Site","on_reserve":"N","label":"Special
+        Collections - Cotsen Children''s Library"}]'
+    http_version: 
+  recorded_at: Wed, 18 Mar 2020 14:35:32 GMT
+recorded_with: VCR 4.0.0

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -92,7 +92,8 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           fill_in 'request_user_name', :with => 'foobar'
           click_button I18n.t('requests.account.other_user_login_btn')
           expect(page).to have_no_content 'Electronic Delivery'
-          select('Firestone Library', :from => 'requestable__pickup')
+          # temporary change issue 438
+          # select('Firestone Library', :from => 'requestable__pickup')
           click_button 'Request this Item'
           # wait_for_ajax
           expect(page).to have_content 'Request submitted'
@@ -154,6 +155,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           expect(page).to have_field 'requestable_user_supplied_enum_2576882'
           check('requestable__selected', exact: true)
           fill_in 'requestable_user_supplied_enum_2576882', :with => 'test'
+          # temporary changes issue 438
           select('Firestone Library', :from => 'requestable__pickup')
           click_button 'Request Selected Items'
           expect(page).to have_content I18n.t('requests.submit.annexa_success')
@@ -200,7 +202,8 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           # some weird issue with this and capybara examining the page source shows it is there.
           expect(page).to have_selector '#request_user_barcode', visible: false
           choose('requestable__delivery_mode_7303228_print') # chooses 'print' radio button
-          select('Firestone Library', :from => 'requestable__pickup')
+          # temporary changes issue 438
+          # select('Firestone Library', :from => 'requestable__pickup')
           expect(page).to have_button('Request this Item', disabled: false)
         end
 
@@ -229,8 +232,9 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         it 'makes sure In-Process ReCAP items with no holding library can be delivered anywhere', js: true do
           visit "/requests/#{recap_in_process_id}"
           expect(page).to have_content 'In Process'
-          select('Firestone Library', :from => 'requestable__pickup')
-          select('Lewis Library', :from => 'requestable__pickup')
+          # temporary changes issue 438
+          # select('Firestone Library', :from => 'requestable__pickup')
+          # select('Lewis Library', :from => 'requestable__pickup')
           click_button 'Request this Item'
           expect(page).to have_content I18n.t("requests.submit.in_process_success")
         end
@@ -249,7 +253,10 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         it 'allows CAS patrons to locate an on_shelf record that has no item data' do
           visit "/requests/#{on_shelf_no_items_id}"
-          expect(page).to have_link('Where to find it')
+          # temporary changes 438
+          expect(page).to have_content 'Pickup location: Firestone Library'
+          expect(page).to have_content 'Pageable item at Firestone Library. Request for delivery in 1-2 business days.'
+          # expect(page).to have_link('Where to find it')
         end
 
         it 'displays an ark link for a plum item' do

--- a/spec/helpers/requests/application_helper_spec.rb
+++ b/spec/helpers/requests/application_helper_spec.rb
@@ -30,21 +30,78 @@ RSpec.describe Requests::ApplicationHelper, type: :helper, vcr: { cassette_name:
     it 'returns a boolean to disable/enable submit' do
       expect(submit_button_disabled).to be_truthy
     end
+
+    # temporary for #348
+    context "Firestone Classics Collection (Clas)" do
+      let(:params) {
+        {
+          system_id: '9222024',
+          user: user
+        }
+      }
+      it 'returns a boolean to enable submit for logged in user' do
+        assign(:user, user)
+        expect(submit_button_disabled).to be_falsey
+      end
+
+      it 'returns a boolean to disable submit for guest' do
+        assign(:user, nil)
+        expect(submit_button_disabled).to be_truthy
+      end
+    end
+
+    describe 'lewis library' do
+      let(:params) {
+        {
+          system_id: '3848872',
+          user: user
+        }
+      }
+      it 'lewis is a submitable request' do
+        expect(submit_button_disabled).to be false
+      end
+    end
   end
 
-  describe 'lewis paging' do
+  describe 'firestone pickup_choices' do
     let(:user) { FactoryGirl.build(:user) }
     let(:params) {
       {
-        system_id: '3848872',
+        system_id: '491654',
+        mfhd: '534140',
         user: user
       }
+    }
+    let(:default_pickups) {
+      [{ label: "Firestone Library", gfa_code: "PA", staff_only: false }, { label: "Architecture Library", gfa_code: "PW", staff_only: false }, { label: "East Asian Library", gfa_code: "PL", staff_only: false }, { label: "Lewis Library", gfa_code: "PN", staff_only: false }, { label: "Marquand Library of Art and Archaeology", gfa_code: "PJ", staff_only: false }, { label: "Mendel Music Library", gfa_code: "PK", staff_only: false }, { label: "Plasma Physics Library", gfa_code: "PQ", staff_only: false }, { label: "Stokes Library", gfa_code: "PM", staff_only: false }]
     }
     let(:lewis_request_with_multiple_requestable) { Requests::Request.new(params) }
     let(:requestable_list) { lewis_request_with_multiple_requestable.requestable }
     let(:submit_button_disabled) { helper.submit_button_disabled(requestable_list) }
     it 'lewis is a submitable request' do
-      expect(submit_button_disabled).to be false
+      choices = helper.pickup_choices(lewis_request_with_multiple_requestable.requestable.last, default_pickups)
+      expect(choices).to eq("<div id=\"fields-print__3826440\" class=\"card card-body bg-light collapse show request--print\"><input type=\"hidden\" name=\"requestable[][pickup]\" id=\"requestable__pickup\" value=\"PN\" class=\"single-pickup-hidden\" /><label class=\"single-pickup\" style=\"\" for=\"requestable__pickup\">Pickup location: Firestone Library</label></div>")
+    end
+  end
+
+  describe 'multiple delivery options' do
+    let(:user) { FactoryGirl.build(:user) }
+    let(:params) {
+      {
+        system_id: '426420',
+        mfhd: '3538795',
+        user: user
+      }
+    }
+    let(:default_pickups) {
+      [{ label: "Firestone Library", gfa_code: "PA", staff_only: false }, { label: "Architecture Library", gfa_code: "PW", staff_only: false }, { label: "East Asian Library", gfa_code: "PL", staff_only: false }, { label: "Lewis Library", gfa_code: "PN", staff_only: false }, { label: "Marquand Library of Art and Archaeology", gfa_code: "PJ", staff_only: false }, { label: "Mendel Music Library", gfa_code: "PK", staff_only: false }, { label: "Plasma Physics Library", gfa_code: "PQ", staff_only: false }, { label: "Stokes Library", gfa_code: "PM", staff_only: false }]
+    }
+    let(:lewis_request_with_multiple_requestable) { Requests::Request.new(params) }
+    let(:requestable_list) { lewis_request_with_multiple_requestable.requestable }
+    let(:submit_button_disabled) { helper.submit_button_disabled(requestable_list) }
+    it 'lewis is a submitable request' do
+      choices = helper.pickup_choices(lewis_request_with_multiple_requestable.requestable.last, default_pickups)
+      expect(choices).to eq("<div id=\"fields-print__2578961\" class=\"card card-body bg-light collapse show request--print\"><input type=\"hidden\" name=\"requestable[][pickup]\" id=\"requestable__pickup\" value=\"PA\" class=\"single-pickup-hidden\" /><label class=\"single-pickup\" style=\"\" for=\"requestable__pickup\">Pickup location: Firestone Library</label></div>")
     end
   end
 

--- a/spec/mailers/requests/request_mailer_spec.rb
+++ b/spec/mailers/requests/request_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 include Requests::ApplicationHelper
 
-describe Requests::RequestMailer, :type => :mailer do
+describe Requests::RequestMailer, :type => :mailer, vcr: { cassette_name: 'mailer', record: :new_episodes } do
   let(:user_info) {
     {
       "user_name" => "Foo Request",
@@ -235,7 +235,7 @@ describe Requests::RequestMailer, :type => :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t('requests.annexa.email_subject'))
       expect(mail.to).to eq([I18n.t('requests.annexa.email')])
-      expect(mail.cc).to eq([submission_for_annexa.email])
+      expect(mail.cc).to eq([submission_for_annexa.email, "fstcirc@princeton.edu"])
       expect(mail.from).to eq([I18n.t('requests.default.email_from')])
     end
 
@@ -288,7 +288,7 @@ describe Requests::RequestMailer, :type => :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t('requests.annexa.email_subject'))
       expect(mail.to).to eq([I18n.t('requests.anxadoc.email')])
-      expect(mail.cc).to eq([submission_for_anxadoc.email])
+      expect(mail.cc).to eq([submission_for_anxadoc.email, "fstcirc@princeton.edu"])
       expect(mail.from).to eq([I18n.t('requests.default.email_from')])
     end
 
@@ -1021,5 +1021,121 @@ describe Requests::RequestMailer, :type => :mailer do
     it "renders the body" do
       expect(mail.body.encoded).to have_content I18n.t('requests.lewis.email_conf_msg')
     end
+  end
+
+  context "Item on shelf in firestone" do
+    let(:requestable) {
+      [
+        {
+          "selected" => "true",
+          "mfhd" => "9092827",
+          "call_number" => "PS3566.I428 A6 2015",
+          "location_code" => "f",
+          "item_id" => "7267874",
+          "barcode" => "32101096297443",
+          "copy_number" => "1",
+          "status" => "Not Charged",
+          "type" => "on_shelf",
+          "pickup" => "PA"
+        }.with_indifferent_access,
+        {
+          "selected" => "false"
+        }.with_indifferent_access
+      ]
+    }
+    let(:bib) {
+      {
+        "id" => "9222024",
+        "title" => "This angel on my chest : stories",
+        "author" => "Pietrzyk, Leslie"
+      }.with_indifferent_access
+    }
+    let(:params) {
+      {
+        request: user_info,
+        requestable: requestable,
+        bib: bib
+      }
+    }
+
+    let(:submission_for_on_shelf) {
+      Requests::Submission.new(params)
+    }
+    # rubocop:disable RSpec/ExampleLength
+    it "sends the email and renders the headers and body" do
+      mail = Requests::RequestMailer.send("on_shelf_email", submission_for_on_shelf).deliver_now
+      expect(mail.subject).to eq(I18n.t('requests.on_shelf.email_subject'))
+      expect(mail.cc).to eq([I18n.t('requests.on_shelf.email')])
+      expect(mail.to).to eq([I18n.t('requests.on_shelf.email')])
+      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+      expect(mail.body.encoded).to have_content I18n.t('requests.on_shelf.email_conf_msg')
+    end
+
+    it "sends the confirmation email and renders the headers and body" do
+      mail = Requests::RequestMailer.send("on_shelf_confirmation", submission_for_on_shelf).deliver_now
+      expect(mail.subject).to eq(I18n.t('requests.on_shelf.email_subject'))
+      expect(mail.to).to eq([submission_for_on_shelf.email])
+      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+      expect(mail.body.encoded).to have_content I18n.t('requests.on_shelf.email_conf_msg')
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  context "Item on shelf in East Asian" do
+    let(:requestable) {
+      [
+        { "selected" => "true",
+          "mfhd" => "3892744",
+          "call_number" => "PL2727.S2 C574 1998",
+          "location_code" => "c",
+          "item_id" => "3020750",
+          "barcode" => "32101042398345",
+          "copy_number" => "1",
+          "status" => "Not Charged",
+          "type" => "on_shelf",
+          "pickup" => "PA"
+        }.with_indifferent_access,
+        {
+          "selected" => "false"
+        }.with_indifferent_access
+      ]
+    }
+    let(:bib) {
+      {
+        "id" => "3573258",
+        "title" => "Hong lou fang zhen : Da guan yuan zai Gong wang fu 红楼访真　: 大观园在恭王府　",
+        "author" => "Zhou, Ruchang"
+      }.with_indifferent_access
+    }
+    let(:params) {
+      {
+        request: user_info,
+        requestable: requestable,
+        bib: bib
+      }
+    }
+
+    let(:submission_for_on_shelf) {
+      Requests::Submission.new(params)
+    }
+
+    # rubocop:disable RSpec/ExampleLength
+    it "sends the email and renders the headers and body" do
+      mail = Requests::RequestMailer.send("on_shelf_email", submission_for_on_shelf).deliver_now
+      expect(mail.subject).to eq(I18n.t('requests.on_shelf.email_subject'))
+      expect(mail.to).to eq(["gestcirc@princeton.edu"])
+      expect(mail.cc).to eq([I18n.t('requests.on_shelf.email')])
+      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+      expect(mail.body.encoded).to have_content I18n.t('requests.on_shelf.email_conf_msg')
+    end
+
+    it "sends the confirmation email and renders the headers and body" do
+      mail = Requests::RequestMailer.send("on_shelf_confirmation", submission_for_on_shelf).deliver_now
+      expect(mail.subject).to eq(I18n.t('requests.on_shelf.email_subject'))
+      expect(mail.to).to eq([submission_for_on_shelf.email])
+      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+      expect(mail.body.encoded).to have_content I18n.t('requests.on_shelf.email_conf_msg')
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION
This allows the libraries to service the public without violating social distancing for COVID-19

Changes:
* Update the pickup location to only be Firestone for items in Lewis
* Update email confirmation message for items in Lewis
* Enabling request button for items in firestone and other on the shelf locations
* Adding email for items on the shelf, cc: email to firestone for items on the shelf and email to: the branch location

Co-authored-by: christinach <actspatial@gmail.com>