### PR TITLE
Allowing users without barcodes to request digital scans

### DIFF
--- a/app/controllers/requests/request_controller.rb
+++ b/app/controllers/requests/request_controller.rb
@@ -19,11 +19,12 @@ module Requests
       @user = current_or_guest_user
 
       @patron = patron(user: @user)
+      user_barcode = @patron[:barcode] if @patron.present?
       @mode = mode
       @title = "Request ID: #{system_id}"
 
       # needed to see if we can suppress login for this item
-      @request = Requests::Request.new(system_id: system_id, mfhd: mfhd, source: source, user: @user)
+      @request = Requests::Request.new(system_id: system_id, mfhd: mfhd, source: source, user: @user, user_barcode: user_barcode)
       ### redirect to Aeon non-voyager items or single Aeon requestable
       if @request.thesis? || @request.numismatics?
         redirect_to "#{Requests.config[:aeon_base]}?#{@request.requestable.first.aeon_mapped_params.to_query}"
@@ -100,6 +101,8 @@ module Requests
         if !user.guest?
           patron = current_patron(user.uid)
           flash.now[:error] = "A problem occurred looking up your library account." if patron == false
+          # Uncomment to fake being a non barcoded user
+          # patron[:barcode] = nil
           patron
         elsif session["email"].present? && session["user_name"].present?
           access_patron(session["email"], session["user_name"])

--- a/app/models/concerns/requests/scsb.rb
+++ b/app/models/concerns/requests/scsb.rb
@@ -91,7 +91,7 @@ module Requests
         deliveryLocation: item[:pickup] || "", emailAddress: user[:active_email],
         endPage: item[:edd_end_page], issue: item[:edd_issue], itemBarcodes: [item[:barcode]],
         itemOwningInstitution: scsb_owning_institution(item[:location_code]),
-        patronBarcode: user[:barcode], requestNotes: item[:edd_note],
+        patronBarcode: user[:barcode] || '198572131', requestNotes: item[:edd_note],
         requestType: scsb_request_map(request_type), requestingInstitution: requesting_institution,
         startPage: item[:edd_start_page], titleIdentifier: bib[:title],
         username: user[:netid], volume: item[:edd_volume_number] }

--- a/app/models/requests/illiad_transaction_client.rb
+++ b/app/models/requests/illiad_transaction_client.rb
@@ -31,7 +31,7 @@ module Requests
     private
 
       def map_metdata
-        {
+        resp = {
           "Username" => user["netid"], "TransactionStatus" => illiad_transaction_status,
           "RequestType" => "Article", "ProcessType" => "Borrowing", "NotWantedAfter" => (DateTime.current + 6.months).strftime("%m/%d/%Y"),
           "WantedBy" => "Yes, until the semester's", # note creation fails if we use any other text value
@@ -43,7 +43,8 @@ module Requests
           "CitedPages" => "COVID-19 Campus Closure", "AcceptNonEnglish" => true, "ESPNumber" => item["edd_oclc_number"]&.truncate(32),
           "DocumentType" => genre, "Location" => item["edd_location"],
           "PhotoArticleTitle" => item["edd_art_title"]&.truncate(250)
-        }.to_json
+        }
+        resp.to_json
       end
 
       def pages

--- a/app/models/requests/submission.rb
+++ b/app/models/requests/submission.rb
@@ -6,7 +6,7 @@ module Requests
 
     validates :email, presence: true, email: true, length: { minimum: 5, maximum: 50 } # , format: { message: "Supply a Valid Email Address" } #, on: :submit
     validates :user_name, presence: true, length: { minimum: 1, maximum: 50 } # ,  format: { message: "Name Can't be Blank" } #, on: :submit
-    validates :user_barcode, presence: true, length: { minimum: 5, maximum: 14 },
+    validates :user_barcode, allow_blank: true, presence: true, length: { minimum: 5, maximum: 14 },
                              format: { with: /(^ACCESS$|^access$|^\d{14}$)/i, message: "Please supply a valid library barcode or type the value 'ACCESS'" }
     validate :item_validations # , presence: true, length: { minimum: 1 }, on: :submit
 

--- a/app/views/requests/request/_form.html.erb
+++ b/app/views/requests/request/_form.html.erb
@@ -4,8 +4,9 @@
   <% end %>
 <% elsif !@user.guest && @patron == false %>
   <%= render partial: 'auth_user_lookup_fail' %>
-<% elsif !@user.guest && @patron['barcode'].blank? %>
-  <%= render partial: 'cas_user_no_barcode' %>
+<!-- Temporary change to allow students not on campus digitization,  but not pickup options -->
+<%# elsif !@user.guest && @patron['barcode'].blank? %>
+  <%# = render partial: 'cas_user_no_barcode' %>
 <% elsif @user.provider == 'barcode' %>
   <%= render partial: 'no_access' %>
 <% else %>

--- a/app/views/requests/request/_request_form.html.erb
+++ b/app/views/requests/request/_request_form.html.erb
@@ -26,5 +26,7 @@
     <%= render partial: "requestable_list_form", collection: @request.filtered_sorted_requestable.keys, as: :mfhd, locals: { sorted_requestable: @request.sorted_requestable, holdings: @request.holdings, default_pickups: @request.default_pickups } %>
     <% if !@request.all_items_online? && @request.any_will_submit_via_form? %>
       <%= f.submit submit_message(@request.requestable), class: "btn btn-primary submit--request", disabled: submit_button_disabled(@request.requestable), data: { disable_with: "Submitting Request" } %>
+    <% elsif @patron[:barcode].blank? %>
+      <h3> <%= I18n.t("requests.account.cas_user_no_barcode_no_choice_msg") %> </h3>
     <% end %>
   <% end %>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -182,6 +182,7 @@ en:
       pul_user_service_msg: 'Princeton Faculty, Staff, and Students need to sign in to see Borrow Direct Services'
       other_user_login_btn: "View Available Request Options"
       cas_user_no_barcode_msg: 'You must register with the Library before you can request materials. Please go to Firestone Circulation for assistance. Thank you.'
+      cas_user_no_barcode_no_choice_msg: 'Only items available for digitization can be requested when you do not have a barcode registered with the Library'
       auth_user_lookup_fail: 'Failed to lookup your library account'
     library_hours:
       firestone: '11am - 3pm, Monday - Friday'

--- a/spec/factories/requests/request.rb
+++ b/spec/factories/requests/request.rb
@@ -9,19 +9,22 @@ FactoryGirl.define do
   factory :request_no_items, class: 'Requests::Request' do
     system_id 4_492_846
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_on_order, class: 'Requests::Request' do
     system_id 11_416_426
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_pending, class: 'Requests::Request' do
     system_id 11_889_085
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   # factory :request_with_items_available, class: 'Requests::Request' do
@@ -67,86 +70,100 @@ FactoryGirl.define do
   factory :request_thesis, class: 'Requests::Request' do
     system_id "dsp01rr1720547"
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_numismatics, class: 'Requests::Request' do
     system_id "coin-1167"
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_paging_available, class: 'Requests::Request' do
     system_id 6_009_363
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_paging_available_barcode_patron, class: 'Requests::Request' do
     system_id 6_009_363
     user { FactoryGirl.build(:valid_barcode_patron) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_paging_available_unauthenticated_patron, class: 'Requests::Request' do
     system_id 6_009_363
     user { FactoryGirl.build(:unauthenticated_patron) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_paging_mutliple_mfhd, class: 'Requests::Request' do
     system_id 2_942_771
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   # missing item
   factory :request_missing_item, class: 'Requests::Request' do
     system_id 1_389_121
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_missing_item_barcode_patron, class: 'Requests::Request' do
     system_id 1_389_121
     user { FactoryGirl.build(:valid_barcode_patron) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_missing_item_unauthenticated_patron, class: 'Requests::Request' do
     system_id 1_389_121
     user { FactoryGirl.build(:unauthenticated_patron) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :request_on_shelf, class: 'Requests::Request' do
     system_id 1_214_063
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :aeon_eal_voyager_item, class: 'Requests::Request' do
     system_id 7_721_323
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :aeon_w_barcode, class: 'Requests::Request' do
     system_id 9_594_435
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :aeon_w_long_title, class: 'Requests::Request' do
     system_id 2_990_846
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :aeon_no_item_record, class: 'Requests::Request' do
     system_id 2_535_845
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, user_barcode: user_barcode) }
   end
 
   factory :aeon_rbsc_voyager_enumerated, class: 'Requests::Request' do
@@ -154,7 +171,8 @@ FactoryGirl.define do
     mfhd_id '675722'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :aeon_rbsc_enumerated, class: 'Requests::Request' do
@@ -162,7 +180,8 @@ FactoryGirl.define do
     mfhd_id '6720550'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :aeon_marquand, class: 'Requests::Request' do
@@ -170,7 +189,8 @@ FactoryGirl.define do
     mfhd_id '7697569'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :aeon_mudd, class: 'Requests::Request' do
@@ -178,7 +198,8 @@ FactoryGirl.define do
     mfhd_id '6080541'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :aeon_mudd_barcode_patron, class: 'Requests::Request' do
@@ -186,7 +207,8 @@ FactoryGirl.define do
     mfhd_id '6080541'
     source 'pulsearch'
     user { FactoryGirl.build(:valid_barcode_patron) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :aeon_mudd_unauthenticated_patron, class: 'Requests::Request' do
@@ -194,7 +216,8 @@ FactoryGirl.define do
     mfhd_id '6080541'
     source 'pulsearch'
     user { FactoryGirl.build(:unauthenticated_patron) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :missing_item, class: 'Requests::Request' do
@@ -202,7 +225,8 @@ FactoryGirl.define do
     mfhd_id '1594697'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :request_with_items_charged, class: 'Requests::Request' do
@@ -210,7 +234,8 @@ FactoryGirl.define do
     mfhd_id '1594698'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :request_with_items_charged_barcode_patron, class: 'Requests::Request' do
@@ -218,7 +243,8 @@ FactoryGirl.define do
     mfhd_id '1594698'
     source 'pulsearch'
     user { FactoryGirl.build(:valid_barcode_patron) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :request_with_items_charged_unauthenticated_patron, class: 'Requests::Request' do
@@ -226,7 +252,8 @@ FactoryGirl.define do
     mfhd_id '1594698'
     source 'pulsearch'
     user { FactoryGirl.build(:unauthenticated_patron) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :request_serial_with_item_on_hold, class: 'Requests::Request' do
@@ -234,21 +261,24 @@ FactoryGirl.define do
     mfhd_id '4808685'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 
   factory :request_aeon_holding_volume_note, class: 'Requests::Request' do
     system_id 616_086
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, source: source, user_barcode: user_barcode) }
   end
 
   factory :request_scsb_cu, class: 'Requests::Request' do
     system_id 'SCSB-5235419'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, source: source, user_barcode: user_barcode) }
   end
 
   # use_statement: "In Library Use"
@@ -256,14 +286,16 @@ FactoryGirl.define do
     system_id 'SCSB-2650865'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, source: source, user_barcode: user_barcode) }
   end
 
   factory :request_scsb_mr, class: 'Requests::Request' do
     system_id 'SCSB-2901229'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, source: source, user_barcode: user_barcode) }
   end
 
   factory :mfhd_with_no_circ_and_circ_item, class: 'Requests::Request' do
@@ -271,6 +303,7 @@ FactoryGirl.define do
     mfhd_id '282033'
     source 'pulsearch'
     user { FactoryGirl.build(:user) }
-    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source) }
+    user_barcode '111222333'
+    initialize_with { new(system_id: system_id, user: user, mfhd: mfhd_id, source: source, user_barcode: user_barcode) }
   end
 end

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -17,8 +17,19 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
     let(:mutiple_items) { '7917192' }
 
     let(:valid_patron_response) { fixture('/bibdata_patron_response.json') }
+    let(:valid_patron_no_barcode_response) { fixture('/bibdata_patron_no_barcode_response.json') }
     let(:valid_barcode_patron_response) { fixture('/bibdata_patron_response_barcode.json') }
     let(:invalid_patron_response) { fixture('/bibdata_not_found_patron_response.json') }
+
+    let(:responses) do
+      {
+        found: '{"UserName":"abc234","ExternalUserId":"123abc","LastName":"Alpha","FirstName":"Capa","SSN":"9999999","Status":"GS - Library Staff","EMailAddress":"abc123@princeton.edu","Phone":"99912345678","Department":"Library","NVTGC":"ILL","NotificationMethod":"Electronic","DeliveryMethod":"Hold for Pickup","LoanDeliveryMethod":"Hold for Pickup","LastChangedDate":"2020-04-06T11:08:05","AuthorizedUsers":null,"Cleared":"Yes","Web":true,"Address":"123 Blah Lane","Address2":null,"City":"Blah Place","State":"PA","Zip":"99999","Site":"Firestone","ExpirationDate":"2021-04-06T11:08:05","Number":null,"UserRequestLimit":null,"Organization":null,"Fax":null,"ShippingAcctNo":null,"ArticleBillingCategory":null,"LoanBillingCategory":null,"Country":null,"SAddress":null,"SAddress2":null,"SCity":null,"SState":null,"SZip":null,"SCountry":null,"RSSID":null,"AuthType":"Default","UserInfo1":null,"UserInfo2":null,"UserInfo3":null,"UserInfo4":null,"UserInfo5":null,"MobilePhone":null}',
+        transaction_created: '{"TransactionNumber":1093806,"Username":"abc123","RequestType":"Article","PhotoArticleAuthor":null,"PhotoJournalTitle":null,"PhotoItemPublisher":null,"LoanPlace":null,"LoanEdition":null,"PhotoJournalTitle":"Test Title","PhotoJournalVolume":"21","PhotoJournalIssue":"4","PhotoJournalMonth":null,"PhotoJournalYear":"2011","PhotoJournalInclusivePages":"165-183","PhotoArticleAuthor":"Williams, Joseph; Woolwine, David","PhotoArticleTitle":"Test Article","CitedIn":null,"CitedTitle":null,"CitedDate":null,"CitedVolume":null,"CitedPages":null,"NotWantedAfter":null,"AcceptNonEnglish":false,"AcceptAlternateEdition":true,"ArticleExchangeUrl":null,"ArticleExchangePassword":null,"TransactionStatus":"Awaiting Request Processing","TransactionDate":"2020-06-15T18:34:44.98","ISSN":"XXXXX","ILLNumber":null,"ESPNumber":null,"LendingString":null,"BaseFee":null,"PerPage":null,"Pages":null,"DueDate":null,"RenewalsAllowed":false,"SpecIns":null,"Pieces":null,"LibraryUseOnly":null,"AllowPhotocopies":false,' \
+                            '"LendingLibrary":null,"ReasonForCancellation":null,"CallNumber":null,"Location":null,"Maxcost":null,"ProcessType":"Borrowing","ItemNumber":null,"LenderAddressNumber":null,"Ariel":false,"Patron":null,"PhotoItemAuthor":null,"PhotoItemPlace":null,"PhotoItemPublisher":null,"PhotoItemEdition":null,"DocumentType":null,"InternalAcctNo":null,"PriorityShipping":null,"Rush":"Regular","CopyrightAlreadyPaid":"Yes","WantedBy":null,"SystemID":"OCLC","ReplacementPages":null,"IFMCost":null,"CopyrightPaymentMethod":null,"ShippingOptions":null,"CCCNumber":null,"IntlShippingOptions":null,"ShippingAcctNo":null,"ReferenceNumber":null,"CopyrightComp":null,"TAddress":null,"TAddress2":null,"TCity":null,"TState":null,"TZip":null,"TCountry":null,"TFax":null,"TEMailAddress":null,"TNumber":null,"HandleWithCare":false,"CopyWithCare":false,"RestrictedUse":false,"ReceivedVia":null,"CancellationCode":null,"BillingCategory":null,"CCSelected":null,"OriginalTN":null,"OriginalNVTGC":null,"InProcessDate":null,' \
+                            '"InvoiceNumber":null,"BorrowerTN":null,"WebRequestForm":null,"TName":null,"TAddress3":null,"IFMPaid":null,"BillingAmount":null,"ConnectorErrorStatus":null,"BorrowerNVTGC":null,"CCCOrder":null,"ShippingDetail":null,"ISOStatus":null,"OdysseyErrorStatus":null,"WorldCatLCNumber":null,"Locations":null,"FlagType":null,"FlagNote":null,"CreationDate":"2020-06-15T18:34:44.957","ItemInfo1":null,"ItemInfo2":null,"ItemInfo3":null,"ItemInfo4":null,"SpecIns":null,"SpecialService":"Digitization Request: ","DeliveryMethod":null,"Web":null,"PMID":null,"DOI":null,"LastOverdueNoticeSent":null,"ExternalRequest":null}',
+        note_created: '{"Message":"An error occurred adding note to transaction 1093946"}'
+      }
+    end
 
     before { stub_delivery_locations }
 
@@ -564,13 +575,6 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
           patron_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/Users/jstudent"
           transaction_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction"
           transaction_note_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction/1093806/notes"
-          responses = {
-            found: '{"UserName":"abc234","ExternalUserId":"123abc","LastName":"Alpha","FirstName":"Capa","SSN":"9999999","Status":"GS - Library Staff","EMailAddress":"abc123@princeton.edu","Phone":"99912345678","Department":"Library","NVTGC":"ILL","NotificationMethod":"Electronic","DeliveryMethod":"Hold for Pickup","LoanDeliveryMethod":"Hold for Pickup","LastChangedDate":"2020-04-06T11:08:05","AuthorizedUsers":null,"Cleared":"Yes","Web":true,"Address":"123 Blah Lane","Address2":null,"City":"Blah Place","State":"PA","Zip":"99999","Site":"Firestone","ExpirationDate":"2021-04-06T11:08:05","Number":null,"UserRequestLimit":null,"Organization":null,"Fax":null,"ShippingAcctNo":null,"ArticleBillingCategory":null,"LoanBillingCategory":null,"Country":null,"SAddress":null,"SAddress2":null,"SCity":null,"SState":null,"SZip":null,"SCountry":null,"RSSID":null,"AuthType":"Default","UserInfo1":null,"UserInfo2":null,"UserInfo3":null,"UserInfo4":null,"UserInfo5":null,"MobilePhone":null}',
-            transaction_created: '{"TransactionNumber":1093806,"Username":"abc123","RequestType":"Article","PhotoArticleAuthor":null,"PhotoJournalTitle":null,"PhotoItemPublisher":null,"LoanPlace":null,"LoanEdition":null,"PhotoJournalTitle":"Test Title","PhotoJournalVolume":"21","PhotoJournalIssue":"4","PhotoJournalMonth":null,"PhotoJournalYear":"2011","PhotoJournalInclusivePages":"165-183","PhotoArticleAuthor":"Williams, Joseph; Woolwine, David","PhotoArticleTitle":"Test Article","CitedIn":null,"CitedTitle":null,"CitedDate":null,"CitedVolume":null,"CitedPages":null,"NotWantedAfter":null,"AcceptNonEnglish":false,"AcceptAlternateEdition":true,"ArticleExchangeUrl":null,"ArticleExchangePassword":null,"TransactionStatus":"Awaiting Request Processing","TransactionDate":"2020-06-15T18:34:44.98","ISSN":"XXXXX","ILLNumber":null,"ESPNumber":null,"LendingString":null,"BaseFee":null,"PerPage":null,"Pages":null,"DueDate":null,"RenewalsAllowed":false,"SpecIns":null,"Pieces":null,"LibraryUseOnly":null,"AllowPhotocopies":false,' \
-                                  '"LendingLibrary":null,"ReasonForCancellation":null,"CallNumber":null,"Location":null,"Maxcost":null,"ProcessType":"Borrowing","ItemNumber":null,"LenderAddressNumber":null,"Ariel":false,"Patron":null,"PhotoItemAuthor":null,"PhotoItemPlace":null,"PhotoItemPublisher":null,"PhotoItemEdition":null,"DocumentType":null,"InternalAcctNo":null,"PriorityShipping":null,"Rush":"Regular","CopyrightAlreadyPaid":"Yes","WantedBy":null,"SystemID":"OCLC","ReplacementPages":null,"IFMCost":null,"CopyrightPaymentMethod":null,"ShippingOptions":null,"CCCNumber":null,"IntlShippingOptions":null,"ShippingAcctNo":null,"ReferenceNumber":null,"CopyrightComp":null,"TAddress":null,"TAddress2":null,"TCity":null,"TState":null,"TZip":null,"TCountry":null,"TFax":null,"TEMailAddress":null,"TNumber":null,"HandleWithCare":false,"CopyWithCare":false,"RestrictedUse":false,"ReceivedVia":null,"CancellationCode":null,"BillingCategory":null,"CCSelected":null,"OriginalTN":null,"OriginalNVTGC":null,"InProcessDate":null,' \
-                                  '"InvoiceNumber":null,"BorrowerTN":null,"WebRequestForm":null,"TName":null,"TAddress3":null,"IFMPaid":null,"BillingAmount":null,"ConnectorErrorStatus":null,"BorrowerNVTGC":null,"CCCOrder":null,"ShippingDetail":null,"ISOStatus":null,"OdysseyErrorStatus":null,"WorldCatLCNumber":null,"Locations":null,"FlagType":null,"FlagNote":null,"CreationDate":"2020-06-15T18:34:44.957","ItemInfo1":null,"ItemInfo2":null,"ItemInfo3":null,"ItemInfo4":null,"SpecIns":null,"SpecialService":"Digitization Request: ","DeliveryMethod":null,"Web":null,"PMID":null,"DOI":null,"LastOverdueNoticeSent":null,"ExternalRequest":null}',
-            note_created: '{"Message":"An error occurred adding note to transaction 1093946"}'
-          }
           stub_request(:get, patron_url)
             .to_return(status: 200, body: responses[:found], headers: {})
           stub_request(:post, transaction_url)
@@ -620,7 +624,316 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
         expect(page).not_to have_selector '#request_user_barcode', visible: false
       end
     end
-  end
 
+    context 'a princeton net ID user without a barcode' do
+      let(:user) { FactoryGirl.create(:user) }
+      let(:in_process_id) { '11543235' }
+      let(:recap_in_process_id) { '11521583' }
+
+      let(:recap_params) do
+        {
+          Bbid: "9493318",
+          item: "7303228",
+          lname: "Student",
+          delivery: "p",
+          pickup: "PN",
+          startpage: "",
+          endpage: "",
+          email: "a@b.com",
+          volnum: "",
+          issue: "",
+          aauthor: "",
+          atitle: "",
+          note: ""
+        }
+      end
+
+      before do
+        stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/#{user.uid}")
+          .to_return(status: 200, body: valid_patron_no_barcode_response, headers: {})
+        login_as user
+      end
+
+      describe 'When visiting a voyager ID as a CAS User' do
+        it 'allow CAS patrons to request an available ReCAP item.' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .with(body: hash_including(author: "", bibId: "9493318", callNumber: "PJ7962.A5495 A95 2016", chapterTitle: "", deliveryLocation: "PA", emailAddress: 'a@b.com', endPage: "", issue: "", itemBarcodes: ["32101095798938"], itemOwningInstitution: "PUL", patronBarcode: "22101008199999",
+                                       requestNotes: "", requestType: "RETRIEVAL", requestingInstitution: "PUL", startPage: "", titleIdentifier: "ʻAwāṭif madfūnah عواطف مدفونة", username: "jstudent", volume: ""))
+            .to_return(status: 200, body: good_response, headers: {})
+          stub_request(:post, Requests.config[:scsb_base])
+            .with(headers: { 'Accept' => '*/*' })
+            .to_return(status: 200, body: "<document count='1' sent='true'></document>", headers: {})
+          visit "/requests/#{voyager_id}"
+          expect(page).to have_content 'Electronic Delivery'
+          expect(page).not_to have_content 'Physical Item Delivery'
+        end
+
+        it 'does display the online access message' do
+          visit "/requests/#{online_id}"
+          expect(page).to have_content 'Online'
+        end
+
+        it 'disallows access to in process items' do
+          visit "/requests/#{in_process_id}"
+          expect(page).not_to have_content 'Pick-up location: Marquand Library'
+          expect(page).not_to have_button('Request this Item')
+          expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))
+        end
+
+        it 'disallows access to in process recap items' do
+          visit "/requests/#{recap_in_process_id}"
+
+          expect(page).not_to have_button('Request this Item')
+          expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))
+        end
+
+        it 'disallows access to  On-Order items' do
+          visit "/requests/#{on_order_id}"
+          expect(page).not_to have_button('Request this Item')
+          expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))
+        end
+
+        it 'disallows access to a record that has no item data' do
+          visit "/requests/#{no_items_id}"
+          expect(page).not_to have_button('Request this Item')
+          expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))
+        end
+
+        it 'disallows access an on_shelf record that has no item data' do
+          visit "/requests/#{on_shelf_no_items_id}"
+          expect(page).not_to have_button('Request this Item')
+          expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))
+        end
+
+        it 'allows digitizing, but not pick up of on on_shelf record' do
+          patron_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/Users/jstudent"
+          stub_request(:get, patron_url)
+            .to_return(status: 200, body: responses[:found], headers: {})
+          transaction_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction"
+          transaction_note_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction/1093806/notes"
+          stub_request(:post, transaction_url)
+            .with(body: hash_including("Username" => "jstudent", "TransactionStatus" => "Awaiting Article Express Processing", "RequestType" => "Article", "ProcessType" => "Borrowing", "WantedBy" => "Yes, until the semester's", "PhotoItemAuthor" => "Chekhov, Anton Pavlovich", "PhotoArticleAuthor" => "", "PhotoJournalTitle" => "Pʹesy Пьесы", "PhotoItemPublisher" => "Moskva: Letniĭ sad", "ISSN" => nil, "CallNumber" => "PG3455 .A2 2015", "PhotoJournalInclusivePages" => "-", "CitedIn" => "https://catalog.princeton.edu/catalog/9770811", "PhotoJournalYear" => "2015", "PhotoJournalVolume" => "", "PhotoJournalIssue" => "", "ItemInfo3" => "", "ItemInfo4" => "", "CitedPages" => "COVID-19 Campus Closure", "AcceptNonEnglish" => true, "ESPNumber" => "964907363", "DocumentType" => "Book", "Location" => "Firestone Library", "PhotoArticleTitle" => "ABC"))
+            .to_return(status: 200, body: responses[:transaction_created], headers: {})
+          stub_request(:post, transaction_note_url)
+            .to_return(status: 200, body: responses[:note_created], headers: {})
+
+          stub_voyager_hold_success('9770811', '7502706', '77777')
+
+          visit "/requests/9770811"
+          expect(page).not_to have_content 'Pick-up location: Firestone Library'
+          expect(page).to have_content 'Electronic Delivery'
+          fill_in "Article/Chapter Title", with: "ABC"
+          expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(confirm_email.subject).to eq("Electronic Document Delivery Request Confirmation")
+          expect(confirm_email.to).to eq(["a@b.com"])
+          expect(confirm_email.cc).to be_blank
+          expect(confirm_email.html_part.body.to_s).to have_content("Chekhov, Anton Pavlovich")
+        end
+
+        it 'displays an ark link for a plum item' do
+          visit "/requests/#{iiif_manifest_item}"
+          expect(page).to have_link('Digital content', href: "https://catalog.princeton.edu/catalog/#{iiif_manifest_item}#view")
+        end
+
+        let(:good_response) { fixture('/scsb_request_item_response.json') }
+        it 'allows patrons to request a physical recap item' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .with(body: hash_including(author: "", bibId: "9944355", callNumber: "Oversize DT549 .E274q", chapterTitle: "ABC", deliveryLocation: "", emailAddress: "a@b.com", endPage: "", issue: "", itemBarcodes: ["32101098722844"], itemOwningInstitution: "PUL", patronBarcode: '198572131', requestNotes: "", requestType: "EDD", requestingInstitution: "PUL", startPage: "", titleIdentifier: "L'écrivain, magazine litteraire trimestriel", username: "jstudent", volume: "2016"))
+            .to_return(status: 200, body: good_response, headers: {})
+          visit '/requests/9944355'
+          expect(page).not_to have_content 'Pick-up location: '
+          expect(page).to have_content 'Electronic Delivery'
+          choose('requestable__delivery_mode_7467161_edd') # chooses 'edd' radio button
+          expect(page).to have_content I18n.t("requests.recap_edd.note_msg")
+          fill_in "Article/Chapter Title", with: "ABC"
+          expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          expect(page).to have_content 'Request submitted'
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(confirm_email.subject).to eq("Electronic Document Delivery Request Confirmation")
+          expect(confirm_email.to).to eq(["a@b.com"])
+          expect(confirm_email.cc).to be_blank
+          expect(confirm_email.html_part.body.to_s).to have_content("L'écrivain, magazine litteraire trimestriel")
+        end
+
+        it 'allows patrons to request a Forrestal annex' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .to_return(status: 200, body: good_response, headers: {})
+          visit '/requests/945550'
+          expect(page).not_to have_content 'Pick-up location: '
+          expect(page).to have_content 'Electronic Delivery'
+        end
+
+        it 'allows patrons to request a Lewis recap item digitally' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .to_return(status: 200, body: good_response, headers: {})
+          visit '/requests/7053307?mfhd=6962326'
+          expect(page).not_to have_content 'Pick-up'
+          fill_in "Title", with: "my stuff"
+          expect { click_button 'Request Selected Items' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          expect(page).to have_content 'Request submitted'
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(confirm_email.subject).to eq("Electronic Document Delivery Request Confirmation")
+          expect(confirm_email.to).to eq(["a@b.com"])
+          expect(confirm_email.cc).to be_blank
+          expect(confirm_email.html_part.body.to_s).to have_content("The decomposition of global conformal invariants")
+          expect(confirm_email.html_part.body.to_s).not_to have_content("Wear a mask or face covering")
+        end
+
+        it 'allows patrons to request a digital copy from Lewis' do
+          patron_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/Users/jstudent"
+          stub_request(:get, patron_url)
+            .to_return(status: 200, body: responses[:found], headers: {})
+          transaction_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction"
+          transaction_note_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction/1093806/notes"
+          stub_request(:post, transaction_url)
+            .with(body: hash_including("Username" => "jstudent", "TransactionStatus" => "Awaiting Article Express Processing", "RequestType" => "Article", "ProcessType" => "Borrowing", "WantedBy" => "Yes, until the semester's", "PhotoItemAuthor" => "Alexakis, Spyros", "PhotoArticleAuthor" => "", "PhotoJournalTitle" => "The decomposition of global conformal invariants", "PhotoItemPublisher" => "Princeton: Princeton University Press", "ISSN" => nil, "CallNumber" => "QA646 .A44 2012", "PhotoJournalInclusivePages" => "-", "CitedIn" => "https://catalog.princeton.edu/catalog/7053307", "PhotoJournalYear" => "2012", "PhotoJournalVolume" => "", "PhotoJournalIssue" => "", "ItemInfo3" => "", "ItemInfo4" => "", "CitedPages" => "COVID-19 Campus Closure", "AcceptNonEnglish" => true, "ESPNumber" => "757838203", "DocumentType" => "Book", "Location" => "Lewis Library", "PhotoArticleTitle" => "ABC"))
+            .to_return(status: 200, body: responses[:transaction_created], headers: {})
+          stub_request(:post, transaction_note_url)
+            .to_return(status: 200, body: responses[:note_created], headers: {})
+          visit '/requests/7053307'
+          expect(page).not_to have_content 'Pick-up location: Lewis Library'
+          within('#request_6322174') do
+            fill_in "Article/Chapter Title", with: "ABC"
+          end
+          check 'requestable_selected_6322174'
+          expect { click_button 'Request Selected Items' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          expect(page).to have_content 'Request submitted to Illiad'
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(confirm_email.subject).to eq("Electronic Document Delivery Request Confirmation")
+          expect(confirm_email.to).to eq(["a@b.com"])
+          expect(confirm_email.cc).to be_nil
+          expect(confirm_email.html_part.body.to_s).to have_content("The decomposition of global conformal invariants")
+        end
+
+        it 'allows patrons to ask for digitizing on non circulating items' do
+          visit '/requests/9594840'
+          expect(page).to have_content 'Electronic Delivery'
+          expect(page).not_to have_content 'Pick-up location: Lewis Library'
+          expect(page).to have_css '.submit--request'
+        end
+
+        it 'allows filtering items by mfhd' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .to_return(status: 200, body: good_response, headers: {})
+          visit '/requests/7917192?mfhd=7699134'
+          expect(page).not_to have_content 'Physical Item Delivery'
+          expect(page).to have_content 'Electronic Delivery'
+          expect(page).not_to have_content 'Copy 2'
+          expect(page).not_to have_content 'Copy 3'
+        end
+
+        it 'show all copies if MFHD is not present' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .to_return(status: 200, body: good_response, headers: {})
+          visit '/requests/7917192'
+          expect(page).not_to have_content 'Pick-up location: Lewis Library'
+          expect(page).to have_content 'Electronic Delivery'
+          expect(page).to have_content 'Copy 2'
+          expect(page).to have_content 'Copy 3'
+        end
+
+        it 'disallow filin forms' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .to_return(status: 200, body: good_response, headers: {})
+          visit 'requests/10574699'
+          expect(page).not_to have_button('Request this Item')
+          expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))
+        end
+
+        # TODO: once Marquad in library use is available again it should show pickup at marquand also
+        it 'Shows marqaund as an EDD option only' do
+          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
+            .to_return(status: 200, body: good_response, headers: {})
+          visit '/requests/11780965?mfhd=11443781'
+          # choose('requestable__delivery_mode_8298341_edd') # chooses 'edd' radio button
+          expect(page).to have_content 'Electronic Delivery'
+          expect(page).not_to have_content 'Physical Item Delivery'
+          expect(page).to have_content 'Article/Chapter Title (Required)'
+          fill_in "Title", with: "my stuff"
+          expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          email = ActionMailer::Base.deliveries.last
+          expect(email.subject).to eq("Electronic Document Delivery Request Confirmation")
+          expect(email.html_part.body.to_s).to have_content("You will receive an email including a link where you can download your scanned section")
+        end
+
+        it "shows items in the Architecture Library as available" do
+          patron_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/Users/jstudent"
+          stub_request(:get, patron_url)
+            .to_return(status: 200, body: responses[:found], headers: {})
+          transaction_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction"
+          transaction_note_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction/1093806/notes"
+          stub_request(:post, transaction_url)
+            .with(body: hash_including("Username" => "jstudent", "TransactionStatus" => "Awaiting Article Express Processing", "RequestType" => "Article", "ProcessType" => "Borrowing", "NotWantedAfter" => "02/19/2021", "WantedBy" => "Yes, until the semester's", "PhotoItemAuthor" => "Steele, James", "PhotoArticleAuthor" => "", "PhotoJournalTitle" => "Abdelhalim Ibrahim Abdelhalim : an architecture of collective memory", "PhotoItemPublisher" => "New York, NY: The American University...", "ISSN" => nil, "CallNumber" => "NA1585.A23 S7 2020", "PhotoJournalInclusivePages" => "-", "CitedIn" => "https://catalog.princeton.edu/catalog/11787671", "PhotoJournalYear" => "2020", "PhotoJournalVolume" => "", "PhotoJournalIssue" => "", "ItemInfo3" => "", "ItemInfo4" => "", "CitedPages" => "COVID-19 Campus Closure", "AcceptNonEnglish" => true, "ESPNumber" => "1137152638", "DocumentType" => "Book", "Location" => "Architecture Library - New Book Shelf", "PhotoArticleTitle" => "ABC"))
+            .to_return(status: 200, body: responses[:transaction_created], headers: {})
+          stub_request(:post, transaction_note_url)
+            .to_return(status: 200, body: responses[:note_created], headers: {})
+          visit '/requests/11787671'
+          expect(page).to have_content 'Electronic Delivery'
+          expect(page).not_to have_content 'Physical Item Delivery'
+          expect(page).not_to have_content 'Pick-up location: Architecture Library'
+          fill_in "Article/Chapter Title", with: "ABC"
+          expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(confirm_email.subject).to eq("Electronic Document Delivery Request Confirmation")
+          expect(confirm_email.html_part.body.to_s).to have_content("Electronic document delivery requests typically take 1-2 business")
+          expect(confirm_email.html_part.body.to_s).to have_content("Abdelhalim Ibrahim Abdelhalim : an architecture of collective memory")
+        end
+
+        it "disallows requests of recap pickup only items" do
+          visit '/requests/11578319?mfhd=11259604'
+          expect(page).not_to have_button('Request this Item')
+          expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))
+        end
+
+        it 'disallows aeon requests' do
+          visit '/requests/336525'
+          expect(page).not_to have_content 'Request to View in Reading Room'
+        end
+
+        it 'allows guest patrons to access Online items' do
+          visit '/requests/9994692'
+          expect(page).to have_content 'www.jstor.org'
+        end
+
+        it 'prohibits using Borrow Direct, ILL, and Recall on Missing items' do
+          visit '/requests/1788796?mfhd=2053005'
+          expect(page).not_to have_button('Request this Item')
+          expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))
+        end
+
+        it 'disallows generic fill in requests enums from Annex or Firestone in mixed holding' do
+          visit '/requests/2286894'
+          expect(page).not_to have_field 'requestable__selected', disabled: false
+          expect(page).to have_field 'requestable_selected_7484608', disabled: false
+          expect(page).not_to have_field 'requestable_user_supplied_enum_2576882'
+          expect(page).to have_content 'Electronic Delivery'
+        end
+
+        it 'allows a non circulating item with not item data to be digitized' do
+          patron_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/Users/jstudent"
+          transaction_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction"
+          transaction_note_url = "https://lib-illiad.princeton.edu/ILLiadWebPlatform/transaction/1093806/notes"
+          stub_request(:get, patron_url)
+            .to_return(status: 200, body: responses[:found], headers: {})
+          stub_request(:post, transaction_url)
+            .with(body: hash_including("Username" => "jstudent", "TransactionStatus" => "Awaiting Article Express Processing", "RequestType" => "Article", "ProcessType" => "Borrowing", "WantedBy" => "Yes, until the semester's", "PhotoArticleAuthor" => "I Aman Author", "PhotoItemAuthor" => "Herzog, Hans-Michael Daros Collection (Art)", "PhotoJournalTitle" => "La mirada : looking at photography in Latin America today", "PhotoItemPublisher" => "Zürich: Edition Oehrli", "PhotoJournalIssue" => "",
+                                       "Location" => "Marquand Library", "ISSN" => nil, "CallNumber" => "", "PhotoJournalInclusivePages" => "-", "CitedIn" => "https://catalog.princeton.edu/catalog/4127409", "PhotoJournalVolume" => "", "ItemInfo3" => "", "ItemInfo4" => "", "CitedPages" => "COVID-19 Campus Closure", "AcceptNonEnglish" => true, "ESPNumber" => "", "DocumentType" => "Book", "PhotoArticleTitle" => "ABC", "PhotoJournalYear" => "2002"))
+            .to_return(status: 200, body: responses[:transaction_created], headers: {})
+          stub_request(:post, transaction_note_url)
+            .to_return(status: 200, body: responses[:note_created], headers: {})
+          visit '/requests/4127409?mfhd=4403772'
+          expect(page).to have_content 'Electronic Delivery'
+          fill_in "Article/Chapter Title", with: "ABC"
+          fill_in "Author", with: "I Aman Author"
+          expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(1)
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(confirm_email.subject).to eq("Electronic Document Delivery Request Confirmation")
+          expect(confirm_email.html_part.body.to_s).to have_content("Electronic document delivery requests typically take 1-2 business days to process")
+          expect(confirm_email.html_part.body.to_s).to have_content("La mirada : looking at photography in Latin America today")
+        end
+      end
+    end
+  end
   # rubocop:enable RSpec/MultipleExpectations
 end

--- a/spec/fixtures/bibdata_patron_no_barcode_response.json
+++ b/spec/fixtures/bibdata_patron_no_barcode_response.json
@@ -1,0 +1,14 @@
+{
+    "netid": "jstudent",
+    "first_name": "Joe",
+    "last_name": "Student",
+    "barcode": null,
+    "barcode_status": 1,
+    "barcode_status_date": "2015-01-06T23:00:02.000-05:00",
+    "university_id": "960594184",
+    "patron_group": "staff",
+    "purge_date": "2016-10-31T23:00:03.000-05:00",
+    "expire_date": "2022-10-31T23:00:03.000-05:00",
+    "patron_id": 77777,
+    "active_email": "a@b.com"
+}

--- a/spec/helpers/requests/application_helper_spec.rb
+++ b/spec/helpers/requests/application_helper_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
     let(:params) do
       {
         system_id: '8179402',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_items_on_reserve) { Requests::Request.new(params) }
@@ -37,7 +38,8 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       let(:params) do
         {
           system_id: '9222024',
-          user: user
+          user: user,
+          user_barcode: '111122223333'
         }
       end
       it 'returns a boolean to enable submit for logged in user' do
@@ -55,7 +57,8 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       let(:params) do
         {
           system_id: '3848872',
-          user: user
+          user: user,
+          user_barcode: '111122223333'
         }
       end
       it 'lewis is a submitable request' do
@@ -71,7 +74,8 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       {
         system_id: '491654',
         mfhd: '534140',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:default_pickups) do
@@ -92,7 +96,8 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       {
         system_id: '426420',
         mfhd: '3538795',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:default_pickups) do
@@ -113,7 +118,8 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       {
         system_id: '7352936',
         mfhd: '7179463',
-        user: unauthenticated_patron
+        user: unauthenticated_patron,
+        user_barcode: '111122223333'
       }
     end
     let(:aeon_only_request) { Requests::Request.new(params) }

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -7,7 +7,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: bad_system_id,
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:bad_request) { described_class.new(params) }
@@ -25,7 +26,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '8880549',
         mfhd: '8805567',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_holding_item) { described_class.new(params) }
@@ -146,7 +148,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '1791763',
         mfhd: '2056183',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_only_holding) { described_class.new(params) }
@@ -174,7 +177,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '490930',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
 
@@ -217,7 +221,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '4758976',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_system_id_only_with_holdings) { described_class.new(params) }
@@ -244,7 +249,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '2478499',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_system_id_only_with_holdings_with_some_items) { described_class.new(params) }
@@ -271,7 +277,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '8179402',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_items_on_reserve) { described_class.new(params) }
@@ -288,7 +295,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '6195942',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_items_at_temp_locations) { described_class.new(params) }
@@ -315,7 +323,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '2385868',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_only_system_id) { described_class.new(params) }
@@ -333,7 +342,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '4759591',
         mfhd: '4978217',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_only_system_id) { described_class.new(params) }
@@ -373,7 +383,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: 'dsp01rr1720547',
         mfhd: 'thesis',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_only_system_id) { described_class.new(params) }
@@ -442,7 +453,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: 'coin-1167/',
         mfhd: 'numismatics',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_only_system_id) { described_class.new(params) }
@@ -510,7 +522,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: 'coin-1167',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_only_system_id) { described_class.new(params) }
@@ -572,7 +585,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '2937003',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_at_paging_outside) { described_class.new(params) }
@@ -629,7 +643,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '4340413',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_at_paging_f) { described_class.new(params) }
@@ -668,7 +683,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9545726',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_at_paging_f) { described_class.new(params) }
@@ -708,7 +724,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9602549',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_on_order) { described_class.new(params) }
@@ -756,7 +773,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '9602551',
         mfhd: '9442918',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_on_order) { described_class.new(params) }
@@ -814,7 +832,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9602545',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_no_callnum) { described_class.new(params) }
@@ -847,7 +866,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '2002206',
         mfhd: '2281830',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_missing) { described_class.new(params) }
@@ -878,7 +898,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9627261',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -899,7 +920,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '616086',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -924,7 +946,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9676483',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -957,7 +980,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '426420',
         mfhd: '464640',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -995,7 +1019,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '9168829',
         mfhd: '9048082',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1019,7 +1044,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '9738136',
         mfhd: '9558038',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1116,7 +1142,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '9907433',
         mfhd: '9723988',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1149,7 +1176,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '495501',
         mfhd: '538750',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1166,7 +1194,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9994692',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1183,7 +1212,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9746776',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1200,7 +1230,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '4815239',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1222,7 +1253,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '495220',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1244,7 +1276,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '7494358',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1272,7 +1305,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '5596067',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1294,7 +1328,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9696811',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1317,7 +1352,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '2631265',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1346,7 +1382,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: '495501',
         mfhd: '538750',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request) { described_class.new(params) }
@@ -1364,7 +1401,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
         system_id: '1969881',
         mfhd: '2246633',
         source: 'pulsearch',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_optional_params) { described_class.new(params) }
@@ -1385,7 +1423,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9712355',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_for_preservation) { described_class.new(params) }
@@ -1401,7 +1440,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '9907486',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_title_author) { described_class.new(params) }
@@ -1427,7 +1467,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '4693146',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_single_aeon_holding) { described_class.new(params) }
@@ -1446,7 +1487,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '2286894',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_fill_in_eligible_holding) { described_class.new(params) }
@@ -1486,7 +1528,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:params) do
       {
         system_id: '3845517',
-        user: user
+        user: user,
+        user_barcode: '111122223333'
       }
     end
     let(:request_with_fill_in_eligible_holding) { described_class.new(params) }
@@ -1508,7 +1551,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: 'SCSB-5290772',
         user: user,
-        source: 'pulsearch'
+        source: 'pulsearch',
+        user_barcode: '111122223333'
       }
     end
     let(:scsb_availability_params) do
@@ -1556,7 +1600,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: 'SCSB-5640725',
         user: user,
-        source: 'pulsearch'
+        source: 'pulsearch',
+        user_barcode: '111122223333'
       }
     end
     let(:scsb_availability_params) do
@@ -1594,7 +1639,8 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       {
         system_id: 'SCSB-7935196',
         user: user,
-        source: 'pulsearch'
+        source: 'pulsearch',
+        user_barcode: '111122223333'
       }
     end
     let(:scsb_availability_params) do

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -424,7 +424,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
   end
 
   context 'A Recap Marquand holding' do
-    let(:requestable) { Requests::Requestable.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'blah' } }], location: { "holding_library" => { "code" => "marquand" } }) }
+    let(:requestable) { Requests::Requestable.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'blah' } }], location: { "holding_library" => { "code" => "marquand" } }, user_barcode: '111222333') }
 
     describe '#site' do
       it 'returns a Marquand site param' do
@@ -582,7 +582,8 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     let(:params) do
       {
         system_id: '9999800',
-        user: user
+        user: user,
+        user_barcode: '111222333'
       }
     end
     let(:request) { Requests::Request.new(params) }
@@ -687,7 +688,8 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     let(:params) do
       {
         system_id: '9999800',
-        user: user
+        user: user,
+        user_barcode: '111222333'
       }
     end
     let(:request) { Requests::Request.new(params) }
@@ -753,7 +755,8 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     let(:params) do
       {
         system_id: '9999800',
-        user: user
+        user: user,
+        user_barcode: '111222333'
       }
     end
     let(:request) { Requests::Request.new(params) }
@@ -863,7 +866,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
   describe "#will_submit_via_form?" do
     let(:location) { {} }
     let(:item_data) {}
-    let(:requestable) { described_class.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'abc' } }], item: item_data, location: location) }
+    let(:requestable) { described_class.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'abc' } }], item: item_data, location: location, user_barcode: '111222333') }
     let(:services) { [] }
     let(:on_reserve) { false }
     let(:traceable) { false }

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -10,7 +10,8 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :new
       {
         system_id: 'SCSB-2635660',
         user: user,
-        source: 'CUL'
+        source: 'CUL',
+        user_barcode: '111222333'
       }
     end
     let(:scsb_availability_params) do


### PR DESCRIPTION
fixes #772

Allows access to only digitizing for non barcoded users
![Screen Shot 2020-08-19 at 10 57 07 AM](https://user-images.githubusercontent.com/1599081/90651210-c15efe80-e20a-11ea-972b-22de2559df39.png)
Allows both for regular users
![Screen Shot 2020-08-19 at 10 56 52 AM](https://user-images.githubusercontent.com/1599081/90651222-c3c15880-e20a-11ea-9784-bfa8db6fcbd4.png)

For items that only show pickup as an option (in process, on order, holdings with no items) a message is output
![Screen Shot 2020-08-19 at 11 03 18 AM](https://user-images.githubusercontent.com/1599081/90651988-a80a8200-e20b-11ea-988d-40afb0f6ce4f.png)

Vs the normal pickup only options:
![Screen Shot 2020-08-19 at 11 01 47 AM](https://user-images.githubusercontent.com/1599081/90651873-8b6e4a00-e20b-11ea-98ce-8d87f90ddd8d.png)

