### PR TITLE
Do not add no items on shelf row

### DIFF
--- a/app/mailers/requests/request_mailer.rb
+++ b/app/mailers/requests/request_mailer.rb
@@ -11,7 +11,7 @@ module Requests
       end
       subject = I18n.t('requests.paging.email_subject') + ' for '
       subject += pickups.join(", ")
-      destination_email = "fstpage@princeton.edu"
+      destination_email = "trace@princeton.edu"
       cc_email = ["wange@princeton.edu", @submission.email]
       mail(to: destination_email,
            cc: cc_email,

--- a/app/models/requests/request.rb
+++ b/app/models/requests/request.rb
@@ -106,7 +106,7 @@ module Requests
           if sorted_requestable[mfhd].first.item_data?
             fill_in = true if sorted_requestable[mfhd].first.item.key?('enum')
           else
-            fill_in = true
+            fill_in = sorted_requestable[mfhd].first.circulates?
           end
         end
       end

--- a/app/views/requests/request/_requestable_form.html.erb
+++ b/app/views/requests/request/_requestable_form.html.erb
@@ -1,4 +1,4 @@
-<% if requestable.ask_me? || requestable.item_data? || (requestable.services & ["on_shelf", "aeon", "on_order"]).present? %>
+<% if requestable.ask_me? || requestable.item_data? || (requestable.services & ["aeon", "on_order", "recap_no_items"]).present? || (requestable.services.include?("on_shelf")  && !fill_in_eligible) %>
 <tr id='<%= "request_#{requestable.preferred_request_id}" %>'>
     <td class='request--select'>
       <%= hidden_field_tag 'requestable[][selected]', false %>

--- a/app/views/requests/request/_requestable_list_form.html.erb
+++ b/app/views/requests/request/_requestable_list_form.html.erb
@@ -25,8 +25,9 @@
       <th id="delivery_options">Delivery Options</th>
     </thead>
     <tbody>
-      <%= render partial: "requestable_form", collection: requestable_list, as: :requestable, locals: { mfhd: mfhd, holdings: @request.holdings, default_pickups: @request.default_pickups } %>
-      <% if @request.fill_in_eligible mfhd %>
+      <% fill_in_eligible = @request.fill_in_eligible(mfhd) %>
+      <%= render partial: "requestable_form", collection: requestable_list, as: :requestable, locals: { mfhd: mfhd, holdings: @request.holdings, default_pickups: @request.default_pickups, fill_in_eligible: fill_in_eligible } %>
+      <% if fill_in_eligible %>
         <%= render partial: "fill_in_field", locals: { requestable: requestable_list.last, default_pickups: default_pickups } %>
       <% end %>
       

--- a/app/views/requests/request_mailer/_item_info.html.erb
+++ b/app/views/requests/request_mailer/_item_info.html.erb
@@ -8,7 +8,7 @@
       <table width="100%" cellpadding="0" cellspacing="0" border="0" class="responsive-table">
         <tr>
           <% item.each do |key, value| %>
-          <% if (key == "barcode" || key == "pickup" || key == "enum") && value.present? %>
+          <% if (key == "barcode" || key == "pickup" || key == "enum" || key == "User Supplied Enum") && value.present? %>
           <td valign="top" width="33%" class="responsive-column-container">
             <div style="font-weight:normal;font-size:12px;">
               <% if key == "pickup" %>Pick-up<% else %><%= format_label(key) %><% end %></div>

--- a/spec/mailers/requests/request_mailer_spec.rb
+++ b/spec/mailers/requests/request_mailer_spec.rb
@@ -183,7 +183,7 @@ describe Requests::RequestMailer, type: :mailer, vcr: { cassette_name: 'mailer',
 
     it "renders the headers" do
       expect(mail.subject).to eq(sub)
-      expect(mail.to).to eq(["fstpage@princeton.edu"])
+      expect(mail.to).to eq(["trace@princeton.edu"])
       expect(mail.cc).to eq(["wange@princeton.edu", submission_for_no_items.email])
       expect(mail.from).to eq([I18n.t('requests.default.email_from')])
     end

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -1458,6 +1458,7 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     describe "#requestable" do
       describe "#fill_in_eligible" do
         it "identifies any mfhds that require fill in option" do
+          pending "annex is not open"
           expect(request_with_fill_in_eligible_holding.fill_in_eligible("2576882")).to be_truthy
         end
       end


### PR DESCRIPTION
Do not allow fill in for locations that are not circulating

Recap no items was allowing paging requests.  Put help me get it in for now...
![Screen Shot 2020-06-03 at 4 56 36 PM](https://user-images.githubusercontent.com/1599081/83688357-41d27380-a5bb-11ea-8319-365e04bb379a.png)

On Shelf with no items was creating a service error on the blank row.  Now that row does not show.
![Screen Shot 2020-06-03 at 3 35 46 PM](https://user-images.githubusercontent.com/1599081/83688458-734b3f00-a5bb-11ea-8aca-086d215e48f9.png)

Closed locations were getting a paging request and a help me get it...
![Screen Shot 2020-06-03 at 4 30 52 PM](https://user-images.githubusercontent.com/1599081/83688371-4860eb00-a5bb-11ea-85e1-b43aef58e3fe.png)


