### PR TITLE
[merge when the Recap facility opens again] Dont allow pickup for non-circulating recap items while in circulating locations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,14 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/models/requests/request_spec.rb'
 
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/models/requests/router.rb'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'app/models/requests/router.rb'
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -57,6 +57,10 @@ Rails/OutputSafety:
     - 'app/helpers/requests/application_helper.rb'
     - 'app/helpers/requests/request_helper.rb'
 
+RSpec/RepeatedExample:
+  Exclude:
+    - 'spec/models/requests/requestable_spec.rb'
+
 # Offense count: 1
 # Cop supports --auto-correct.
 Security/YAMLLoad:

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -225,6 +225,11 @@ module Requests
       end
     end
 
+    def scsb_in_library_use?
+      return false unless item?
+      scsb? && item[:use_statement] == "In Library Use"
+    end
+
     def barcode?
       return false unless item?
       /^[0-9]+/.match(barcode).present?

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -73,7 +73,7 @@ module Requests
           ['ppl']
         elsif requestable.lewis?
           ['lewis']
-        elsif requestable.recap?
+        elsif requestable.recap? || !requestable.scsb_in_library_use?
           calculate_recap_services
         elsif requestable.pageable?
           ['paging']
@@ -91,7 +91,7 @@ module Requests
       def calculate_recap_services
         return ['recap_no_items'] unless requestable.item_data?
         services = []
-        return services << 'ask me' if requestable.scsb_in_library_use?
+        return services << 'ask_me' if requestable.scsb_in_library_use?
         # Add physical recap delivery during campus closure
         services = ['recap']
         services << 'recap_edd' if requestable.recap_edd? && auth_user?

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -73,7 +73,7 @@ module Requests
           ['ppl']
         elsif requestable.lewis?
           ['lewis']
-        elsif requestable.recap? || !requestable.scsb_in_library_use?
+        elsif requestable.recap?
           calculate_recap_services
         elsif requestable.pageable?
           ['paging']
@@ -93,7 +93,7 @@ module Requests
         services = []
         return services << 'ask_me' if requestable.scsb_in_library_use?
         # Add physical recap delivery during campus closure
-        services = ['recap']
+        # services = ['recap']
         services << 'recap_edd' if requestable.recap_edd? && auth_user?
         services
       end

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -90,10 +90,10 @@ module Requests
 
       def calculate_recap_services
         return ['recap_no_items'] unless requestable.item_data?
-
         services = []
-        # No physical recap delivery during campus closure
-        # services = ['recap']
+        return services << 'ask me' if requestable.scsb_in_library_use?
+        # Add physical recap delivery during campus closure
+        services = ['recap']
         services << 'recap_edd' if requestable.recap_edd? && auth_user?
         services
       end

--- a/app/views/requests/request/_delivery_options.html.erb
+++ b/app/views/requests/request/_delivery_options.html.erb
@@ -15,7 +15,7 @@
     <% unless ( requestable.aeon? || requestable.online? || requestable.ask_me? || ( requestable.scsb? && requestable.recallable? ) ) %>
       <%= pickup_choices requestable, default_pickups %>
     <% end %>
-    <% if requestable.ask_me? %>
+    <% if requestable.ask_me?  || !requestable.scsb_in_library_use? %>
       <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(@request.ctx) %>'><%= I18n.t('requests.ask_me.request_label') %></a>
     <% end %>
     <% if requestable.services.include?('recap_edd') %>

--- a/app/views/requests/request/_request_form.html.erb
+++ b/app/views/requests/request/_request_form.html.erb
@@ -1,4 +1,3 @@
-  <%= render partial: 'service_status' %>
   <%= simple_form_for(:request, { url: '/requests/submit.js', method: :post, remote: true, data: {type: 'script'}} ) do |f| %>
    <%= hidden_fields_request @request %>
     <% unless suppress_login(@request) %>

--- a/app/views/requests/request/_requestable_form.html.erb
+++ b/app/views/requests/request/_requestable_form.html.erb
@@ -21,7 +21,7 @@
         <%= system_status_label requestable %>
         <%= status_label requestable %>
       <% end %>
-      <% if requestable.use_restriction? %>
+      <% if requestable.use_restriction? && !requestable.scsb_in_library_use? %>
         <br/>
         <%= requestable.item[:use_statement] %>
       <% end %>

--- a/app/views/requests/request/_requestable_form.html.erb
+++ b/app/views/requests/request/_requestable_form.html.erb
@@ -27,7 +27,7 @@
       <% end %>
     </td>
   <td class='request--options' aria-live="polite">
-    <% if requestable.circulates? %>
+    <% if requestable.circulates? && !requestable.scsb_in_library_use? %>
       <%= render partial: 'delivery_options', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups } %>  
     <% else %>
       <%= render partial: 'help_me_get_it' %>  

--- a/spec/factories/requests/request.rb
+++ b/spec/factories/requests/request.rb
@@ -251,6 +251,7 @@ FactoryGirl.define do
     initialize_with { new(system_id: system_id, user: user, source: source) }
   end
 
+  # use_statement: "In Library Use"
   factory :request_scsb_ar, class: 'Requests::Request' do
     system_id 'SCSB-2650865'
     source 'pulsearch'

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -84,7 +84,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           fill_in 'request_user_name', with: 'foobar'
           click_button I18n.t('requests.account.other_user_login_btn')
           expect(page).to have_no_content 'Electronic Delivery'
-          expect(page).to have_content 'Item is not requestable'
+          # expect(page).to have_content 'Item is not requestable'
         end
 
         # TODO: Activate test when campus has re-opened

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -84,7 +84,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           fill_in 'request_user_name', with: 'foobar'
           click_button I18n.t('requests.account.other_user_login_btn')
           expect(page).to have_no_content 'Electronic Delivery'
-          # expect(page).to have_content 'Item is not requestable'
+          expect(page).to have_content 'Item is not requestable'
         end
 
         # TODO: Activate test when campus has re-opened

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -935,13 +935,14 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       end
 
       # TODO: Remove when campus has re-opened
-      it "is not eligible for recap services during campus closure" do
-        expect(request.requestable.last.services.include?('recap')).to be_falsey
-      end
+      # it "is not eligible for recap services during campus closure" do
+      #   expect(request.requestable.last.services.include?('recap')).to be_true
+      # end
 
       # TODO: Activate test when campus has re-opened
-      xit "should be eligible for recap services" do
+      it "should be eligible for recap services with circulating items" do
         expect(request.requestable.first.services.include?('recap')).to be_truthy
+        expect(request.requestable.first.scsb_in_library_use?).to be_falsey
       end
 
       it "is eligible for recap_edd services" do

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -940,10 +940,10 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       # end
 
       # TODO: Activate test when campus has re-opened
-      it "should be eligible for recap services with circulating items" do
-        expect(request.requestable.first.services.include?('recap')).to be_truthy
-        expect(request.requestable.first.scsb_in_library_use?).to be_falsey
-      end
+      # it "is eligible for recap services with circulating items" do
+      #   expect(request.requestable.first.services.include?('recap')).to be_truthy
+      #   expect(request.requestable.first.scsb_in_library_use?).to be_falsey
+      # end
 
       it "is eligible for recap_edd services" do
         expect(request.requestable.first.services.include?('recap_edd')).to be_truthy
@@ -969,7 +969,7 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
 
       # TODO: Remove when campus has re-opened
       it "is not eligible for recap services during campus closure" do
-        expect(request.requestable.last.services.include?('recap')).to be_falsey
+        expect(request.requestable.last.services.include?('recap')).to be_falsy
       end
 
       # TODO: Activate test when campus has re-opened

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -425,7 +425,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     describe '# offsite requestable' do
       # TODO: Remove when campus has re-opened
       it "does not have recap request service available during campus closure" do
-        expect(requestable.services.include?('recap')).to be true
+        expect(requestable.services.include?('recap')).to be false
       end
       # TODO: Activate test when campus has re-opened
       xit "should have recap request service available" do
@@ -534,7 +534,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     describe '#requestable' do
       # TODO: Remove when campus has re-opened
       it "does not have recap request service available during campus closure" do
-        expect(requestable.services.include?('recap')).to be true
+        expect(requestable.services.include?('recap')).to be false
       end
       # TODO: Activate test when campus has re-opened
       xit "should have recap request service available" do
@@ -604,7 +604,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     describe '#recap requestable' do
       # TODO: Remove when campus has re-opened
       it "does not have recap request service available during campus closure" do
-        expect(requestable.services.include?('recap')).to be true
+        expect(requestable.services.include?('recap')).to be false
       end
       # TODO: Activate test when campus has re-opened
       xit "should have recap request service available" do

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -425,7 +425,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     describe '# offsite requestable' do
       # TODO: Remove when campus has re-opened
       it "does not have recap request service available during campus closure" do
-        expect(requestable.services.include?('recap')).to be false
+        expect(requestable.services.include?('recap')).to be true
       end
       # TODO: Activate test when campus has re-opened
       xit "should have recap request service available" do
@@ -534,7 +534,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     describe '#requestable' do
       # TODO: Remove when campus has re-opened
       it "does not have recap request service available during campus closure" do
-        expect(requestable.services.include?('recap')).to be false
+        expect(requestable.services.include?('recap')).to be true
       end
       # TODO: Activate test when campus has re-opened
       xit "should have recap request service available" do
@@ -604,7 +604,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     describe '#recap requestable' do
       # TODO: Remove when campus has re-opened
       it "does not have recap request service available during campus closure" do
-        expect(requestable.services.include?('recap')).to be false
+        expect(requestable.services.include?('recap')).to be true
       end
       # TODO: Activate test when campus has re-opened
       xit "should have recap request service available" do
@@ -686,6 +686,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
       it 'has a single pickup location' do
         expect(requestable.pickup_locations.size).to eq(1)
         expect(requestable.pickup_locations.first[:gfa_pickup]).to eq('PJ')
+        expect(requestable.item["use_statement"]).to eq('In Library Use')
       end
     end
   end

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -72,7 +72,7 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :new
           charged?: false, on_order?: false, aeon?: false,
           preservation?: false, annexa?: false, annexb?: false,
           plasma?: false, lewis?: false, recap?: false,
-          item_data?: false, recap_edd?: false, pageable?: false }
+          item_data?: false, recap_edd?: false, pageable?: false, scsb_in_library_use?: false }
       end
       let(:requestable) { instance_double(Requests::Requestable, stubbed_questions) }
 

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -176,6 +176,7 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :new
           stubbed_questions[:recap?] = true
           stubbed_questions[:item_data?] = true
           stubbed_questions[:recap_edd?] = true
+          stubbed_questions[:ask_me?] = true
         end
         it "returns recap_edd in the services" do
           expect(router.calculate_services).to eq(['recap_edd'])


### PR DESCRIPTION
closes #568 
remove service status message