### PR TITLE
Reopening marquad

### DIFF
--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -96,8 +96,12 @@ module Requests
       location[:circulates] == true && open_libraries.include?(location[:library][:code])
     end
 
-    def open_libraries
-      ['firestone', 'annexa', 'recap', 'marquand', 'architecture', 'mendel', 'stokes', 'eastasian']
+    def available_for_digitizing?
+      open_libraries.include?(location[:library][:code])
+    end
+
+    def can_be_delivered?
+      circulates? && !scsb_in_library_use?
     end
 
     def always_requestable?
@@ -252,6 +256,10 @@ module Requests
     end
 
     private
+
+      def open_libraries
+        ['firestone', 'annexa', 'recap', 'marquand', 'architecture', 'mendel', 'stokes', 'eastasian']
+      end
 
       def scsb_locations
         ['scsbnypl', 'scsbcul']

--- a/app/views/requests/request/_delivery_options.html.erb
+++ b/app/views/requests/request/_delivery_options.html.erb
@@ -1,15 +1,11 @@
     <% if requestable.ask_me? %>
-        <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(@request.ctx) %>'><%= I18n.t('requests.ask_me.request_label') %></a>
+        <%= render partial: 'help_me_get_it', locals: { requestable: requestable, request_context: request_context } %>
     <% elsif requestable.on_shelf_edd? %>
         <div class="delivery-option">Physical Item Delivery</div>
         <%= show_service_options requestable, mfhd %>
         <%= hidden_service_options requestable %>
         <%= pickup_choices requestable, default_pickups %>
-        <div class="delivery-option" >Electronic Delivery</div>
-        <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(@request.ctx) %>'><%= I18n.t('requests.on_shelf_edd.request_label') %></a>
-        <% if requestable.annexa? || requestable.annexb? || requestable.lewis? || requestable.plasma? || requestable.on_order? %>
-          <%= hidden_field_tag "requestable[][type]", requestable.services.first %>
-        <% end %>
+        <%= render partial: 'digitization', locals: { requestable: requestable, request_context: request_context } %>
     <% elsif requestable.services.include?('recap_edd') %>
         <%= hidden_field_tag "requestable[][type]", "recap" %>
         <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", 'print', false, data: { target: "#fields-print__#{requestable.item['id']}" }, 'aria-controls' => "fields-print__#{requestable.item['id']}", class: 'control-label' %>
@@ -23,7 +19,7 @@
         <%= render partial: "edd_fields", locals: { requestable: requestable } %>
     <% else %>
         <% if requestable.ill_eligible? %>
-          <span class="ill-data" data-ill-url="<%= requestable.illiad_request_url(@request.ctx) %>"></span>
+          <span class="ill-data" data-ill-url="<%= requestable.illiad_request_url(request_context) %>"></span>
         <% end %>
         <%= show_service_options requestable, mfhd %>
         <%= hidden_service_options requestable %>

--- a/app/views/requests/request/_digitization.html.erb
+++ b/app/views/requests/request/_digitization.html.erb
@@ -1,0 +1,5 @@
+        <div class="delivery-option" >Electronic Delivery</div>
+        <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(request_context, note: 'Digitization Request') %>'><%= I18n.t('requests.on_shelf_edd.request_label') %></a>
+        <% if requestable.annexa? || requestable.annexb? || requestable.lewis? || requestable.plasma? || requestable.on_order? %>
+          <%= hidden_field_tag "requestable[][type]", requestable.services.first %>
+        <% end %>

--- a/app/views/requests/request/_help_me_get_it.html.erb
+++ b/app/views/requests/request/_help_me_get_it.html.erb
@@ -1,1 +1,1 @@
-<a class='btn btn-primary btn-lg' href='<%= @request.requestable.first.illiad_request_url(@request.ctx) %>'>Help Me Get It</a>
+<a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(request_context) %>'>Help Me Get It</a>

--- a/app/views/requests/request/_requestable_form.html.erb
+++ b/app/views/requests/request/_requestable_form.html.erb
@@ -27,10 +27,12 @@
       <% end %>
     </td>
   <td class='request--options' aria-live="polite">
-    <% if requestable.circulates? && !requestable.scsb_in_library_use? %>
-      <%= render partial: 'delivery_options', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups } %>  
+    <% if requestable.can_be_delivered? %>
+      <%= render partial: 'delivery_options', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups, request_context: @request.ctx } %>  
+    <% elsif requestable.available_for_digitizing? %>
+      <%= render partial: 'digitization', locals: { requestable: requestable, request_context: @request.ctx } %>
     <% else %>
-      <%= render partial: 'help_me_get_it' %>  
+      <%= render partial: 'help_me_get_it', locals: { requestable: requestable, request_context: @request.ctx } %>  
     <% end %>
   </td>
 </tr>

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -293,6 +293,8 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     describe '#site' do
       it 'returns a Marquand site param' do
         expect(requestable.site).to eq('MARQ')
+        expect(requestable.available_for_digitizing?).to be_truthy
+        expect(requestable.can_be_delivered?).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Add a digitization partial that can be reused for digitization requests (marquad or on_shelf)
Make help me get it use the specific requestable item
refs #645

![Screen Shot 2020-06-05 at 10 54 14 AM](https://user-images.githubusercontent.com/1599081/83893787-65fa9580-a71e-11ea-920f-a7c57b2a11c5.png)


There are still issues with marquad items at recap.  Currently they can be requested to be picked up.  I will be working on that next...