### PR TITLE
Adding confirmation email for annex a

### DIFF
--- a/app/controllers/requests/request_controller.rb
+++ b/app/controllers/requests/request_controller.rb
@@ -170,7 +170,7 @@ module Requests
         return if submission.service_types.include? 'bd' # emails already sent
         submission.service_email_types.each do |type|
           Requests::RequestMailer.send("#{type}_email", submission).deliver_now unless type == 'recap_edd'
-          Requests::RequestMailer.send("#{type}_confirmation", submission).deliver_now if ['on_shelf', 'on_order', 'in_process', 'pres', 'recap_no_items', 'lewis', 'ppl', 'paging', 'recap', 'recap_edd'].include? type
+          Requests::RequestMailer.send("#{type}_confirmation", submission).deliver_now if ['on_shelf', 'on_order', 'in_process', 'pres', 'recap_no_items', 'lewis', 'ppl', 'paging', 'recap', 'recap_edd', 'annexa'].include? type
           Requests::RequestMailer.send("scsb_recall_email", submission).deliver_now if type == 'recall' && submission.scsb?
         end
       end

--- a/app/mailers/requests/request_mailer.rb
+++ b/app/mailers/requests/request_mailer.rb
@@ -41,9 +41,15 @@ module Requests
     def annexa_email(submission)
       @submission = submission
       destination_email = annexa_email_destinations(submission: @submission)
-      cc_email = [@submission.email]
       mail(to: destination_email,
-           cc: cc_email,
+           from: I18n.t('requests.default.email_from'),
+           subject: subject_line(I18n.t('requests.annexa.email_subject'), @submission.user_barcode))
+    end
+
+    def annexa_confirmation(submission)
+      @submission = submission
+      destination_email = @submission.email
+      mail(to: destination_email,
            from: I18n.t('requests.default.email_from'),
            subject: subject_line(I18n.t('requests.annexa.email_subject'), @submission.user_barcode))
     end

--- a/app/views/requests/request_mailer/_covid_pickup_guidelines.text.erb
+++ b/app/views/requests/request_mailer/_covid_pickup_guidelines.text.erb
@@ -1,0 +1,6 @@
+* Please pick-up promptly
+* Remain only in the designated pick-up area
+* Wear a mask or face covering
+* Follow social distancing guidelines
+Please plan to limit your number of trips to the Library. We appreciate your help in our efforts to slow the spread of Covid-19.
+Sincere thanks.

--- a/app/views/requests/request_mailer/annexa_confirmation.html.erb
+++ b/app/views/requests/request_mailer/annexa_confirmation.html.erb
@@ -1,0 +1,29 @@
+<tr class="email-header">
+  <td colspan="2" style="padding: 18px;border-top: 6px solid #e77500;">
+    <%= render 'request_header_patron' %>
+  </td>
+</tr>
+
+<tr>
+  <td colspan="2" style="padding: 18px;">
+    <p class="body-content" style="margin-bottom:0;"><%= I18n.t('requests.annexa.email_conf_msg') %></p>
+  </td>
+</tr>
+
+<tr class="pikcup-info">
+  <td colspan="2" style="padding: 18px;">
+    <%= render 'covid_pickup_guidelines' %>
+  </td>
+</tr>
+
+<tr class="bib-info">
+  <td colspan="2" style="padding: 18px;border-top:1px solid #ccc;">
+    <%= render 'bib_info_patron' %>
+  </td>
+</tr>
+
+<tr>
+  <td colspan="2" style="padding: 18px;border-top:1px solid #ccc;">
+    <%= render 'item_info' %>
+  </td>
+</tr>

--- a/app/views/requests/request_mailer/annexa_confirmation.text.erb
+++ b/app/views/requests/request_mailer/annexa_confirmation.text.erb
@@ -1,10 +1,9 @@
 ==============================================
-Paging Request
+Forrestal Annex Request
 
-<%= I18n.t('requests.paging.email_conf_msg') %>
+<%= I18n.t('requests.annexa.email_conf_msg') %>
 
 <%= render 'patron_info' %>
 <%= render 'covid_pickup_guidelines' %>
 <%= render 'bib_info' %>
 <%= render 'item_info' %>
-

--- a/app/views/requests/request_mailer/on_order_confirmation.text.erb
+++ b/app/views/requests/request_mailer/on_order_confirmation.text.erb
@@ -4,5 +4,6 @@ On Order Request
 <%= I18n.t('requests.on_order.patron_conf_msg') %>
 
 <%= render 'patron_info' %>
+<%= render 'covid_pickup_guidelines' %>
 <%= render 'bib_info' %>
 <%= render 'item_info' %>

--- a/app/views/requests/request_mailer/on_shelf_confirmation.text.erb
+++ b/app/views/requests/request_mailer/on_shelf_confirmation.text.erb
@@ -5,5 +5,6 @@
 <%= I18n.t('requests.on_shelf.email_conf_msg') %>
 
 <%= render 'patron_info' %>
+<%= render 'covid_pickup_guidelines' %>
 <%= render 'bib_info' %>
 <%= render 'item_info' %>

--- a/app/views/requests/request_mailer/recap_confirmation.text.erb
+++ b/app/views/requests/request_mailer/recap_confirmation.text.erb
@@ -9,5 +9,6 @@
 <% end %>
 
 <%= render 'patron_info' %>
+<%= render 'covid_pickup_guidelines' %>
 <%= render 'bib_info' %>
 <%= render 'item_info' %>

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -311,10 +311,20 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           visit '/requests/945550'
           expect(page).to have_content 'Item offsite at Forrestal Annex. Request for pick-up'
           expect(page).to have_content 'Digitization Request'
-          # temporary change issue 438
           select('Firestone Library', from: 'requestable__pickup')
-          click_button 'Request Selected Items'
+          expect { click_button 'Request Selected Items' }.to change { ActionMailer::Base.deliveries.count }.by(2)
           expect(page).to have_content 'Request submitted'
+          email = ActionMailer::Base.deliveries[ActionMailer::Base.deliveries.count - 2]
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(email.subject).to eq("Annex Request")
+          expect(email.to).to eq(["forranx@princeton.edu"])
+          expect(email.cc).to be_blank
+          expect(email.html_part.body.to_s).to have_content("A tale of cats and mice of Obeyd of Záákán")
+          expect(confirm_email.subject).to eq("Annex Request")
+          expect(confirm_email.to).to eq(["a@b.com"])
+          expect(confirm_email.cc).to be_blank
+          expect(confirm_email.html_part.body.to_s).to have_content("A tale of cats and mice of Obeyd of Záákán")
+          expect(confirm_email.html_part.body.to_s).to have_content("Wear a mask or face covering")
         end
 
         it 'allows patrons to request a Lewis' do

--- a/spec/mailers/requests/request_mailer_spec.rb
+++ b/spec/mailers/requests/request_mailer_spec.rb
@@ -235,15 +235,27 @@ describe Requests::RequestMailer, type: :mailer, vcr: { cassette_name: 'mailer',
       Requests::RequestMailer.send("annexa_email", submission_for_annexa).deliver_now
     end
 
-    it "renders the headers" do
-      expect(mail.subject).to eq(I18n.t('requests.annexa.email_subject'))
-      expect(mail.to).to eq([I18n.t('requests.annexa.email')])
-      expect(mail.cc).to eq([submission_for_annexa.email])
-      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+    let(:confirmation_mail) do
+      Requests::RequestMailer.send("annexa_confirmation", submission_for_annexa).deliver_now
     end
 
-    it "renders the body" do
+    it "renders email to library staffs" do
+      expect(mail.subject).to eq(I18n.t('requests.annexa.email_subject'))
+      expect(mail.to).to eq([I18n.t('requests.annexa.email')])
+      expect(mail.cc).to be_nil
+      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
       expect(mail.body.encoded).to have_content I18n.t('requests.annexa.email_conf_msg')
+    end
+
+    it "renders email confirmation" do
+      expect(confirmation_mail.subject).to eq(I18n.t('requests.annexa.email_subject'))
+      expect(confirmation_mail.to).to eq([submission_for_annexa.email])
+      expect(confirmation_mail.cc).to be_nil
+      expect(confirmation_mail.from).to eq([I18n.t('requests.default.email_from')])
+      expect(confirmation_mail.html_part.body.to_s).to have_content I18n.t('requests.annexa.email_conf_msg')
+      expect(confirmation_mail.html_part.body.to_s).to have_content('Wear a mask or face covering')
+      expect(confirmation_mail.text_part.body.to_s).to have_content I18n.t('requests.annexa.email_conf_msg')
+      expect(confirmation_mail.text_part.body.to_s).to have_content('Wear a mask or face covering')
     end
   end
 
@@ -288,15 +300,28 @@ describe Requests::RequestMailer, type: :mailer, vcr: { cassette_name: 'mailer',
       Requests::RequestMailer.send("annexa_email", submission_for_anxadoc).deliver_now
     end
 
-    it "renders the headers" do
-      expect(mail.subject).to eq(I18n.t('requests.annexa.email_subject'))
-      expect(mail.to).to eq([I18n.t('requests.anxadoc.email')])
-      expect(mail.cc).to eq([submission_for_anxadoc.email])
-      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+    let(:confirmation_mail) do
+      Requests::RequestMailer.send("annexa_confirmation", submission_for_anxadoc).deliver_now
     end
 
-    it "renders the body" do
-      expect(mail.body.encoded).to have_content I18n.t('requests.annexa.email_conf_msg')
+    it "renders and email to the librarians" do
+      expect(mail.subject).to eq(I18n.t('requests.annexa.email_subject'))
+      expect(mail.to).to eq([I18n.t('requests.anxadoc.email')])
+      expect(mail.cc).to be_nil
+      expect(mail.from).to eq([I18n.t('requests.default.email_from')])
+      expect(confirmation_mail.html_part.body.to_s).to have_content I18n.t('requests.annexa.email_conf_msg')
+      expect(confirmation_mail.text_part.body.to_s).to have_content I18n.t('requests.annexa.email_conf_msg')
+    end
+
+    it "renders a confirmation" do
+      expect(confirmation_mail.subject).to eq(I18n.t('requests.annexa.email_subject'))
+      expect(confirmation_mail.to).to eq([submission_for_anxadoc.email])
+      expect(confirmation_mail.cc).to be_nil
+      expect(confirmation_mail.from).to eq([I18n.t('requests.default.email_from')])
+      expect(confirmation_mail.html_part.body.to_s).to have_content I18n.t('requests.annexa.email_conf_msg')
+      expect(confirmation_mail.html_part.body.to_s).to have_content('Wear a mask or face covering')
+      expect(confirmation_mail.text_part.body.to_s).to have_content I18n.t('requests.annexa.email_conf_msg')
+      expect(confirmation_mail.text_part.body.to_s).to have_content('Wear a mask or face covering')
     end
   end
 
@@ -685,6 +710,7 @@ describe Requests::RequestMailer, type: :mailer, vcr: { cassette_name: 'mailer',
       expect(confirmation_mail.html_part.body.to_s).to have_content I18n.t('requests.recap.email_conf_msg')
       expect(confirmation_mail.html_part.body.to_s).to have_content('Wear a mask or face covering')
       expect(confirmation_mail.text_part.body.to_s).to have_content I18n.t('requests.recap.email_conf_msg')
+      expect(confirmation_mail.text_part.body.to_s).to have_content('Wear a mask or face covering')
     end
   end
 
@@ -751,6 +777,7 @@ describe Requests::RequestMailer, type: :mailer, vcr: { cassette_name: 'mailer',
       expect(mail.html_part.body.to_s).to have_content I18n.t('requests.recap_edd.email_conf_msg')
       expect(mail.html_part.body.to_s).not_to have_content('Wear a mask or face covering')
       expect(mail.text_part.body.to_s).to have_content I18n.t('requests.recap_edd.email_conf_msg')
+      expect(mail.text_part.body.to_s).not_to have_content('Wear a mask or face covering')
     end
   end
 
@@ -827,6 +854,7 @@ describe Requests::RequestMailer, type: :mailer, vcr: { cassette_name: 'mailer',
       expect(confirmation_mail.html_part.body.to_s).to have_content I18n.t('requests.recap_guest.email_conf_msg')
       expect(confirmation_mail.html_part.body.to_s).to have_content('Wear a mask or face covering')
       expect(confirmation_mail.text_part.body.to_s).to have_content I18n.t('requests.recap_guest.email_conf_msg')
+      expect(confirmation_mail.text_part.body.to_s).to have_content('Wear a mask or face covering')
     end
   end
 


### PR DESCRIPTION
Add Covid infomration into text confirmation emails

fixes #657