### PR TITLE
updating internal error email to look a bit nicer

### DIFF
--- a/app/views/requests/request_mailer/_service_errors.html.erb
+++ b/app/views/requests/request_mailer/_service_errors.html.erb
@@ -1,10 +1,19 @@
-==============================================
-Request Service Errors
-==============================================
 <% @services.each do |s| %>
+<h2><%= s.class.name.titleize.gsub("/"," ") %> Errors</h2>
+<table>
   <% s.errors.each do |error| %>
-      <% error.each do |k,v| %>
-        <%= "#{k}=#{v}" %>
+      <% error.each do |key,value| %>
+        <tr>
+        <td><%= key.to_s.humanize.titleize %></td>
+        <td>
+          <% if value.is_a? Hash %>
+            <%= value.to_a.map{|k,v| "#{k}: #{v}"}.join(", ") %>
+          <% else %>
+            <%= value %>
+          <% end %>
+        </td>
+        </tr>
       <% end %>
   <% end %>
+</table>
 <% end %>

--- a/app/views/requests/request_mailer/service_error_email.html.erb
+++ b/app/views/requests/request_mailer/service_error_email.html.erb
@@ -1,5 +1,8 @@
-==============================================
-Remote Service Request Error
+<tr>
+  <td colspan="2" style="padding: 18px;">
+    <h1>Remote Service Request Error</h1>
 
-<%= I18n.t('requests.error.service_error_conf_msg') %>
-<%= render 'service_errors' %>
+    <%= I18n.t('requests.error.service_error_conf_msg') %>
+    <%= render 'service_errors' %>
+  </td>
+</tr>


### PR DESCRIPTION
I will admit this is far from perfect, but I believe it is much more readable.
This is the new look:
![Screen Shot 2020-06-02 at 12 34 43 PM](https://user-images.githubusercontent.com/1599081/83545687-8b449500-a4cd-11ea-85d0-2ed3bf9f3e08.png)

This is the old look:
<img width="1127" alt="Screen Shot 2020-06-02 at 10 01 42 AM" src="https://user-images.githubusercontent.com/1599081/83545705-90a1df80-a4cd-11ea-9d39-aef23b7f2ae3.png">
