### PR TITLE
Adding link to libcal for items that do not circulate

### DIFF
--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -310,6 +310,8 @@ module Requests
     def status_label(requestable)
       if requestable.charged?
         content_tag(:span, 'Not Available', class: "availability--label badge-alert badge badge-danger")
+      elsif !requestable.circulates?
+        content_tag(:span, 'On-site access', class: "availability--label badge badge-success")
       else
         content_tag(:span, 'Available', class: "availability--label badge badge-success")
       end

--- a/app/views/requests/request/_requestable_form.html.erb
+++ b/app/views/requests/request/_requestable_form.html.erb
@@ -1,3 +1,6 @@
+<% if requestable.available_for_appointment? %>
+  <%= render partial: "requestable_make_appointment", locals: { requestable: requestable, single_item_request: @request.single_item_request? } %>
+<% end %>
 <% if requestable.help_me? %>
   <%= render partial: 'requestable_form_help_me', locals: { requestable: requestable } %>
 <% elsif requestable.digitize? && requestable.pick_up? %>

--- a/app/views/requests/request/_requestable_make_appointment.html.erb
+++ b/app/views/requests/request/_requestable_make_appointment.html.erb
@@ -1,0 +1,8 @@
+<tr class='request--make-appointment' id='request_online_items_<%= "#{requestable.holding.keys[0]}" %>'>
+  <td class='request--select'></td>
+  <td class='request--enum'></td>
+  <%= render partial: 'requestable_status', locals: { requestable: requestable } %>
+  <td>
+    Please utilize our study-browse service to <%= link_to I18n.t('requests.appointment.request_label'), requestable.libcal_url, target: :_blank %> to come in a view the item in the Library    
+  </td>
+</tr>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -179,6 +179,8 @@ en:
       brief_msg: "Trace a Missing Item. Library staff will search for this item and contact you with an outcome."
       email_conf_msg: "Our Circulation Department will search for the material you cannot find. You will receive an email notification if the item is found or if the search is unsucessful. If possible please request the material in question via Borrow Direct or Interlibrary Loan."
       access_msg: 'Access Users are not eligible for trace requests.'
+    appointment:
+      request_label: "make an appointment"
     account:
       netid_login_msg: "Princeton faculty, staff, and students log in with NetID"
       barcode_login_msg: "Log in with a barcode (affiliates, family members, guest borrowers, etc)"

--- a/spec/cassettes/request_features.yml
+++ b/spec/cassettes/request_features.yml
@@ -19772,4 +19772,168 @@ http_interactions:
         258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false}]}'
     http_version: null
   recorded_at: Wed, 02 Sep 2020 13:57:46 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/5636487/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.0
+      Date:
+      - Thu, 03 Sep 2020 16:50:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - b6051b4e-5d6e-45c9-a715-b412ce6fe791
+      X-Download-Options:
+      - noopen
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"46472385197cc1a5983c5d3515990e2d"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.013072'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger 6.0.6
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6IjU2MzY0ODciLCJudW1lcmljX2lkX2IiOnRydWUsImF1dGhvcl9kaXNwbGF5IjpbIkpvaG5zLCBDYXRoZXJpbmUiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiSm9obnMsIENhdGhlcmluZSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltdLFwidHJhbnNsYXRvcnNcIjpbXSxcImVkaXRvcnNcIjpbXSxcImNvbXBpbGVyc1wiOltdLFwicHJpbWFyeV9hdXRob3JcIjpcIkpvaG5zLCBDYXRoZXJpbmVcIn0iLCJhdXRob3JfcyI6WyJKb2hucywgQ2F0aGVyaW5lIl0sIm1hcmNfcmVsYXRvcl9kaXNwbGF5IjpbIkF1dGhvciJdLCJ0aXRsZV9kaXNwbGF5IjoiRG9ncyA6IGhpc3RvcnksIG15dGgsIGFydCAvIENhdGhlcmluZSBKb2hucy4iLCJ0aXRsZV90IjpbIkRvZ3MgOiBoaXN0b3J5LCBteXRoLCBhcnQgLyBDYXRoZXJpbmUgSm9obnMuIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiRG9ncyA6IGhpc3RvcnksIG15dGgsIGFydCJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiRG9ncyA6IGhpc3RvcnksIG15dGgsIGFydCAvIENhdGhlcmluZSBKb2hucy4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJDYW1icmlkZ2UsIE1hc3MuIDogSGFydmFyZCBVbml2ZXJzaXR5IFByZXNzLCAyMDA4LiJdLCJwdWJfY3JlYXRlZF9zIjpbIkNhbWJyaWRnZSwgTWFzcy4gOiBIYXJ2YXJkIFVuaXZlcnNpdHkgUHJlc3MsIDIwMDguIl0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIkNhbWJyaWRnZSwgTWFzczogSGFydmFyZCBVbml2ZXJzaXR5IFByZXNzIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAwOCJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDA4LCJjYXRhbG9nZWRfdGR0IjoiMjAwOS0wMS0yM1QxMjozNzo1MFoiLCJmb3JtYXQiOlsiQm9vayJdLCJkZXNjcmlwdGlvbl9kaXNwbGF5IjpbIjIwOCBwLiA6IGlsbC4gKGNoaWVmbHkgY29sLikgOyAyMyBjbS4iXSwiZGVzY3JpcHRpb25fdCI6WyIyMDggcC4gOiBpbGwuIChjaGllZmx5IGNvbC4pIDsgMjMgY20uIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjIwOCBwLiJdLCJiaWJfcmVmX25vdGVzX2Rpc3BsYXkiOlsiSW5jbHVkZXMgYmlibGlvZ3JhcGhpY2FsIHJlZmVyZW5jZXMgKHAuIDIwMSkgYW5kIGluZGV4LiJdLCJsYW5ndWFnZV9mYWNldCI6WyJFbmdsaXNoIl0sImxhbmd1YWdlX2NvZGVfcyI6WyJlbmciXSwibGFuZ3VhZ2VfaWFuYV9zIjpbImVuIl0sImxjX3N1YmplY3RfZGlzcGxheSI6WyJEb2dzIGluIGFydCIsIkRvZ3PigJRIaXN0b3J5IiwiRG9nc+KAlE15dGhvbG9neSJdLCJzdWJqZWN0X2ZhY2V0IjpbIkRvZ3MgaW4gYXJ0IiwiRG9nc+KAlEhpc3RvcnkiLCJEb2dz4oCUTXl0aG9sb2d5Il0sImlzYm5fZGlzcGxheSI6WyI5NzgwNjc0MDMwOTMwIChhbGsuIHBhcGVyKSIsIjA2NzQwMzA5MzEgKGFsay4gcGFwZXIpIl0sImxjY25fZGlzcGxheSI6WyIgIDIwMDgwMTIwMzMiXSwibGNjbl9zIjpbIjIwMDgwMTIwMzMiXSwiaXNibl9zIjpbIjk3ODA2NzQwMzA5MzAiXSwib2NsY19zIjpbIjIxMzQ5NTMxOSJdLCJvdGhlcl92ZXJzaW9uX3MiOlsib2NuMjEzNDk1MzE5IiwiOTc4MDY3NDAzMDkzMCIsIm9jbjI2MDUxODA3NyJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjU3NDQyNDhcIjp7XCJsb2NhdGlvblwiOlwiTWFycXVhbmQgTGlicmFyeVwiLFwibGlicmFyeVwiOlwiTWFycXVhbmQgTGlicmFyeVwiLFwibG9jYXRpb25fY29kZVwiOlwic2FcIixcImNhbGxfbnVtYmVyXCI6XCJONzY2OC5ENiBKNjQgMjAwOFwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJONzY2OC5ENiBKNjQgMjAwOFwifX0iLCJsb2NhdGlvbl9jb2RlX3MiOlsic2EiXSwibG9jYXRpb24iOlsiTWFycXVhbmQgTGlicmFyeSJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIk1hcnF1YW5kIExpYnJhcnkiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJzYSIsIk1hcnF1YW5kIExpYnJhcnkiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJKb2hucywgQ2F0aGVyaW5lLiBEb2dzIl0sImNhbGxfbnVtYmVyX2Rpc3BsYXkiOlsiTjc2NjguRDYgSjY0IDIwMDgiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiTjc2NjguRDYgSjY0IDIwMDgiXSwiX3ZlcnNpb25fIjoxNjYxOTk4NzEzMzY4NzM5ODQwLCJ0aW1lc3RhbXAiOiIyMDIwLTAzLTIzVDIzOjE4OjA2Ljc3OFoifQ==
+    http_version: null
+  recorded_at: Thu, 03 Sep 2020 16:50:17 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?id=5636487
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.0
+      Date:
+      - Thu, 03 Sep 2020 16:50:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"4eb6e5c02b7cafb3e0fd7a07597f9a2d"
+      X-Runtime:
+      - '0.118035'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - ff04972f-b3de-409c-ad2d-7e607bba406b
+      X-Powered-By:
+      - Phusion Passenger 6.0.5
+    body:
+      encoding: UTF-8
+      string: '{"5744248":{"more_items":false,"location":"sa","copy_number":1,"item_id":5214248,"on_reserve":"N","patron_group_charged":null,"status":"On-Site","label":"Marquand
+        Library"}}'
+    http_version: null
+  recorded_at: Thu, 03 Sep 2020 16:50:17 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/availability?mfhd=5744248
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.0
+      Date:
+      - Thu, 03 Sep 2020 16:50:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Etag:
+      - W/"5065cc40e1312b43b9ae0859624a3da0"
+      X-Runtime:
+      - '0.063785'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - 294e6b4d-ac12-4552-b783-4e526f398f19
+      X-Powered-By:
+      - Phusion Passenger 6.0.5
+    body:
+      encoding: UTF-8
+      string: '[{"barcode":"32101072349515","id":5214248,"location":"sa","copy_number":1,"item_sequence_number":1,"status":"On-Site","on_reserve":"N","item_type":"Closed","pickup_location_id":299,"pickup_location_code":"fcirc","patron_group_charged":null,"label":"Marquand
+        Library"}]'
+    http_version: null
+  recorded_at: Thu, 03 Sep 2020 16:50:18 GMT
 recorded_with: VCR 5.1.0

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -718,7 +718,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
           stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem")
             .with(body: hash_including(author: "", bibId: "SCSB-2879206", callNumber: "ML3477 .G74 1989g", chapterTitle: "ABC", deliveryLocation: "", emailAddress: "a@b.com", endPage: "", issue: "", itemBarcodes: ["CU61436348"], itemOwningInstitution: "CUL", patronBarcode: "22101008199999", requestNotes: "", requestType: "EDD", requestingInstitution: "PUL", startPage: "", titleIdentifier: "Let's face the music : the golden age of popular song", username: "jstudent", volume: ""))
             .to_return(status: 200, body: good_response, headers: {})
-          visit '/requests//SCSB-2879206'
+          visit '/requests/SCSB-2879206'
           expect(page).not_to have_content 'Physical Item Delivery'
           expect(page).to have_content 'Electronic Delivery'
           choose('requestable__delivery_mode_4497920_edd') # chooses 'edd' radio button
@@ -733,6 +733,13 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
           expect(confirm_email.html_part.body.to_s).to have_content("ABC")
           expect(confirm_email.html_part.body.to_s).not_to have_content("Wear a mask or face covering")
           expect(confirm_email.html_part.body.to_s).not_to have_content("Please do not use disinfectant or cleaning product on books")
+        end
+
+        it "Shows a Appointment link for a marquand in library use item" do
+          visit '/requests/5636487'
+          expect(page).not_to have_content 'Physical Item Delivery'
+          expect(page).to have_content 'Electronic Delivery'
+          expect(page).to have_link('make an appointment', href: "https://libcal.princeton.edu/seats?lid=10656")
         end
       end
     end

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -27,6 +27,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
         expect(stackmap_url).to include("#{requestable.bib[:id]}/stackmap?cn=#{call_number}&loc=#{location_code}")
       end
     end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
+      end
+    end
   end
 
   context "Is a bibliographic record from the thesis collection" do
@@ -67,6 +73,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     describe '#location_label' do
       it 'has a location label' do
         expect(requestable.location_label).to eq('Mudd Manuscript Library')
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
       end
     end
   end
@@ -111,6 +123,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
         expect(requestable.location_label).to eq('Special Collections - Numismatics Collection')
       end
     end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
+      end
+    end
   end
 
   context 'A requestable item with a missing status' do
@@ -153,6 +171,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
           expect(requestable.first.location_label).to eq('Firestone Library')
         end
       end
+
+      describe '#libcal_url' do
+        it "is available for appointment" do
+          expect(requestable.first.libcal_url).to be_nil
+        end
+      end
     end
   end
 
@@ -180,6 +204,13 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     describe '#location_label' do
       it 'has a location label' do
         expect(requestable_on_hold.location_label).to eq('ReCAP')
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable_on_hold.libcal_url).to be_nil
+        expect(requestable_not_on_hold.libcal_url).to be_nil
       end
     end
   end
@@ -225,6 +256,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
           expect(requestable.first.location_label).to eq('Firestone Library')
         end
       end
+
+      describe '#libcal_url' do
+        it "is available for appointment" do
+          expect(requestable.first.libcal_url).to be_nil
+        end
+      end
     end
   end
 
@@ -251,6 +288,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
         expect(requestable.location_label).to eq('Firestone Library')
       end
     end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to eq("https://libcal.princeton.edu/seats?lid=1919")
+      end
+    end
   end
 
   context 'A circulating item' do
@@ -274,6 +317,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     describe '#location_label' do
       it 'has a location label' do
         expect(requestable.location_label).to eq('Firestone Library')
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
       end
     end
   end
@@ -306,6 +355,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
         expect(requestable.location_label).to eq('East Asian Library - Rare Books')
       end
     end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
+      end
+    end
   end
 
   context 'A requestable serial item that has volume and item data in its openurl' do
@@ -326,6 +381,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     describe '#location_label' do
       it 'has a location label' do
         expect(requestable.location_label).to eq('ReCAP - Rare Books Off-Site Storage')
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
       end
     end
   end
@@ -356,6 +417,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     describe '#location_label' do
       it 'has a location label' do
         expect(requestable.location_label).to eq('Special Collections - Rare Books')
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
       end
     end
   end
@@ -389,6 +456,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
         expect(requestable.location_label).to eq('Special Collections - Rare Books')
       end
     end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
+      end
+    end
   end
 
   context 'A MUDD holding' do
@@ -403,7 +476,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     end
   end
 
-  context 'A Marquand holding' do
+  context 'A Recap Marquand holding' do
     let(:user) { FactoryGirl.build(:user) }
     let(:request) { FactoryGirl.build(:aeon_marquand) }
     let(:requestable) { request.requestable.first } # assume only one requestable
@@ -421,14 +494,43 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
         expect(requestable.location_label).to eq('ReCAP - Marquand Library (Rare) use only')
       end
     end
+
+    describe '#available_for_appointment?' do
+      it "is available for appointment" do
+        expect(requestable.available_for_appointment?).to be_falsey
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
+      end
+    end
   end
 
-  context 'A Recap Marquand holding' do
-    let(:requestable) { Requests::Requestable.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'blah' } }], location: { "holding_library" => { "code" => "marquand" } }, user_barcode: '111222333') }
+  context 'A Non-Recap Marquand holding' do
+    let(:requestable) { Requests::Requestable.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'blah' } }], location: { "holding_library" => { "code" => "marquand" }, "library" => { "code" => "marquand" } }, user_barcode: '111222333') }
 
     describe '#site' do
       it 'returns a Marquand site param' do
         expect(requestable.in_library_use_only?).to be_truthy
+      end
+    end
+    describe '#available_for_appointment?' do
+      it "is available for appointment" do
+        expect(requestable.available_for_appointment?).to be_truthy
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to eq('https://libcal.princeton.edu/seats?lid=10656')
       end
     end
   end
@@ -520,6 +622,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
         expect(requestable.location_label).to eq('ReCAP - Rare Books Off-Site Storage')
       end
     end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
+      end
+    end
   end
 
   context 'A requestable item from Forrestal Annex with no item data' do
@@ -536,6 +644,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     describe '#location_label' do
       it 'has a location label' do
         expect(requestable.location_label).to eq('Forrestal Annex - Princeton Collection')
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
       end
     end
   end
@@ -556,6 +670,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
         expect(requestable.location_label).to eq('Firestone Library')
       end
     end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
+      end
+    end
   end
 
   context 'Pending Order materials' do
@@ -572,6 +692,12 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     describe '#location_label' do
       it 'has a location label' do
         expect(requestable.location_label).to eq('ReCAP - Marquand Library use only')
+      end
+    end
+
+    describe '#libcal_url' do
+      it "is available for appointment" do
+        expect(requestable.libcal_url).to be_nil
       end
     end
   end


### PR DESCRIPTION
Adds a link to the study browse service for viewing items in the library.
![Screen Shot 2020-09-08 at 10 29 15 AM](https://user-images.githubusercontent.com/1599081/92490669-4c566780-f1bf-11ea-90a5-9265ec444517.png)
