### PR TITLE
Allowing staff locations to be chosen for Recap and Forestal

### DIFF
--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -173,7 +173,7 @@ module Requests
         [default_pickups[idx]]
       elsif requestable.recap? || requestable.annexa?
         # open libraries
-        pickups = default_pickups.select { |loc| ['PA', 'PL', 'PK', 'PM', 'QX', 'PW', 'PN'].include?(loc[:gfa_pickup]) }
+        pickups = default_pickups.select { |loc| ['PA', 'PL', 'PK', 'PM', 'QX', 'PW', 'PN', 'QA', 'QT', 'QC'].include?(loc[:gfa_pickup]) }
         pickups << default_pickups[0] if pickups.empty?
         pickups
       else

--- a/app/views/requests/request_mailer/in_process_confirmation.html.erb
+++ b/app/views/requests/request_mailer/in_process_confirmation.html.erb
@@ -10,6 +10,12 @@
   </td>
 </tr>
 
+<tr class="pikcup-info">
+  <td colspan="2" style="padding: 18px;">
+    <%= render 'covid_pickup_guidelines' %>
+  </td>
+</tr>
+
 <tr class="bib-info">
   <td colspan="2" style="padding: 18px;border-top:1px solid #ccc;">
     <%= render 'bib_info_patron' %>

--- a/app/views/requests/request_mailer/in_process_confirmation.text.erb
+++ b/app/views/requests/request_mailer/in_process_confirmation.text.erb
@@ -4,5 +4,6 @@ In Process Request
 <%= I18n.t('requests.in_process.patron_conf_msg') %>
 
 <%= render 'patron_info' %>
+<%= render 'covid_pickup_guidelines' %>
 <%= render 'bib_info' %>
 <%= render 'item_info' %>


### PR DESCRIPTION
Also added Covid pickup guidelines that I noticed were missing when I tested the email.

    fixes #724