### PR TITLE
Updating recap marquand items to be in_library_use_only

### DIFF
--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -101,7 +101,7 @@ module Requests
     end
 
     def can_be_delivered?
-      circulates? && !scsb_in_library_use?
+      circulates? && !scsb_in_library_use? && !in_library_use_only?
     end
 
     def always_requestable?
@@ -240,6 +240,11 @@ module Requests
     def scsb_in_library_use?
       return false unless item?
       scsb? && item[:use_statement] == "In Library Use"
+    end
+
+    def in_library_use_only?
+      return false unless location["holding_library"]
+      ["marquand"].include? location["holding_library"]["code"]
     end
 
     def barcode?

--- a/app/models/requests/selected_items_validator.rb
+++ b/app/models/requests/selected_items_validator.rb
@@ -19,7 +19,6 @@ module Requests
       # rubocop:disable Metrics/MethodLength
       def validate_selected(record, selected)
         return unless selected['selected'] == 'true'
-
         case selected["type"]
         when 'bd'
           validate_recall_or_bd(record, selected, pickup_phrase: 'delivery of your borrow direct item', action_phrase: 'requested via Borrow Direct')

--- a/app/views/requests/request/_delivery_options.html.erb
+++ b/app/views/requests/request/_delivery_options.html.erb
@@ -16,7 +16,7 @@
         <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", "edd", false, data: { target: "#fields-eed__#{requestable.item[:id]}" }, 'aria-controls' => "fields-eed__#{requestable.item[:id]}", class: 'control-label' %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_edd]", "Electronic Delivery", class: 'control-label', id: "requestable__type_recap_edd_#{requestable.item[:id]}" %>
         <br/><small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text"><%= I18n.t('requests.recap_edd.brief_msg') %></small>
-        <%= render partial: "edd_fields", locals: { requestable: requestable } %>
+        <%= render partial: "edd_fields", locals: { requestable: requestable, collapse_field: "" } %>
     <% else %>
         <% if requestable.ill_eligible? %>
           <span class="ill-data" data-ill-url="<%= requestable.illiad_request_url(request_context) %>"></span>

--- a/app/views/requests/request/_digitization.html.erb
+++ b/app/views/requests/request/_digitization.html.erb
@@ -1,5 +1,15 @@
-        <div class="delivery-option" >Electronic Delivery</div>
-        <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(request_context, note: 'Digitization Request') %>'><%= I18n.t('requests.on_shelf_edd.request_label') %></a>
-        <% if requestable.annexa? || requestable.annexb? || requestable.lewis? || requestable.plasma? || requestable.on_order? %>
-          <%= hidden_field_tag "requestable[][type]", requestable.services.first %>
-        <% end %>
+    <% if requestable.services.include?('recap_edd') %>
+        <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", "edd", true, data: { target: "#fields-eed__#{requestable.item[:id]}" }, 'aria-controls' => "fields-eed__#{requestable.item[:id]}", class: 'control-label' %>
+        <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_edd]", "Electronic Delivery", class: 'control-label', id: "requestable__type_recap_edd_#{requestable.item[:id]}" %>
+        <br/><small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text"><%= I18n.t('requests.recap_edd.brief_msg') %></small>
+        <%= render partial: "edd_fields", locals: { requestable: requestable, collapse_field: "" } %>
+        <%= hidden_field_tag "requestable[][type]", "recap" %>
+    <% else %>
+        <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_edd]", "Electronic Delivery", class: 'control-label', id: "requestable__type_recap_edd_#{requestable.item[:id]}" %>
+        <div>
+          <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(request_context, note: 'Digitization Request') %>'><%= I18n.t('requests.on_shelf_edd.request_label') %></a>
+        </div>
+    <% end %>
+    <% if requestable.annexa? || requestable.annexb? || requestable.lewis? || requestable.plasma? || requestable.on_order? %>
+        <%= hidden_field_tag "requestable[][type]", requestable.services.first %>
+    <% end %>

--- a/app/views/requests/request/_edd_fields.html.erb
+++ b/app/views/requests/request/_edd_fields.html.erb
@@ -1,4 +1,4 @@
-<div aria-live='polite' class='card card-body bg-light collapse' id='fields-eed__<%= "#{requestable.item['id']}" %>'>
+<div aria-live='polite' class='card card-body bg-light <%= collapse_field %>' id='fields-eed__<%= "#{requestable.item['id']}" %>'>
   <fieldset class="form-group required">
     <%= label_tag "requestable__edd_art_title", 'Article/Chapter Title *', class: 'control-label col-sm-4' %>
     <div class="col-sm-6">

--- a/app/views/requests/request/_requestable_form.html.erb
+++ b/app/views/requests/request/_requestable_form.html.erb
@@ -27,7 +27,7 @@
       <% end %>
     </td>
   <td class='request--options' aria-live="polite">
-    <% if requestable.can_be_delivered? %>
+    <% if requestable.can_be_delivered? || requestable.in_process? %>
       <%= render partial: 'delivery_options', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups, request_context: @request.ctx } %>  
     <% elsif requestable.available_for_digitizing? %>
       <%= render partial: 'digitization', locals: { requestable: requestable, request_context: @request.ctx } %>

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -299,6 +299,16 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     end
   end
 
+  context 'A Recap Marquand holding' do
+    let(:requestable) { Requests::Requestable.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'blah' } }], location: { "holding_library" => { "code" => "marquand" } }) }
+
+    describe '#site' do
+      it 'returns a Marquand site param' do
+        expect(requestable.in_library_use_only?).to be_truthy
+      end
+    end
+  end
+
   context 'A requestable item from a RBSC holding that has a long title' do
     let(:user) { FactoryGirl.build(:user) }
     let(:request) { FactoryGirl.build(:aeon_w_long_title) }


### PR DESCRIPTION
Added in_library_use_only? check to the can_be_delivered?
Added recap section to the digitization only partial
fixes #645

Normal Marquand Record:
![Screen Shot 2020-06-05 at 2 20 54 PM](https://user-images.githubusercontent.com/1599081/83910083-f396af00-a737-11ea-830e-d66a10c9ecbc.png)

Regular item to that can be delivered or digitized:
![Screen Shot 2020-06-05 at 2 19 51 PM](https://user-images.githubusercontent.com/1599081/83910145-090bd900-a738-11ea-895d-1f876377fc23.png)

Recap Marquad item:
![Screen Shot 2020-06-05 at 2 23 01 PM](https://user-images.githubusercontent.com/1599081/83910205-2345b700-a738-11ea-826f-60b6e47b595d.png)

