### PR TITLE
Add covid training message to unauthorized staff, student, and faculty

### DIFF
--- a/app/models/requests/patron.rb
+++ b/app/models/requests/patron.rb
@@ -62,6 +62,10 @@ module Requests
       campus_authorized || patron[:campus_authorized_category] == "trained"
     end
 
+    def training_eligable?
+      ["staff", "faculty", "student"].include? status
+    end
+
     def telephone
       ldap[:telephone]
     end

--- a/app/views/requests/request/generate.erb
+++ b/app/views/requests/request/generate.erb
@@ -31,7 +31,11 @@
         <% if @patron.pickup_only? %>
           <div class="alert alert-warning">You are only currently authorized to utilize our book <a href='https://library.princeton.edu/services/book-pick-up'>pick-up service</a>. Please consult with your Department if you would like to book time to spend in our libraries using our <a href='https://library.princeton.edu/services/study-browse'>study-browse service</a>.</div>
         <% elsif !@patron.guest? && !@patron.campus_authorized %>
-          <div class="alert alert-warning">You are not currently authorized for on-campus services at the Library. Please consult with your Department if you believe you should have access to these services.</div>
+          <div class="alert alert-warning">You are not currently authorized for on-campus services at the Library. Please consult with your Department if you believe you should have access to these services. 
+          <% if @patron.training_eligable? %>
+            If you would like to have access to pick-up books <a href="https://ehs.princeton.edu/COVIDTraining">please complete the mandatory COVID-19 training</a>.
+          <% end %>
+          </div>
         <% end %>
         <%= render "form" %>
       </div>

--- a/app/views/requests/request_mailer/_covid_library_guidelines.html.erb
+++ b/app/views/requests/request_mailer/_covid_library_guidelines.html.erb
@@ -4,17 +4,6 @@
   <table width="100%" cellpadding="9" class="responsive-table">
                 
     <tr>
-      <td colspan="4" valign="top" width="100%" class="responsive-column-container">
-        <table border="0" cellpadding="10" cellspacing="0" width="100%">
-          <tr>
-            <td style="background-color:#f6f6f6;border-top-style:solid;border-top-width:3px;border-top-color:#e77500;font-weight:bold;text-decoration:underline;" align="center" class="covid-guideline" valign="top">
-              <a href="https://ehs.princeton.edu/COVIDTraining">Prior to coming complete mandatory COVID-19 training</a>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-    <tr>
       <td valign="top" width="25%" height="90" class="responsive-column-container">
         <table border="0" cellpadding="10" cellspacing="0" width="100%">
           <tr>

--- a/app/views/requests/request_mailer/_covid_library_guidelines.text.erb
+++ b/app/views/requests/request_mailer/_covid_library_guidelines.text.erb
@@ -1,4 +1,3 @@
-* Prior to coming complete mandatory COVID-19 training (https://ehs.princeton.edu/COVIDTraining")
 * Book your appointment
 * Retrieve your item at the circulation desk.
 * Wear a mask or face covering

--- a/app/views/requests/request_mailer/_covid_pickup_guidelines.html.erb
+++ b/app/views/requests/request_mailer/_covid_pickup_guidelines.html.erb
@@ -4,17 +4,6 @@
   <table width="100%" cellpadding="9" class="responsive-table">
                 
     <tr>
-      <td colspan="4" valign="top" width="100%" class="responsive-column-container">
-        <table border="0" cellpadding="10" cellspacing="0" width="100%">
-          <tr>
-            <td style="background-color:#f6f6f6;border-top-style:solid;border-top-width:3px;border-top-color:#e77500;font-weight:bold;text-decoration:underline;" align="center" class="covid-guideline" valign="top">
-              <a href="https://ehs.princeton.edu/COVIDTraining">Prior to coming complete mandatory COVID-19 training</a>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-    <tr>
       <td valign="top" width="25%" height="90" class="responsive-column-container">
         <table border="0" cellpadding="10" cellspacing="0" width="100%">
           <tr>

--- a/app/views/requests/request_mailer/_covid_pickup_guidelines.text.erb
+++ b/app/views/requests/request_mailer/_covid_pickup_guidelines.text.erb
@@ -1,4 +1,3 @@
-* Prior to coming complete mandatory COVID-19 training (https://ehs.princeton.edu/COVIDTraining")
 * Please pick-up promptly
 * Remain only in the designated pick-up area
 * Wear a mask or face covering

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -24,6 +24,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
     let(:valid_patron_no_barcode_response) { fixture('/bibdata_patron_no_barcode_response.json') }
     let(:valid_barcode_patron_response) { fixture('/bibdata_patron_response_barcode.json') }
     let(:valid_barcode_patron_pickup_only_response) { fixture('/bibdata_patron_barcode_pickup_only_response.json') }
+    let(:valid_patron_no_campus_response) { fixture('/bibdata_patron_response_no_campus.json') }
     let(:invalid_patron_response) { fixture('/bibdata_not_found_patron_response.json') }
 
     let(:responses) do
@@ -833,6 +834,21 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
         expect(page).not_to have_content 'Electronic Delivery'
         expect(page).not_to have_selector '#request_user_barcode', visible: false
         expect(page).to have_content('You are only currently authorized to utilize our book')
+        expect(page).not_to have_content('If you would like to have access to pick-up books')
+      end
+    end
+
+    context 'A student who has not taken the training' do
+      let(:user) { FactoryGirl.create(:user) }
+      it 'displays a request form for a ReCAP item.' do
+        stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/#{user.uid}?ldap=true")
+          .to_return(status: 200, body: valid_patron_no_campus_response, headers: {})
+        login_as user
+        visit "/requests/#{voyager_id}"
+        expect(page).to have_content 'Electronic Delivery'
+        expect(page).to have_selector '#request_user_barcode', visible: false
+        expect(page).to have_content('You are not currently authorized for on-campus services at the Library. Please consult with your Department if you believe you should have access to these services.')
+        expect(page).to have_content('If you would like to have access to pick-up books')
       end
     end
 

--- a/spec/fixtures/bibdata_patron_response_no_campus.json
+++ b/spec/fixtures/bibdata_patron_response_no_campus.json
@@ -11,5 +11,19 @@
     "expire_date": "2022-10-31T23:00:03.000-05:00",
     "patron_id": 77777,
     "active_email": "a@b.com",
-    "campus_authorized": false
+    "campus_authorized": false,
+    "campus_authorized_category": "none",
+    "ldap": {
+        "netid": "jstudent",
+        "department": "First ",
+        "address": "Box 0000",
+        "telephone": "111-222-3333",
+        "givenname": "Joe",
+        "surname": "Student",
+        "email": "a@b.com",
+        "status": "student",        
+        "pustatus": "undergraduate",
+        "universityid": "960594184",
+        "title": null
+        }
 }

--- a/spec/models/requests/patron_spec.rb
+++ b/spec/models/requests/patron_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# rubocop:disable RSpec/MultipleExpectations
 describe Requests::Patron do
   let(:valid_patron_response) { fixture('/bibdata_patron_response.json') }
   let(:valid_barcode_patron_response) { fixture('/bibdata_patron_response_barcode.json') }
@@ -15,6 +16,7 @@ describe Requests::Patron do
         expect(patron.last_name).to eq('foobar')
         expect(patron.barcode).to eq('ACCESS')
         expect(patron.campus_authorized).to be_falsey
+        expect(patron.training_eligable?).to be_falsey
       end
     end
   end
@@ -24,7 +26,6 @@ describe Requests::Patron do
         stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/foo?ldap=true")
           .to_return(status: 200, body: valid_patron_response, headers: {})
       end
-      # rubocop:disable RSpec/MultipleExpectations
       it 'Handles an authorized princeton net ID holder' do
         patron = described_class.new(user: instance_double(User, guest?: false, uid: 'foo'),
                                      session: { email: 'foo@bar.com', user_name: 'foobar' }.with_indifferent_access)
@@ -35,8 +36,8 @@ describe Requests::Patron do
         expect(patron.telephone).to eq('111-222-3333')
         expect(patron.status).to eq('student')
         expect(patron.pustatus).to eq('undergraduate')
+        expect(patron.training_eligable?).to be_truthy
       end
-      # rubocop:enable RSpec/MultipleExpectations
     end
   end
   context 'A user with a valid barcode patron record' do
@@ -99,3 +100,4 @@ describe Requests::Patron do
     end
   end
 end
+# rubocop:enable RSpec/MultipleExpectations


### PR DESCRIPTION

![Screen Shot 2020-10-01 at 8 11 51 AM](https://user-images.githubusercontent.com/1599081/94811576-8cc29300-03c3-11eb-9fd5-e4d652bb8947.png)
Removes training from emails, since all users requesting books must already be trained