### PR TITLE
Adding selected radio button for print only so the form works

### DIFF
--- a/app/views/requests/request/_requestable_delivery_option_pick_up.html.erb
+++ b/app/views/requests/request/_requestable_delivery_option_pick_up.html.erb
@@ -1,13 +1,9 @@
       <div>
-      <% if (['recap_edd', 'on_shelf_edd'] & requestable.services).present? %>
         <%= hidden_service_options requestable %>
-        <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", 'print', false, data: { target: "#fields-print__#{requestable.item['id']}" }, 'aria-controls' => "fields-print__#{requestable.item['id']}", class: 'control-label' %>
+        <%= radio_button_tag "requestable[][delivery_mode_#{requestable.item[:id]}]", 'print', selected, data: { target: "#fields-print__#{requestable.item['id']}" }, 'aria-controls' => "fields-print__#{requestable.item['id']}", class: 'control-label' %>
         <%= label_tag "requestable[][delivery_mode_#{requestable.item[:id]}_print]", I18n.t("requests.recap.delivery_label"), class: 'control-label', id: "requestable__type_recap_label_#{requestable.item[:id]}" %>
-        <%= pickup_choices requestable, default_pickups %>
-      <% else %>
-        <div class="delivery-option">Physical Item Delivery</div>
+      <% unless (['recap_edd', 'on_shelf_edd'] & requestable.services).present? %>
         <%= show_pickup_service_options requestable, mfhd %>
-        <%= hidden_service_options requestable %>
-        <%= pickup_choices requestable, default_pickups %>
       <% end %>
+        <%= pickup_choices requestable, default_pickups %>
       </div>

--- a/app/views/requests/request/_requestable_form_digitize_and_pickup.html.erb
+++ b/app/views/requests/request/_requestable_form_digitize_and_pickup.html.erb
@@ -3,7 +3,7 @@
   <%= render partial: 'requestable_enum', locals: { requestable: requestable } %>
   <%= render partial: 'requestable_status', locals: { requestable: requestable } %>
   <td class='delivery--options' aria-live="polite">
-    <%= render partial: 'requestable_delivery_option_pick_up', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups, request_context: request_context } %>  
+    <%= render partial: 'requestable_delivery_option_pick_up', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups, request_context: request_context, selected: false } %>  
     <%= render partial: 'requestable_delivery_option_digitize', locals: { requestable: requestable, request_context: request_context, collapse: "collapse", selected: false } %>
   </td>
 </tr>

--- a/app/views/requests/request/_requestable_form_pickup.html.erb
+++ b/app/views/requests/request/_requestable_form_pickup.html.erb
@@ -3,6 +3,6 @@
   <%= render partial: 'requestable_enum', locals: { requestable: requestable } %>
   <%= render partial: 'requestable_status', locals: { requestable: requestable } %>
   <td class='delivery--options' aria-live="polite">
-    <%= render partial: 'requestable_delivery_option_pick_up', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups, request_context: request_context } %>  
+    <%= render partial: 'requestable_delivery_option_pick_up', locals: { requestable: requestable, mfhd: mfhd, default_pickups: default_pickups, request_context: request_context, selected: true } %>  
   </td>
 </tr>


### PR DESCRIPTION
fixes #755

The reason there is an unless still in the form is because we are showing `Item off-site at ReCAP facility. Request for delivery in 1-2 business days.` when print is the only option.  @kevinreiss I'm wondering if we should really be showing that in both cases...

<img width="1410" alt="Screen Shot 2020-07-13 at 3 39 00 PM" src="https://user-images.githubusercontent.com/1599081/87346074-12e6e000-c51f-11ea-877a-36bcd9314257.png">
<img width="1447" alt="Screen Shot 2020-07-13 at 3 38 53 PM" src="https://user-images.githubusercontent.com/1599081/87346085-15493a00-c51f-11ea-9447-b12e35fac476.png">
