### PR TITLE
Allow auth_users to request items at ReCAP that are at phsyical delivery only holding locations.

### DIFF
--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -99,9 +99,11 @@ module Requests
         return ['recap_no_items'] unless requestable.item_data?
         services = []
         return services << 'ask_me' if requestable.scsb_in_library_use?
-        # Add physical recap delivery during campus closure
-        # services = ['recap']
-        services << 'recap_edd' if requestable.recap_edd? && auth_user?
+        # When campus services reopen to guests remove auth_user? check
+        if auth_user?
+          services << 'recap' unless requestable.in_library_use_only?
+          services << 'recap_edd' if requestable.recap_edd?
+        end
         services
       end
 

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -462,6 +462,16 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           expect(confirm_email.html_part.body.to_s).to have_content("Abdelhalim Ibrahim Abdelhalim : an architecture of collective memory")
           expect(confirm_email.html_part.body.to_s).to have_content("Wear a mask or face covering")
         end
+
+        it "allows requests of recap pickup only items" do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .to_return(status: 200, body: good_response, headers: {})
+          visit '/requests/11578319?mfhd=11259604'
+          # choose('requestable__delivery_mode_8298341_edd') # chooses 'edd' radio button
+          expect(page).not_to have_content 'Item is not requestable.'
+          expect(page).not_to have_content 'Electronic Delivery'
+          expect(page).to have_content 'Item off-site at ReCAP facility. Request for delivery in 1-2 business days.'
+        end
       end
     end
 

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -481,12 +481,8 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     let(:requestable) { request.requestable.first }
 
     describe '# offsite requestable' do
-      # TODO: Remove when campus has re-opened
-      it "does not have recap request service available during campus closure" do
-        expect(requestable.services.include?('recap')).to be false
-      end
       # TODO: Activate test when campus has re-opened
-      xit "should have recap request service available" do
+      it "has recap request service available" do
         expect(requestable.services.include?('recap')).to be true
       end
       it "has recap edd request service available" do
@@ -590,12 +586,8 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     let(:requestable) { request.requestable.first }
 
     describe '#requestable' do
-      # TODO: Remove when campus has re-opened
-      it "does not have recap request service available during campus closure" do
-        expect(requestable.services.include?('recap')).to be false
-      end
       # TODO: Activate test when campus has re-opened
-      xit "should have recap request service available" do
+      it "has recap request service available" do
         expect(requestable.services.include?('recap')).to be true
       end
       it "has recap edd request service available" do

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -176,10 +176,11 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :new
           stubbed_questions[:recap?] = true
           stubbed_questions[:item_data?] = true
           stubbed_questions[:recap_edd?] = true
+          stubbed_questions[:in_library_use_only?] = false
           stubbed_questions[:ask_me?] = true
         end
         it "returns recap_edd in the services" do
-          expect(router.calculate_services).to eq(['recap_edd'])
+          expect(router.calculate_services).to include('recap_edd')
         end
         context "unauthorized user" do
           let(:user) { FactoryGirl.build(:unauthenticated_patron) }


### PR DESCRIPTION
For #705 