### PR TITLE
Removing AR collection from the in library use

### DIFF
--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -96,9 +96,9 @@ module Requests
       def calculate_recap_services
         if !requestable.item_data?
           ['recap_no_items']
-        elsif requestable.scsb_in_library_use?
+        elsif requestable.scsb_in_library_use? && requestable.item[:collection_code] != "MR"
           ['recap_in_library']
-        elsif !requestable.circulates? && !requestable.recap_edd?
+        elsif (!requestable.circulates? || requestable.scsb_in_library_use?) && !requestable.recap_edd?
           ['ask_me']
         elsif auth_user?
           services = []

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -70,12 +70,13 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
     end
 
     describe "calculate_services" do
+      let(:item) { {} }
       let(:stubbed_questions) do
         { voyager_managed?: true, online?: false, in_process?: false,
           charged?: false, on_order?: false, aeon?: false,
           preservation?: false, annexa?: false, annexb?: false,
           plasma?: false, lewis?: false, recap?: false,
-          item_data?: false, recap_edd?: false, pageable?: false, scsb_in_library_use?: false }
+          item_data?: false, recap_edd?: false, pageable?: false, scsb_in_library_use?: false, item: item }
       end
       let(:requestable) { instance_double(Requests::Requestable, stubbed_questions) }
 
@@ -205,6 +206,37 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
           end
           it "returns recap_no_items in the services" do
             expect(router.calculate_services).to eq(['recap_no_items'])
+          end
+        end
+
+        context "scsb_in_library_use" do
+          before do
+            stubbed_questions[:scsb_in_library_use?] = true
+          end
+          it "returns recap_in_library in the services" do
+            expect(router.calculate_services).to eq(['recap_in_library'])
+          end
+        end
+
+        context "scsb_in_library_use AR collection" do
+          let(:item) { { collection_code: 'AR' } }
+          before do
+            stubbed_questions[:scsb_in_library_use?] = true
+            stubbed_questions[:recap_edd?] = false
+          end
+          it "returns recap_in_library in the services" do
+            expect(router.calculate_services).to eq(["recap_in_library"])
+          end
+        end
+
+        context "scsb_in_library_use MR collection" do
+          let(:item) { { collection_code: 'MR' } }
+          before do
+            stubbed_questions[:scsb_in_library_use?] = true
+            stubbed_questions[:recap_edd?] = false
+          end
+          it "returns recap_in_library in the services" do
+            expect(router.calculate_services).to eq(["ask_me"])
           end
         end
       end


### PR DESCRIPTION
The equipment is not available during the COVID shutdown.
fixes #820

Used this item as an example: http://localhost:3000/requests/SCSB-8896859?source=pulsearch