### PR TITLE
Adding recap to the list of libraries that is open

### DIFF
--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -180,14 +180,16 @@ module Requests
     end
 
     def pickup_choices_fill_in(requestable, default_pickups)
-      locs = []
-      if requestable.pickup_locations.nil? || requestable.location['delivery_locations'].empty?
-        locs = available_pickups(requestable, default_pickups)
-      else
-        requestable.pickup_locations.each do |location|
-          locs << { label: location[:label], gfa_code: location[:gfa_pickup] }
-        end
-      end
+      locs = available_pickups(requestable, default_pickups)
+      # temporary only deliver to holding library or firestone
+      # locs = []
+      # if requestable.pickup_locations.nil? || requestable.location['delivery_locations'].empty?
+      #   locs = available_pickups(requestable, default_pickups)
+      # else
+      #   requestable.pickup_locations.each do |location|
+      #     locs << { label: location[:label], gfa_code: location[:gfa_pickup] }
+      #   end
+      # end
       if locs.size > 1
         select_tag "requestable[][pickup]", options_for_select(locs.map { |loc| [loc[:label], loc[:gfa_code]] }), prompt: I18n.t("requests.default.pickup_placeholder")
       else
@@ -393,9 +395,12 @@ module Requests
     # only show the table sort if there are enough items
     # to make it worthwhile
     def show_tablesorter(requestable_list)
-      table_class = ""
-      table_class += "tablesorter" if requestable_list.size > 5
-      table_class
+      return "tablesorter" if table_sorter_present?(requestable_list)
+      ""
+    end
+
+    def table_sorter_present?(requestable_list)
+      requestable_list.size > 5
     end
 
     def display_label

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -93,7 +93,7 @@ module Requests
     end
 
     def circulates?
-      location[:circulates] == true && ["firestone", "annexa"].include?(location[:library][:code])
+      location[:circulates] == true && ["firestone", "annexa", "recap"].include?(location[:library][:code])
     end
 
     def always_requestable?

--- a/app/views/requests/request/_fill_in_field.html.erb
+++ b/app/views/requests/request/_fill_in_field.html.erb
@@ -4,7 +4,7 @@
     <%= check_box_tag "requestable[][selected]", true, false, class: 'request--select' %>
     <%= hidden_fields_holding requestable %>
   </td>
-  <td class='request--options'>
+  <td class='request--options' <%= 'colspan="2"'.html_safe unless table_sorter_present?(requestable_list) %>>
     <fieldset class="form-group">
      <label class="control-label col-sm-6" for="user_supplied_enum">
           If the specific volume does not appear in the list above, please enter it here:
@@ -14,7 +14,9 @@
       </div>
     </fieldset>
   </td>
-  <td></td>
+  <% if table_sorter_present?(requestable_list) %>
+     <td></td>
+  <% end %>
   <td>
     <%= show_service_options_fill_in requestable %>
     <%= hidden_service_options_fill_in requestable %>

--- a/app/views/requests/request/_requestable_form.html.erb
+++ b/app/views/requests/request/_requestable_form.html.erb
@@ -1,4 +1,4 @@
-<% if requestable.ask_me? || requestable.item_data? || (requestable.services & ["aeon", "on_order", "recap_no_items"]).present? || (requestable.services.include?("on_shelf")  && !fill_in_eligible) %>
+<% if requestable.ask_me? || requestable.item_data? || (requestable.services & ["aeon", "on_order"]).present? || ((requestable.services & ["recap_no_items", "on_shelf"]).present?  && !fill_in_eligible) %>
 <tr id='<%= "request_#{requestable.preferred_request_id}" %>'>
     <td class='request--select'>
       <%= hidden_field_tag 'requestable[][selected]', false %>

--- a/app/views/requests/request/_requestable_list_form.html.erb
+++ b/app/views/requests/request/_requestable_list_form.html.erb
@@ -28,7 +28,7 @@
       <% fill_in_eligible = @request.fill_in_eligible(mfhd) %>
       <%= render partial: "requestable_form", collection: requestable_list, as: :requestable, locals: { mfhd: mfhd, holdings: @request.holdings, default_pickups: @request.default_pickups, fill_in_eligible: fill_in_eligible } %>
       <% if fill_in_eligible %>
-        <%= render partial: "fill_in_field", locals: { requestable: requestable_list.last, default_pickups: default_pickups } %>
+        <%= render partial: "fill_in_field", locals: { requestable: requestable_list.last, default_pickups: default_pickups, requestable_list: requestable_list } %>
       <% end %>
       
     </tbody>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -104,10 +104,11 @@ en:
       email_subject: "Paging Request"
       status: "Items requested (online, via email, or in person) anytime before 3:00pm (weekdays) will be available for you to pick up at Circulation no later than 5:00pm the same day (and often much sooner)."
       message: "If you have not picked up a requested book by the end of the same day, you will receive an email reminder that your book is available for you at Circulation."
-      brief_msg: "Paging Request, will be delivered to Firestone Circulation."
+      # brief_msg: "Paging Request, will be delivered to Firestone Circulation."
+      brief_msg: "Paging Request, will be delivered to:"
       success: "Request submitted. Please visit Firsestone Circulation at the next scheduled paging delivery time."
       # temporary changes issue 438
-      #email_conf_msg: "Items requested anytime before 3:00pm (weekdays) will be available for you to pick up at Circulation no later than 5:00pm the same day (and often much sooner)."
+      # email_conf_msg: "Items requested anytime before 3:00pm (weekdays) will be available for you to pick up at Circulation no later than 5:00pm the same day (and often much sooner)."
       email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email the day prior telling you the item will be available for pick-up in Firestone Lobby between the hours of 12-2."
     recap_guest:
       email_subject: "Patron Initiated Catalog Request - ReCAP Access Only Request"
@@ -128,7 +129,8 @@ en:
     recap_no_items:
       email: "recapproblems@princeton.edu"
       email_subject: "ReCAP Non-Barcoded Request."
-      brief_msg: "Please select the delivery location for this off-site ReCAP request."
+      # brief_msg: "Please select the delivery location for this off-site ReCAP request."
+      brief_msg: "ReCAP Paging Request, will be delivered to:"
       email_msg: "A request was made on a record that has no barcoded item data. This is likely a data issue that should be corrected."
       email_conf_msg: "The following record has been requested:"
     recall:

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -78,7 +78,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         # TODO: Remove when campus has re-opened
         it 'guest patrons can not request a physical recap item during the closure' do
-          pending "firestone only"
           visit '/requests/9944355'
           fill_in 'request_email', with: 'name@email.com'
           fill_in 'request_user_name', with: 'foobar'
@@ -87,8 +86,8 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           expect(page).to have_content 'Item is not requestable'
         end
 
-        # TODO: Activate test when campus has re-opened
-        xit 'allows guest patrons to request a physical recap item' do
+        it 'allows guest patrons to request a physical recap item' do
+          pending "Guest have no access during COVID-19 pandemic"
           visit '/requests/9944355'
           # click_link(I18n.t('requests.account.other_user_login_msg'))
           fill_in 'request_email', with: 'name@email.com'
@@ -103,7 +102,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         end
 
         it 'prohibits guest patrons from requesting In-Process items' do
-          pending "firestone only"
           visit "/requests/#{in_process_id}"
           # click_link(I18n.t('requests.account.other_user_login_msg'))
           fill_in 'request_email', with: 'name@email.com'
@@ -199,7 +197,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
       describe 'When visiting a voyager ID as a CAS User' do
         it 'allow CAS patrons to request an available ReCAP item.' do
-          pending "firestone only"
           stub_request(:post, Requests.config[:scsb_base])
             .with(headers: { 'Accept' => '*/*' })
             .to_return(status: 200, body: "<document count='1' sent='true'></document>", headers: {})
@@ -219,7 +216,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         end
 
         it 'allows CAS patrons to request In-Process items', js: true do
-          pending "firestone only"
           visit "/requests/#{in_process_id}"
           expect(page).to have_content 'In Process'
           expect(page).to have_button('Request this Item', disabled: false)
@@ -228,7 +224,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         end
 
         it 'makes sure In-Process items can only be delivered to their holding library', js: true do
-          pending "firestone only"
           visit "/requests/#{in_process_id}"
           expect(page).to have_content 'In Process'
           expect(page).to have_content 'Pick-up location: Marquand Library'
@@ -238,7 +233,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         end
 
         it 'makes sure In-Process ReCAP items with no holding library can be delivered anywhere', js: true do
-          pending "firestone only"
           visit "/requests/#{recap_in_process_id}"
           expect(page).to have_content 'In Process'
           # temporary changes issue 438
@@ -263,9 +257,9 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         it 'allows CAS patrons to locate an on_shelf record that has no item data' do
           visit "/requests/#{on_shelf_no_items_id}"
+          expect(page).to have_content "ReCAP Paging Request, will be delivered to:\nFirestone Library"
+          expect(page).to have_content "Paging Request, will be delivered to:\nFirestone Library"
           # temporary changes 438
-          expect(page).to have_content 'Help Me Get It' # while recap is closed
-          expect(page).to have_content 'Paging Request, will be delivered to Firestone Circulation.'
           # expect(page).to have_link('Where to find it')
         end
 
@@ -283,7 +277,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         let(:good_response) { fixture('/scsb_request_item_response.json') }
         it 'allows patrons to request a physical recap item' do
-          pending "firestone only"
           stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
             .to_return(status: 200, body: good_response, headers: {})
           visit '/requests/9944355'
@@ -408,7 +401,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
       let(:user) { FactoryGirl.create(:valid_barcode_patron) }
 
       it 'display a request form for a ReCAP item.' do
-        pending "firestone only"
         stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/#{user.uid}")
           .to_return(status: 200, body: valid_barcode_patron_response, headers: {})
         login_as user

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -1229,7 +1229,6 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:request) { described_class.new(params) }
     describe '#any_loanable_copies?' do
       it "has available copy" do
-        pending "firestone only"
         expect(request.any_loanable_copies?).to be true
       end
     end
@@ -1252,7 +1251,6 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:request) { described_class.new(params) }
     describe '#any_loanable_copies?' do
       it "has available copy" do
-        pending "firestone only"
         expect(request.any_loanable_copies?).to be true
       end
     end


### PR DESCRIPTION
There is still one failing test, but I am not sure what a recap no items one should really look like...
![Screen Shot 2020-06-04 at 3 09 01 PM](https://user-images.githubusercontent.com/1599081/83800950-4740c400-a676-11ea-8327-2e8ebbdd1b35.png)
