### PR TITLE
Make request table content vieweable on mobile

### DIFF
--- a/app/assets/javascripts/requests/requests.js
+++ b/app/assets/javascripts/requests/requests.js
@@ -186,9 +186,12 @@ $(document).ready(function() {
         language: {
           search: "Search by Enumeration"
         },
-        responsive: true,
         ordering: false
       });
+    });
+
+    $('.table input[type=checkbox]').on('change', function() {
+      $(this).closest('tr').toggleClass('selected', $(this).is(':checked'));
     });
   
 

--- a/app/assets/stylesheets/requests/request.scss
+++ b/app/assets/stylesheets/requests/request.scss
@@ -45,8 +45,8 @@
 }
 
 #returnToRecordLink {
-  margin-top: 20px;
   margin-bottom: 20px;
+  margin-top: 0;
 }
 
 .btn-sub-text {
@@ -129,4 +129,140 @@ div#other_user_account_info div.card-body {
 td.request--options .card {
   margin-bottom: 1.6rem;
   padding: 1rem;
+}
+
+.selected {
+  background-color: rgba(149, 189, 228, 0.1) !important;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
+input[type="radio"] + label {
+  cursor: pointer;
+}
+
+.form-text.brief-msg {
+  margin-bottom: 1rem;
+}
+
+.card {
+  margin-bottom: 1rem;
+}
+
+.card-body {
+  padding: 1rem;
+}
+
+@media screen and (max-width: 650px) {
+  .visually-hidden-sm { 
+    position: absolute !important;
+    height: 1px; 
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip: rect(1px, 1px, 1px, 1px);
+    white-space: nowrap; /* added line */
+  }
+ 
+  .blacklight-request tbody td {
+    display: block;
+    border: 0;
+
+    &:empty {
+      padding: 0;
+    }
+
+    &.request--select {
+      padding: 22px;
+    }
+
+    &.request--select,
+    &.request--options {
+      display: inline-block;
+      font-size: 1rem;
+      line-height: 1.5;
+    }
+
+    &.request--options {
+      width: calc(100% - 90px);
+      font-size: 18px;
+    }
+
+    &.request--availability {
+      display: flex;
+      flex: 1 auto;
+      padding: 0 0.75rem;
+  
+      .system-status {
+        order: 2;
+        margin-left: 1rem;
+      }
+    }
+  }
+
+  .btn {
+    display: block;
+    width: 100%;
+    min-height: 48px;
+    font-size: 1rem;
+    margin-top: 1rem;
+
+    span {
+      vertical-align: middle;
+    }
+  }
+
+  input[type="checkbox"] {
+    transform: scale(2.5);
+  } 
+
+  input[type="radio"] {
+    transform: scale(1.75);
+    margin: 1rem;
+    vertical-align: middle;
+  }
+
+  input[type="text"] {
+    height: 44px;
+    width: 100%;
+  }
+
+  .single-pickup {
+    margin: 0;
+  }
+
+  .control-label.col-sm-6 {
+    padding: 0;
+    max-width: 100%;
+  }
+
+  .blacklight-request div.dataTables_wrapper .row:first-child .col-sm-12:last-child {
+    padding-left: 15px;
+  }
+
+  .blacklight-request div.dataTables_wrapper div.dataTables_filter label {
+    display: block;
+  }
+
+  .blacklight-request div.dataTables_wrapper div.dataTables_filter input {
+    display: block;
+    min-height: 44px;
+  }
+
+  .blacklight-request div.dataTables_wrapper div.dataTables_paginate ul.pagination {
+    justify-content: center;
+  }
+
+  .blacklight-request .table-responsive-sm {
+    overflow-x: unset;
+  }
 }

--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -437,7 +437,7 @@ module Requests
     end
 
     def system_status_label(requestable)
-      content_tag(:div, requestable.item[:status]) unless requestable.item.key? :scsb_status
+      content_tag(:div, requestable.item[:status], class: 'system-status') unless requestable.item.key? :scsb_status
     end
 
     def display_urls(requestable)

--- a/app/views/requests/request/_delivery_options.html.erb
+++ b/app/views/requests/request/_delivery_options.html.erb
@@ -11,11 +11,9 @@
         <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", 'print', false, data: { target: "#fields-print__#{requestable.item['id']}" }, 'aria-controls' => "fields-print__#{requestable.item['id']}", class: 'control-label' %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_print]", I18n.t("requests.recap.delivery_label"), class: 'control-label', id: "requestable__type_recap_label_#{requestable.item[:id]}" %>
         <br/><small id="requestable__type_recap_caption_<%#= requestable.item[:id] %>" class="form-text text-muted"><%#= I18n.t('requests.recap.brief_msg') %></small>
-        <br/>
         <%= pickup_choices requestable, default_pickups %>
         <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", "edd", false, data: { target: "#fields-eed__#{requestable.item[:id]}" }, 'aria-controls' => "fields-eed__#{requestable.item[:id]}", class: 'control-label' %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_edd]", "Electronic Delivery", class: 'control-label', id: "requestable__type_recap_edd_#{requestable.item[:id]}" %>
-        <br/><small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text"><%= I18n.t('requests.recap_edd.brief_msg') %></small>
         <%= render partial: "edd_fields", locals: { requestable: requestable, collapse_field: "collapse" } %>
     <% else %>
         <% if requestable.ill_eligible? %>

--- a/app/views/requests/request/_digitization.html.erb
+++ b/app/views/requests/request/_digitization.html.erb
@@ -1,12 +1,11 @@
     <% if requestable.services.include?('recap_edd') %>
         <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", "edd", true, data: { target: "#fields-eed__#{requestable.item[:id]}" }, 'aria-controls' => "fields-eed__#{requestable.item[:id]}", class: 'control-label' %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_edd]", "Electronic Delivery", class: 'control-label', id: "requestable__type_recap_edd_#{requestable.item[:id]}" %>
-        <br/><small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text"><%= I18n.t('requests.recap_edd.brief_msg') %></small>
         <%= render partial: "edd_fields", locals: { requestable: requestable, collapse_field: "" } %>
         <%= hidden_field_tag "requestable[][type]", "recap" %>
     <% else %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_edd]", "Electronic Delivery", class: 'control-label', id: "requestable__type_recap_edd_#{requestable.item[:id]}" %>
-        <br/><small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text"><%= I18n.t('requests.on_shelf_edd.brief_msg') %></small>
+        <small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text brief-msg"><%= I18n.t('requests.on_shelf_edd.brief_msg') %></small>
         <div>
           <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(request_context, note: 'Digitization Request') %>'><%= I18n.t('requests.on_shelf_edd.request_label') %></a>
         </div>

--- a/app/views/requests/request/_edd_fields.html.erb
+++ b/app/views/requests/request/_edd_fields.html.erb
@@ -1,45 +1,48 @@
-<div aria-live='polite' class='card card-body bg-light <%= collapse_field %>' id='fields-eed__<%= "#{requestable.item['id']}" %>'>
-  <fieldset class="form-group required">
-    <%= label_tag "requestable__edd_art_title", 'Article/Chapter Title *', class: 'control-label col-sm-4' %>
-    <div class="col-sm-6">
-      <%= text_field_tag 'requestable[][edd_art_title]', "", value: "", placeholder: "", maxlength: 60, size: 30 %>
-    </div>
-  </fieldset>
-  <fieldset class="form-group">
-    <%= label_tag "requestable__edd_start_page", 'Start Page', class: 'control-label col-sm-4' %>
-    <div class="col-sm-6">
-      <%= text_field_tag 'requestable[][edd_start_page]', "", value: "", placeholder: "1, xi, toc", maxlength: 20, size: 20 %>
-    </div>
-  </fieldset>
-  <fieldset class="form-group">
-    <%= label_tag "requestable__edd_end_page", 'End Page', class: 'control-label col-sm-4' %>
-    <div class="col-sm-6">
-      <%= text_field_tag 'requestable[][edd_end_page]', "", value: "", placeholder: "20, xi", maxlength: 20, size: 20 %>
-    </div>
-  </fieldset>
-  <fieldset class="form-group">
-    <%= label_tag "requestable__edd_volume_number", 'Volume Number', class: 'control-label col-sm-4' %>
-    <div class="col-sm-6">
-      <%= text_field_tag 'requestable[][edd_volume_number]', "", value: requestable.item['enum'], placeholder: "Vol. 50", maxlength: 20, size: 20 %>
-    </div>
-  </fieldset>
-  <fieldset class="form-group">
-    <%= label_tag "requestable__edd_issue", 'Issue', class: 'control-label col-sm-4' %>
-    <div class="col-sm-6">
-      <%= text_field_tag 'requestable[][edd_issue]', "", value: requestable.item['chron'], placeholder: "3", maxlength: 20, size: 20 %>
-    </div>
-  </fieldset>
-  <fieldset class="form-group">
-    <%= label_tag "requestable__edd_author", 'Author', class: 'control-label col-sm-4' %>
-    <div class="col-sm-6">
-      <%= text_field_tag 'requestable[][edd_author]', "", value: "", placeholder: "", maxlength: 60, size: 30 %>
-    </div>
-  </fieldset>
-  <fieldset class="form-group">
-    <%= label_tag "requestable__edd_note", 'Note', class: 'control-label col-sm-4' %>
-    <div class="col-sm-6">
-      <%= text_field_tag 'requestable[][edd_note]', "", value: "", placeholder: "", maxlength: 60, size: 30 %>
-    </div>
-  </fieldset>
-  <small>* indicates a required field for Electronic Delivery requests.</small>
+<div aria-live='polite' class='<%= collapse_field %>' id='fields-eed__<%= "#{requestable.item['id']}" %>'>
+  <small id="requestable__type_recap_edd_caption_<%= requestable.item[:id] %>" class="form-text brief-msg"><%= I18n.t('requests.recap_edd.brief_msg') %></small>
+  <div class="card card-body bg-light">
+    <fieldset class="form-group required">
+      <%= label_tag "requestable__edd_art_title", 'Article/Chapter Title *', class: 'control-label col-sm-12' %>
+      <div class="col-sm-6">
+        <%= text_field_tag 'requestable[][edd_art_title]', "", value: "", placeholder: "", maxlength: 60, size: 30 %>
+      </div>
+    </fieldset>
+    <fieldset class="form-group">
+      <%= label_tag "requestable__edd_start_page", 'Start Page', class: 'control-label col-sm-12' %>
+      <div class="col-sm-6">
+        <%= text_field_tag 'requestable[][edd_start_page]', "", value: "", placeholder: "1, xi, toc", maxlength: 20, size: 20 %>
+      </div>
+    </fieldset>
+    <fieldset class="form-group">
+      <%= label_tag "requestable__edd_end_page", 'End Page', class: 'control-label col-sm-12' %>
+      <div class="col-sm-6">
+        <%= text_field_tag 'requestable[][edd_end_page]', "", value: "", placeholder: "20, xi", maxlength: 20, size: 20 %>
+      </div>
+    </fieldset>
+    <fieldset class="form-group">
+      <%= label_tag "requestable__edd_volume_number", 'Volume Number', class: 'control-label col-sm-12' %>
+      <div class="col-sm-6">
+        <%= text_field_tag 'requestable[][edd_volume_number]', "", value: requestable.item['enum'], placeholder: "Vol. 50", maxlength: 20, size: 20 %>
+      </div>
+    </fieldset>
+    <fieldset class="form-group">
+      <%= label_tag "requestable__edd_issue", 'Issue', class: 'control-label col-sm-12' %>
+      <div class="col-sm-6">
+        <%= text_field_tag 'requestable[][edd_issue]', "", value: requestable.item['chron'], placeholder: "3", maxlength: 20, size: 20 %>
+      </div>
+    </fieldset>
+    <fieldset class="form-group">
+      <%= label_tag "requestable__edd_author", 'Author', class: 'control-label col-sm-12' %>
+      <div class="col-sm-6">
+        <%= text_field_tag 'requestable[][edd_author]', "", value: "", placeholder: "", maxlength: 60, size: 30 %>
+      </div>
+    </fieldset>
+    <fieldset class="form-group">
+      <%= label_tag "requestable__edd_note", 'Note', class: 'control-label col-sm-12' %>
+      <div class="col-sm-6">
+        <%= text_field_tag 'requestable[][edd_note]', "", value: "", placeholder: "", maxlength: 60, size: 30 %>
+      </div>
+    </fieldset>
+    <small class="col-sm-12">* indicates a required field for Electronic Delivery requests.</small>
+  </div>
 </div>

--- a/app/views/requests/request/_fill_in_field.html.erb
+++ b/app/views/requests/request/_fill_in_field.html.erb
@@ -1,7 +1,7 @@
 <tr class='user-supplied-input' id='request_user_supplied_<%= "#{requestable.holding.keys[0]}" %>'>
   <td class='request--select'>
     <%= hidden_field_tag 'requestable[][selected]', false %>
-    <%= check_box_tag "requestable[][selected]", true, false, class: 'request--select' %>
+    <%= check_box_tag "requestable[][selected]", true, false, class: 'request--select', aria: { label: "Volume not listed"} %>
     <%= hidden_fields_holding requestable %>
   </td>
   <td class='request--options' <%= 'colspan="2"'.html_safe unless table_sorter_present?(requestable_list) %>>
@@ -10,7 +10,7 @@
           If the specific volume does not appear in the list below, please enter it here:
       </label>
       <div class="col-sm-6">
-        <%= text_field_tag 'requestable[][user_supplied_enum]', "", value: "", placeholder: "Ex: Volume 2, 1987", id: "requestable_user_supplied_enum_#{requestable.holding.keys[0]}", maxlength: 60, size: 20 %>
+        <%= text_field_tag 'requestable[][user_supplied_enum]', "", value: "", placeholder: "Ex: Volume 2, 1987", id: "requestable_user_supplied_enum_#{requestable.holding.keys[0]}", maxlength: 60 %>
       </div>
     </fieldset>
   </td>

--- a/app/views/requests/request/_requestable_form.html.erb
+++ b/app/views/requests/request/_requestable_form.html.erb
@@ -9,14 +9,14 @@
          <%= hidden_fields_for_requestable requestable: requestable %>
       <% end %>
     </td>
-    <td>
+    <td class="request--options">
       <% if requestable.item_data? || requestable.scsb? %>
         <span id="<%= "enum_#{requestable.preferred_request_id}" %>">
           <%= enum_copy_display requestable.item %>
         </span>
       <% end %>
     </td>
-    <td>
+    <td class="request--availability">
       <% if requestable.item_data? || (requestable.services & ["on_order", "in_process"]).present? %>
         <%= system_status_label requestable %>
         <%= status_label requestable %>
@@ -26,7 +26,7 @@
         <%= requestable.item[:use_statement] %>
       <% end %>
     </td>
-  <td class='request--options' aria-live="polite">
+  <td class='delivery--options' aria-live="polite">
     <% if requestable.can_be_delivered? || requestable.in_process? %>
       <%= render partial: 'delivery_options', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups, request_context: @request.ctx } %>  
     <% elsif requestable.available_for_digitizing? %>

--- a/app/views/requests/request/_requestable_list_form.html.erb
+++ b/app/views/requests/request/_requestable_list_form.html.erb
@@ -18,7 +18,7 @@
 </div>
 <div class="table-responsive-sm">
   <table class="table table-striped table-bordered request--available_items <%= show_tablesorter(requestable_list) %>">
-    <thead>
+    <thead class="visually-hidden-sm">
       <th>Select</th>
       <th class="w-25">Enumeration</th>
       <th>Status</th>

--- a/app/views/requests/request/generate.erb
+++ b/app/views/requests/request/generate.erb
@@ -1,15 +1,15 @@
 <div class="col-12">
-  <div class="col-12">
-    <div class="button--start-over">
+  <%# <div class="col-12"> %>
+    <%# <div class="button--start-over"> %>
       <a class="btn btn-primary" id="returnToRecordLink"
         href=<%= "/catalog/#{@request.system_id}" %>>
         <span class="icon-refresh"></span>
-        <span class="d-none d-lg-inline">
+        <span class="d-lg-inline">
           Return to record
         </span>
       </a>
-    </div>
-  </div>
+    <%# </div> %>
+  <%# </div> %>
   <!-- div class="doc-message-<%= @request.system_id %>">
     <h1>Physical Requests are not being accepted at this time including Borrow Direct and Interlibrary Loan services.</h1>
     <p>While requests for physical material cannot be fulfilled at this time, library staff are working remotely to deliver materials digitally whenever possible. Responses to your request will take longer and some requests might not be fulfilled until library operations return to normal. Please use the ArticleExpress service to make your request. If you have any questions, <a href="https://library.princeton.edu/ask-us">please let us know</a>.


### PR DESCRIPTION
Stacks row cells to be viewable blocks on smaller viewports:

<img width="559" alt="Screen Shot 2020-06-11 at 2 00 42 PM" src="https://user-images.githubusercontent.com/8161144/84423147-0c95d900-abec-11ea-98cd-702505cd583d.png">
