### PR TITLE
Removing additional delivery_mode

### DIFF
--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -106,7 +106,6 @@ module Requests
       # id = requestable.item? ? requestable.item['id'] : requestable.holding['id']
       content_tag(:fieldset, class: 'recap--print', id: "recap_group_#{requestable.preferred_request_id}") do
         concat hidden_field_tag "requestable[][type]", "", value: 'recap'
-        concat hidden_field_tag "requestable[][delivery_mode_#{requestable.preferred_request_id}]", "print"
       end
     end
 

--- a/app/models/requests/selected_items_validator.rb
+++ b/app/models/requests/selected_items_validator.rb
@@ -72,7 +72,7 @@ module Requests
           record.errors[:items] << { item_id => { 'text' => 'Please select a delivery type for your selected recap item', 'type' => 'options' } }
         else
           delivery_type = selected["delivery_mode_#{item_id}"]
-          record.errors[:items] << { item_id => { 'text' => 'Please select a pickup location for your selected recap item', 'type' => 'pickup' } } if delivery_type == 'print' && selected['pickup'].empty?
+          record.errors[:items] << { item_id => { 'text' => 'Please select a pickup location for your selected recap item', 'type' => 'pickup' } } if delivery_type == 'print' && selected['pickup'].blank?
           if delivery_type == 'edd'
             record.errors[:items] << { item_id => { 'text' => 'Please specify title for the selection you want digitized.', 'type' => 'options' } } if selected['edd_art_title'].empty?
           end


### PR DESCRIPTION
that is causing recap print request to fail badly