### PR TITLE
Allow PPL to be requested

### DIFF
--- a/app/views/requests/request/_delivery_options.html.erb
+++ b/app/views/requests/request/_delivery_options.html.erb
@@ -24,6 +24,7 @@
         <br/><small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text text-muted"><%= I18n.t('requests.recap_edd.brief_msg') %></small>
         <%= render partial: "edd_fields", locals: { requestable: requestable } %>
     <% end %>
-    <% if requestable.on_shelf? || requestable.annexa? || requestable.annexb? || requestable.lewis? %>
+    <% if requestable.on_shelf? || requestable.annexa? || requestable.annexb? || requestable.lewis? ||
+          requestable.plasma? %>
       <%= hidden_field_tag "requestable[][type]", requestable.services.first %>
     <% end %>

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -309,6 +309,17 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           expect(page).to have_content 'Help Me Get It'
           expect(page).not_to have_css '.submit--request'
         end
+
+        it 'allows patrons to request a PPL Item' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .to_return(status: 200, body: good_response, headers: {})
+          visit '/requests/578830'
+          expect(page).to have_content 'Pickup location: Firestone Library'
+          # temporary change issue 438
+          # select('Firestone Library', from: 'requestable__pickup')
+          click_button 'Request this Item'
+          expect(page).to have_content 'Request submitted'
+        end
       end
     end
 


### PR DESCRIPTION
This PR enables the form for the old workflow.  Did we want this, or for it to go through the on_shelf workflow instead?

fixes #563