### PR TITLE
Adding Scan It button

### DIFF
--- a/app/assets/stylesheets/requests/request.scss
+++ b/app/assets/stylesheets/requests/request.scss
@@ -116,3 +116,17 @@ div#other_user_account_info div.card-body {
     color: $dark;
   }
 }
+
+.control-label {
+  font-size: 1.2rem; 
+}
+
+.delivery-option {
+  font-size: 1.2rem;
+  margin-bottom: 0.8rem;
+}
+
+td.request--options .card {
+  margin-bottom: 1.6rem;
+  padding: 1rem;
+}

--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -57,7 +57,7 @@ module Requests
                     else
                       I18n.t("requests.paging.brief_msg")
                     end
-        concat content_tag(:li, brief_msg.html_safe, class: "service-item text-muted")
+        concat content_tag(:li, brief_msg.html_safe, class: "service-item")
       end
     end
 
@@ -446,7 +446,7 @@ module Requests
           # temporary changes issue 438
           brief_msg = I18n.t("requests.on_shelf.brief_msg", location: requestable.location[:library][:label])
           content_tag(:ul, class: "service-list") do
-            concat content_tag(:li, brief_msg, class: 'service-item text-muted')
+            concat content_tag(:li, brief_msg, class: 'service-item')
           end
           # concat link_to 'Where to find it', requestable.map_url(mfhd_id)
           # concat content_tag(:div, I18n.t("requests.trace.brief_msg").html_safe, class: 'service-item') if requestable.traceable?

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -162,6 +162,10 @@ module Requests
       services.include?('on_shelf')
     end
 
+    def on_shelf_edd?
+      services.include?('on_shelf_edd')
+    end
+
     def borrow_direct?
       services.include?('bd')
     end

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -78,7 +78,7 @@ module Requests
         elsif requestable.pageable?
           ['paging']
         else
-          ['on_shelf'] # goes to stack mapping
+          ['on_shelf', 'on_shelf_edd'] # goes to stack mapping
           # suppressing Trace service for the moment, but leaving this code
           # see https://github.com/pulibrary/requests/issues/164 for info
           # if (requestable.open? && auth_user?)

--- a/app/views/requests/request/_delivery_options.html.erb
+++ b/app/views/requests/request/_delivery_options.html.erb
@@ -1,30 +1,34 @@
-    <% if requestable.ill_eligible? %>
-      <span class="ill-data" data-ill-url="<%= requestable.illiad_request_url(@request.ctx) %>"></span>
-    <% end %>
-    <% if requestable.services.include?('recap_edd') %>
+    <% if requestable.ask_me? %>
+        <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(@request.ctx) %>'><%= I18n.t('requests.ask_me.request_label') %></a>
+    <% elsif requestable.on_shelf_edd? %>
+        <div class="delivery-option">Physical Item Delivery</div>
+        <%= show_service_options requestable, mfhd %>
+        <%= hidden_service_options requestable %>
+        <%= pickup_choices requestable, default_pickups %>
+        <div class="delivery-option" >Electronic Delivery</div>
+        <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(@request.ctx) %>'><%= I18n.t('requests.on_shelf_edd.request_label') %></a>
+    <% elsif requestable.services.include?('recap_edd') %>
         <%= hidden_field_tag "requestable[][type]", "recap" %>
         <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", 'print', false, data: { target: "#fields-print__#{requestable.item['id']}" }, 'aria-controls' => "fields-print__#{requestable.item['id']}", class: 'control-label' %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_print]", I18n.t("requests.recap.delivery_label"), class: 'control-label', id: "requestable__type_recap_label_#{requestable.item[:id]}" %>
         <br/><small id="requestable__type_recap_caption_<%#= requestable.item[:id] %>" class="form-text text-muted"><%#= I18n.t('requests.recap.brief_msg') %></small>
         <br/>
-    <% end %>
-    <% unless requestable.services.include?('recap_edd') %>
-        <%= show_service_options requestable, mfhd %>
-        <%= hidden_service_options requestable %>
-    <% end %>
-    <% unless ( requestable.aeon? || requestable.online? || requestable.ask_me? || ( requestable.scsb? && requestable.recallable? ) ) %>
-      <%= pickup_choices requestable, default_pickups %>
-    <% end %>
-    <% if requestable.ask_me? %>
-      <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(@request.ctx) %>'><%= I18n.t('requests.ask_me.request_label') %></a>
-    <% end %>
-    <% if requestable.services.include?('recap_edd') %>
+        <%= pickup_choices requestable, default_pickups %>
         <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", "edd", false, data: { target: "#fields-eed__#{requestable.item[:id]}" }, 'aria-controls' => "fields-eed__#{requestable.item[:id]}", class: 'control-label' %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_edd]", "Electronic Delivery", class: 'control-label', id: "requestable__type_recap_edd_#{requestable.item[:id]}" %>
-        <br/><small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text text-muted"><%= I18n.t('requests.recap_edd.brief_msg') %></small>
+        <br/><small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text"><%= I18n.t('requests.recap_edd.brief_msg') %></small>
         <%= render partial: "edd_fields", locals: { requestable: requestable } %>
-    <% end %>
-    <% if requestable.annexa? || requestable.annexb? || requestable.lewis? ||
-          requestable.plasma? || requestable.on_order? %>
-      <%= hidden_field_tag "requestable[][type]", requestable.services.first %>
+    <% else %>
+        <% if requestable.ill_eligible? %>
+          <span class="ill-data" data-ill-url="<%= requestable.illiad_request_url(@request.ctx) %>"></span>
+        <% end %>
+        <%= show_service_options requestable, mfhd %>
+        <%= hidden_service_options requestable %>
+        <% unless ( requestable.aeon? || requestable.online? || requestable.ask_me? || ( requestable.scsb? && requestable.recallable? ))  %>
+          <%= pickup_choices requestable, default_pickups %>
+        <% end %>
+        <% if requestable.annexa? || requestable.annexb? || requestable.lewis? ||
+              requestable.plasma? || requestable.on_order? %>
+          <%= hidden_field_tag "requestable[][type]", requestable.services.first %>
+        <% end %>
     <% end %>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -74,6 +74,8 @@ en:
       brief_msg: "Item in Preservation Office."
       email_conf_msg: "The following Preservation item has been requested:"
       patron_conf_msg: "You will be notified via email when your item is ready for pick-up from the Preservation Office."
+    on_shelf_edd:
+      request_label: "Scan This"
     on_shelf:
       # temporary changes issue 438
       # brief_msg: "Item on Shelf. Consult shelf location map."

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -270,6 +270,13 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           # expect(page).to have_link('Where to find it')
         end
 
+        it 'allows CAS patrons to locate an on_shelf record' do
+          visit "/requests/9770811"
+          expect(page).to have_content 'Pick-up location: Firestone Library'
+          expect(page).to have_content 'Pageable item at Firestone Library. Request for pick-up.'
+          expect(page).to have_content I18n.t("requests.on_shelf_edd.request_label")
+        end
+
         it 'displays an ark link for a plum item' do
           visit "/requests/#{iiif_manifest_item}"
           expect(page).to have_link('Digital content', href: "https://catalog.princeton.edu/catalog/#{iiif_manifest_item}#view")

--- a/spec/helpers/requests/application_helper_spec.rb
+++ b/spec/helpers/requests/application_helper_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
         assign(:request, request)
         # temporary change no maps everything is pageable
         # expect(helper.show_service_options(requestable, 'acb')).to eq "<div><a href=\"map_abc\">Where to find it</a></div>"
-        expect(helper.show_service_options(requestable, 'acb')).to eq "<div><ul class=\"service-list\"><li class=\"service-item text-muted\">Pageable item at abc. Request for pick-up.</li></ul></div>"
+        expect(helper.show_service_options(requestable, 'acb')).to eq "<div><ul class=\"service-list\"><li class=\"service-item\">Pageable item at abc. Request for pick-up.</li></ul></div>"
       end
     end
 
@@ -225,7 +225,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
         assign(:request, request)
         # temporary change no maps everything is pageable
         # expect(helper.show_service_options(requestable, 'acb')).to eq "<div><a href=\"map_abc\">Where to find it</a><div class=\"service-item\">Trace a Missing Item. Library staff will search for this item and contact you with an outcome.</div></div>"
-        expect(helper.show_service_options(requestable, 'acb')).to eq "<div><ul class=\"service-list\"><li class=\"service-item text-muted\">Pageable item at abc. Request for pick-up.</li></ul></div>"
+        expect(helper.show_service_options(requestable, 'acb')).to eq "<div><ul class=\"service-list\"><li class=\"service-item\">Pageable item at abc. Request for pick-up.</li></ul></div>"
       end
     end
 

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -12,7 +12,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
 
     describe '#services' do
       it 'has a service on on_shelf' do
-        expect(requestable.services.include?('on_shelf')).to be true
+        expect(requestable.services).to contain_exactly('on_shelf', 'on_shelf_edd')
       end
     end
 

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -209,7 +209,7 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :new
 
       context "on_shelf" do
         it "returns on_shelf in the services" do
-          expect(router.calculate_services).to eq(['on_shelf'])
+          expect(router.calculate_services).to eq(['on_shelf', 'on_shelf_edd'])
         end
       end
 


### PR DESCRIPTION
Rework delivery options so it is easier to read
Also removed muted text since the contrast is not enough

@axa and I tried to match up the option for Monday with the recap option we are head more towards:
![Screen Shot 2020-06-04 at 12 06 29 PM](https://user-images.githubusercontent.com/1599081/83797422-9dab0400-a670-11ea-92ab-b63b8410b4d8.png)
