### PR TITLE
Add article author (user supplied) and item author to illiad transaction

### DIFF
--- a/app/models/requests/illiad_transaction_client.rb
+++ b/app/models/requests/illiad_transaction_client.rb
@@ -35,9 +35,9 @@ module Requests
           "Username" => user["netid"], "TransactionStatus" => illiad_transaction_status,
           "RequestType" => "Article", "ProcessType" => "Borrowing", "NotWantedAfter" => (DateTime.current + 6.months).strftime("%m/%d/%Y"),
           "WantedBy" => "Yes, until the semester's", # note creation fails if we use any other text value
-          "PhotoArticleAuthor" => bib["author"]&.truncate(100), "PhotoJournalTitle" => bib["title"]&.truncate(255), "PhotoItemPublisher" => item["edd_publisher"]&.truncate(40),
-          "ISSN" => bib["isbn"], "CallNumber" => item["edd_call_number"]&.truncate(255), "PhotoJournalInclusivePages" => pages&.truncate(30),
-          "CitedIn" => "#{Requests.config[:pulsearch_base]}/catalog/#{bib['id']}", "PhotoJournalYear" => item["edd_date"],
+          "PhotoItemAuthor" => bib["author"]&.truncate(100), "PhotoArticleAuthor" => item["edd_author"]&.truncate(100), "PhotoJournalTitle" => bib["title"]&.truncate(255),
+          "PhotoItemPublisher" => item["edd_publisher"]&.truncate(40), "ISSN" => bib["isbn"], "CallNumber" => item["edd_call_number"]&.truncate(255),
+          "PhotoJournalInclusivePages" => pages&.truncate(30), "CitedIn" => "#{Requests.config[:pulsearch_base]}/catalog/#{bib['id']}", "PhotoJournalYear" => item["edd_date"],
           "PhotoJournalVolume" => item["edd_volume_number"]&.truncate(30), "PhotoJournalIssue" => item["edd_issue"]&.truncate(30),
           "ItemInfo3" => item["edd_volume_number"]&.truncate(255), "ItemInfo4" => item["edd_issue"]&.truncate(255),
           "CitedPages" => "COVID-19 Campus Closure", "AcceptNonEnglish" => true, "ESPNumber" => item["edd_oclc_number"]&.truncate(32),

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -568,7 +568,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
           stub_request(:get, patron_url)
             .to_return(status: 200, body: responses[:found], headers: {})
           stub_request(:post, transaction_url)
-            .with(body: hash_including("Username" => "jstudent", "TransactionStatus" => "Awaiting Article Express Processing", "RequestType" => "Article", "ProcessType" => "Borrowing", "WantedBy" => "Yes, until the semester's", "PhotoArticleAuthor" => "Herzog, Hans-Michael Daros Collection (Art)", "PhotoJournalTitle" => "La mirada : looking at photography in Latin America today", "PhotoItemPublisher" => "Zürich: Edition Oehrli", "PhotoJournalIssue" => "",
+            .with(body: hash_including("Username" => "jstudent", "TransactionStatus" => "Awaiting Article Express Processing", "RequestType" => "Article", "ProcessType" => "Borrowing", "WantedBy" => "Yes, until the semester's", "PhotoArticleAuthor" => "I Aman Author", "PhotoItemAuthor" => "Herzog, Hans-Michael Daros Collection (Art)", "PhotoJournalTitle" => "La mirada : looking at photography in Latin America today", "PhotoItemPublisher" => "Zürich: Edition Oehrli", "PhotoJournalIssue" => "",
                                        "Location" => "Marquand Library", "ISSN" => nil, "CallNumber" => "", "PhotoJournalInclusivePages" => "-", "CitedIn" => "https://catalog.princeton.edu/catalog/4127409", "PhotoJournalVolume" => "", "ItemInfo3" => "", "ItemInfo4" => "", "CitedPages" => "COVID-19 Campus Closure", "AcceptNonEnglish" => true, "ESPNumber" => "", "DocumentType" => "Book", "PhotoArticleTitle" => "ABC", "PhotoJournalYear" => "2002"))
             .to_return(status: 200, body: responses[:transaction_created], headers: {})
           stub_request(:post, transaction_note_url)
@@ -576,6 +576,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
           visit '/requests/4127409?mfhd=4403772'
           expect(page).to have_content 'Electronic Delivery'
           fill_in "Article/Chapter Title", with: "ABC"
+          fill_in "Author", with: "I Aman Author"
           expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(1)
           confirm_email = ActionMailer::Base.deliveries.last
           expect(confirm_email.subject).to eq("Electronic Document Delivery Request Confirmation")

--- a/spec/models/requests/illiad_transaction_client_spec.rb
+++ b/spec/models/requests/illiad_transaction_client_spec.rb
@@ -8,7 +8,7 @@ describe Requests::IlliadTransactionClient, type: :controller do
   let(:requestable) do
     [{ "selected" => "true", "bibid" => "10921934", "mfhd" => "10637717", "call_number" => "HF1131 .B485",
        "location_code" => "f", "item_id" => "7892830", "barcode" => "32101102865654", "enum" => "2019",
-       "copy_number" => "0", "status" => "Not Charged", "type" => "on_shelf", "pickup" => "PA",
+       "copy_number" => "0", "status" => "Not Charged", "type" => "on_shelf", "pickup" => "PA", "edd_author" => "That One",
        "edd_genre" => "journal", "edd_isbn" => "", "edd_date" => "", "edd_publisher" => "Santa Barbara, Calif: ABC-CLIO",
        "edd_call_number" => "HF1131 .B485", "edd_oclc_number" => "1033410889", "edd_title" => "Best business schools", "edd_note" => "Customer note" }]
     # {"selected"=>"true", "bibid"=>"3510207", "mfhd"=>"3832636", "call_number"=>"D25 .D385 1999",
@@ -58,7 +58,7 @@ describe Requests::IlliadTransactionClient, type: :controller do
       stub_request(:get, patron_url)
         .to_return(status: 200, body: responses[:found], headers: {})
       stub_request(:post, transaction_url)
-        .with(body: hash_including("Username" => "abc234", "TransactionStatus" => "Awaiting Article Express Processing", "RequestType" => "Article", "ProcessType" => "Borrowing", "WantedBy" => "Yes, until the semester's", "PhotoArticleAuthor" => "Davis, Paul K.", "PhotoJournalTitle" => "100 decisive battles : from ancient times to the present", "PhotoItemPublisher" => "Santa Barbara, Calif: ABC-CLIO", "ISSN" => "9781576070758", "CallNumber" => "HF1131 .B485", "PhotoJournalInclusivePages" => "-", "CitedIn" => "https://catalog.princeton.edu/catalog/3510207", "PhotoJournalVolume" => nil,
+        .with(body: hash_including("Username" => "abc234", "TransactionStatus" => "Awaiting Article Express Processing", "RequestType" => "Article", "ProcessType" => "Borrowing", "WantedBy" => "Yes, until the semester's", "PhotoArticleAuthor" => "That One", "PhotoItemAuthor" => "Davis, Paul K.", "PhotoJournalTitle" => "100 decisive battles : from ancient times to the present", "PhotoItemPublisher" => "Santa Barbara, Calif: ABC-CLIO", "ISSN" => "9781576070758", "CallNumber" => "HF1131 .B485", "PhotoJournalInclusivePages" => "-", "CitedIn" => "https://catalog.princeton.edu/catalog/3510207", "PhotoJournalVolume" => nil,
                                    "PhotoJournalIssue" => nil, "ItemInfo3" => nil, "ItemInfo4" => nil, "CitedPages" => "COVID-19 Campus Closure", "AcceptNonEnglish" => true, "ESPNumber" => "1033410889", "DocumentType" => "Book", "PhotoArticleTitle" => nil))
         .to_return(status: 200, body: responses[:transaction_created], headers: {})
       stub_request(:post, transaction_note_url)


### PR DESCRIPTION
@kevinreiss when I did the audit I noticed that the Author had two places, one for the Item, and one for the article.  We were filling in the wrong one with the item data and not sending the user filled in author.  Can we double check all the field lengths at some point?