### PR TITLE
Adding edd message back to non recap items

### DIFF
--- a/app/views/requests/request/_requestable_delivery_option_digitize.html.erb
+++ b/app/views/requests/request/_requestable_delivery_option_digitize.html.erb
@@ -6,6 +6,7 @@
         <%= hidden_field_tag "requestable[][type]", "recap" %>
     <% else %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_edd]", "Electronic Delivery", class: 'control-label', id: "requestable__type_recap_edd_#{requestable.item[:id]}" %>
+        <small id="requestable__type_edd_caption_<%= requestable.item[:id] %>" class="form-text brief-msg"><%= I18n.t('requests.on_shelf_edd.brief_msg') %></small>
         <div>
           <a class='btn btn-primary btn-lg' href='<%= requestable.illiad_request_url(request_context, note: 'Digitization Request') %>' aria-labelledby='title <%= "enum_#{requestable.preferred_request_id}"%>'><%= I18n.t('requests.on_shelf_edd.request_label') %></a>
         </div>


### PR DESCRIPTION
What is in production:
![Screen Shot 2020-06-12 at 4 23 41 PM](https://user-images.githubusercontent.com/1599081/84543429-5e606100-acc9-11ea-84d7-10bc006c5a7c.png)

What is on staging without this update:
![Screen Shot 2020-06-12 at 4 23 48 PM](https://user-images.githubusercontent.com/1599081/84543437-60c2bb00-acc9-11ea-9160-97e16c5038d2.png)
