### PR TITLE
Adding a Alma hold request for Princeton owned ReCap items

### DIFF
--- a/app/models/requests/clancy.rb
+++ b/app/models/requests/clancy.rb
@@ -29,6 +29,7 @@ module Requests
       def handle_item(item)
         # place the item on hold
         hold = Requests::HoldItem.new(@submission, service_type: item["type"])
+        hold.handle
 
         if hold.errors.empty?
           # request it from the clancy facility

--- a/app/models/requests/hold_item.rb
+++ b/app/models/requests/hold_item.rb
@@ -4,16 +4,17 @@ module Requests
   class HoldItem
     include Requests::Voyager
 
+    attr_reader :submission, :errors
+
     def initialize(submission, service_type: 'on_shelf')
       @service_type = service_type
       @submission = submission
       @errors = []
       @sent = []
-      handle
     end
 
     def handle
-      items = @submission.filter_items_by_service(@service_type)
+      items = submission.filter_items_by_service(@service_type)
       items.each do |item|
         item_status = handle_item(item: item)
         @sent << item_status unless item_status.blank?
@@ -25,30 +26,28 @@ module Requests
       @sent
     end
 
-    attr_reader :errors
+    def handle_item(item:)
+      status = {}
+      begin
+        status = place_hold(item)
+      rescue Alma::BibRequest::ItemAlreadyExists => exists
+        errors << { reply_text: "Can not create hold", create_hold: { note: "Hold already exists", message: exists.message } }.merge(submission.bib.to_h).merge(item.to_h).with_indifferent_access
+      rescue StandardError => invalid
+        errors << { reply_text: "Can not create hold", create_hold: { note: "Hold can not be created", message: invalid.message } }.merge(submission.bib.to_h).merge(item.to_h).with_indifferent_access
+      end
+      status
+    end
 
     private
 
-      def handle_item(item:)
-        status = {}
-        begin
-          status = place_hold(item)
-        rescue Alma::BibRequest::ItemAlreadyExists => exists
-          errors << { reply_text: "Can not create hold", create_hold: { note: "Hold already exists", message: exists.message } }.merge(@submission.bib.to_h).merge(item.to_h).with_indifferent_access
-        rescue StandardError => invalid
-          errors << { reply_text: "Can not create hold", create_hold: { note: "Hold can not be created", message: invalid.message } }.merge(@submission.bib.to_h).merge(item.to_h).with_indifferent_access
-        end
-        status
-      end
-
       def place_hold(item)
         status = {}
-        options = { mms_id: @submission.bib['id'], holding_id: item["mfhd"], item_pid: item['item_id'], user_id: @submission.patron.university_id, request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: item["pick_up_location_code"] }
+        options = { mms_id: submission.bib['id'], holding_id: item["mfhd"], item_pid: item['item_id'], user_id: submission.patron.university_id, request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: item["pick_up_location_code"] }
         response = Requests::AlmaHoldRequest.submit(options)
         if response.success?
           status = item.merge(payload: options, response: response.raw_response.parsed_response)
         else
-          errors << reponse_json["response"].merge(@submission.bib.to_h).merge(item.to_h).merge(type: @service_type)
+          errors << reponse_json["response"].merge(submission.bib.to_h).merge(item.to_h).merge(type: @service_type)
         end
         status
       end

--- a/app/models/requests/recap.rb
+++ b/app/models/requests/recap.rb
@@ -5,6 +5,8 @@ module Requests
     # include Requests::Gfa
     include Requests::Scsb
 
+    attr_reader :submission
+
     def initialize(submission)
       @service_types = ['recap', 'recap_edd', 'recap_in_library', 'recap_marquand_in_library', 'recap_marquand_edd']
       @submission = submission
@@ -15,7 +17,7 @@ module Requests
 
     def handle
       service_types.each do |service_type|
-        items = @submission.filter_items_by_service(service_type)
+        items = submission.filter_items_by_service(service_type)
         items.each do |item|
           handle_item(item)
         end
@@ -31,19 +33,28 @@ module Requests
     private
 
       def handle_item(item)
-        params = scsb_param_mapping(@submission.bib, @submission.patron, item)
+        params = scsb_param_mapping(submission.bib, submission.patron, item)
         response = scsb_request(params)
         if response.status != 200
           error_message = "Request failed because #{response.body}"
-          @errors << { type: 'recap', bibid: params[:bibId], item: params[:itemBarcodes], user_name: @submission.user_name, barcode: @submission.user_barcode, error: error_message }
+          @errors << { type: 'recap', bibid: params[:bibId], item: params[:itemBarcodes], user_name: submission.user_name, barcode: submission.user_barcode, error: error_message }
         else
           response = parse_scsb_response(response)
           if response[:success] == false
-            @errors << { type: 'recap', bibid: params[:bibId], item: params[:itemBarcodes], user_name: @submission.user_name, barcode: @submission.user_barcode, error: response[:screenMessage] }
+            @errors << { type: 'recap', bibid: params[:bibId], item: params[:itemBarcodes], user_name: submission.user_name, barcode: submission.user_barcode, error: response[:screenMessage] }
           else
-            @sent << { bibid: params[:bibId], item: params[:itemBarcodes], user_name: @submission.user_name, barcode: @submission.user_barcode }
+            @sent << { bibid: params[:bibId], item: params[:itemBarcodes], user_name: submission.user_name, barcode: submission.user_barcode }
+            handle_hold_for_item(item)
           end
         end
+      end
+
+      def handle_hold_for_item(item)
+        return if submission.scsb_item?(item) || submission.edd?(item)
+
+        hold = Requests::HoldItem.new(@submission, service_type: "recap")
+        status = hold.handle_item(item: item)
+        @errors << { type: 'hold-for-recap', error: hold.errors.first } unless status
       end
   end
 end

--- a/app/models/requests/requestable/item.rb
+++ b/app/models/requests/requestable/item.rb
@@ -94,6 +94,10 @@ class Requests::Requestable
       self[:barcode]
     end
 
+    def scsb?
+      ['scsbnypl', 'scsbcul'].include? self["location_code"]
+    end
+
     class NullItem
       def nil?
         true
@@ -189,6 +193,10 @@ class Requests::Requestable
 
       def barcode
         ''
+      end
+
+      def scsb?
+        false
       end
     end
 

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -224,6 +224,9 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           stub_request(:post, Requests.config[:scsb_base])
             .with(headers: { 'Accept' => '*/*' })
             .to_return(status: 200, body: "<document count='1' sent='true'></document>", headers: {})
+          stub_request(:post, "#{Alma.configuration.region}/almaws/v1/bibs/9994933183506421/holdings/22131438430006421/items/23131438400006421/requests?user_id=960594184")
+            .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "firestone"))
+            .to_return(status: 200, body: fixture("alma_hold_response.json"), headers: { 'content-type': 'application/json' })
           visit "/requests/#{voyager_id}"
           expect(page).to have_content 'Electronic Delivery'
           # some weird issue with this and capybara examining the page source shows it is there.
@@ -606,6 +609,9 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           stub_request(:post, scsb_url)
             .with(body: hash_including(author: nil, bibId: "99115783193506421", callNumber: "DVD", chapterTitle: nil, deliveryLocation: "PA", emailAddress: "a@b.com", endPage: nil, issue: nil, itemBarcodes: ["32101108035435"], itemOwningInstitution: "PUL", patronBarcode: "22101008199999", requestNotes: nil, requestType: "RETRIEVAL", requestingInstitution: "PUL", startPage: nil, titleIdentifier: "Chernobyl : a 5-part miniseries", username: "jstudent", volume: nil))
             .to_return(status: 200, body: good_response, headers: {})
+          stub_request(:post, "#{Alma.configuration.region}/almaws/v1/bibs/99115783193506421/holdings/22155047580006421/items/23155047570006421/requests?user_id=960594184")
+            .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "firestone"))
+            .to_return(status: 200, body: fixture("alma_hold_response.json"), headers: { 'content-type': 'application/json' })
           visit '/requests/99115783193506421?mfhd=22155047580006421'
           expect(page).not_to have_content 'Item is not requestable.'
           expect(page).not_to have_content 'Electronic Delivery'
@@ -1113,6 +1119,9 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
             .with(body: hash_including(author: "", bibId: "99117809653506421", callNumber: "N6923.B257 H84 2020", chapterTitle: "", deliveryLocation: "PJ", emailAddress: "a@b.com", endPage: "", issue: "", itemBarcodes: ["32101106347378"], itemOwningInstitution: "PUL", patronBarcode: "22101008199999", requestNotes: "", requestType: "RETRIEVAL", requestingInstitution: "PUL", startPage: "", titleIdentifier: "Alesso Baldovinetti und die Florentiner Malerei der Frührenaissance", username: "jstudent", volume: ""))
             .to_return(status: 200, body: good_response, headers: {})
           visit '/requests/99117809653506421?mfhd=22203397510006421'
+          stub_request(:post, "#{Alma.configuration.region}/almaws/v1/bibs/99117809653506421/holdings/22203397510006421/items/23203397500006421/requests?user_id=960594184")
+            .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "pj"))
+            .to_return(status: 200, body: fixture("alma_hold_response.json"), headers: { 'content-type': 'application/json' })
           choose('requestable__delivery_mode_23203397500006421_in_library') # chooses 'in_library' radio button
           expect(page).to have_content 'Electronic Delivery'
           expect(page).to have_content 'Available for In Library'
@@ -1246,6 +1255,9 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           stub_request(:post, Requests.config[:scsb_base])
             .with(headers: { 'Accept' => '*/*' })
             .to_return(status: 200, body: "<document count='1' sent='true'></document>", headers: {})
+          stub_request(:post, "#{Alma.configuration.region}/almaws/v1/bibs/9994933183506421/holdings/22131438430006421/items/23131438400006421/requests?user_id=960594184")
+            .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "firestone"))
+            .to_return(status: 200, body: fixture("alma_hold_response.json"), headers: { 'content-type': 'application/json' })
           visit "/requests/#{voyager_id}"
           expect(page).to have_content 'Electronic Delivery'
           expect(page).not_to have_content 'Physical Item Delivery'

--- a/spec/models/requests/hold_item_spec.rb
+++ b/spec/models/requests/hold_item_spec.rb
@@ -64,6 +64,7 @@ describe Requests::HoldItem, type: :controller do
         stub_request(:post, stub_url)
           .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "fcirc"))
           .to_return(status: 200, body: responses[:error], headers: { 'content-type': 'application/json' })
+        hold_request.handle
         expect(hold_request.submitted.size).to eq(0)
         expect(hold_request.errors.size).to eq(1)
         expect(hold_request.errors.first[:create_hold][:note]).to eq('Hold already exists')
@@ -73,6 +74,7 @@ describe Requests::HoldItem, type: :controller do
         stub_request(:post, stub_url)
           .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "fcirc"))
           .to_return(status: 400, body: responses[:error_malformed], headers: { 'content-type': 'application/json' })
+        hold_request.handle
         expect(hold_request.submitted.size).to eq(0)
         expect(hold_request.errors.size).to eq(1)
         expect(hold_request.errors.first[:create_hold][:note]).to eq('Hold can not be created')
@@ -82,6 +84,7 @@ describe Requests::HoldItem, type: :controller do
         stub_request(:post, stub_url)
           .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "fcirc"))
           .to_return(status: 200, body: responses[:success], headers: { 'content-type': 'application/json' })
+        hold_request.handle
         expect(hold_request.submitted.size).to eq(1)
         expect(hold_request.errors.size).to eq(0)
         expect(hold_request.submitted.first[:payload][:pickup_location_library]).to eq('fcirc')
@@ -108,6 +111,7 @@ describe Requests::HoldItem, type: :controller do
           stub_request(:post, stub_url)
             .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "fcirc"))
             .to_return(status: 200, body: responses[:success], headers: { 'content-type': 'application/json' })
+          hold_request.handle
           expect(hold_request.submitted.first[:payload][:pickup_location_library]).to eq('fcirc')
         end
       end

--- a/spec/models/requests/recap_spec.rb
+++ b/spec/models/requests/recap_spec.rb
@@ -2,11 +2,15 @@ require 'spec_helper'
 
 describe Requests::Recap do
   context 'ReCAP Request' do
-    let(:valid_patron) { { "netid" => "foo" }.with_indifferent_access }
+    let(:valid_patron) { { "netid" => "foo", "university_id" => "99999999" }.with_indifferent_access }
     let(:user_info) do
       user = instance_double(User, guest?: false, uid: 'foo')
       Requests::Patron.new(user: user, session: {}, patron: valid_patron)
     end
+    let(:scsb_url) { "#{Requests.config[:scsb_base]}/requestItem/requestItem" }
+    let(:alma_url) { "#{Alma.configuration.region}/almaws/v1/bibs/#{bib['id']}/holdings/#{requestable[0]['mfhd']}/items/#{requestable[0]['item_id']}/requests?user_id=99999999" }
+    let(:alma2_url) { "#{Alma.configuration.region}/almaws/v1/bibs/#{bib['id']}/holdings/#{requestable[1]['mfhd']}/items/#{requestable[1]['item_id']}/requests?user_id=99999999" }
+
     let(:requestable) do
       [{ "selected" => "true",
          "mfhd" => "22113812720006421",
@@ -18,7 +22,7 @@ describe Requests::Recap do
          "copy_number" => "1",
          "status" => "Not Charged",
          "type" => "recap",
-         "delivery_mode_6067274" => "print",
+         "delivery_mode_23113812570006421" => "print",
          "edd_start_page" => "",
          "edd_end_page" => "",
          "edd_volume_number" => "",
@@ -27,7 +31,8 @@ describe Requests::Recap do
          "edd_art_title" => "",
          "edd_note" => "",
          "library_code" => "recap",
-         "pick_up" => "PA" },
+         "pick_up" => "PA",
+         "pick_up_location_code" => 'firestone' },
        { "selected" => "true",
          "mfhd" => "22113812720006421",
          "call_number" => "HA202 .U581",
@@ -38,7 +43,7 @@ describe Requests::Recap do
          "copy_number" => "1",
          "status" => "Not Charged",
          "type" => "recap",
-         "delivery_mode_3147971" => "edd",
+         "delivery_mode_23113812580006421" => "edd",
          "edd_start_page" => "1",
          "edd_end_page" => "",
          "edd_volume_number" => "",
@@ -47,7 +52,8 @@ describe Requests::Recap do
          "edd_art_title" => "Baz",
          "edd_note" => "",
          "library_code" => "recap",
-         "pick_up" => "PH" }]
+         "pick_up" => "PH",
+         "pick_up_location_code" => 'mudd' }]
     end
 
     let(:bib) do
@@ -78,43 +84,160 @@ describe Requests::Recap do
 
     describe 'All ReCAP Requests' do
       it "captures errors when the request is unsuccessful or malformed." do
-        stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem").
+        stub_request(:post, scsb_url).
           # with(headers: { 'Accept' => '*/*', 'Content-Type' => "application/json", 'api_key' => 'TESTME' }).
           to_return(status: 401, body: "Unauthorized", headers: {})
         expect(recap_request.submitted.size).to eq(0)
         expect(recap_request.errors.size).to eq(2)
+        expect(a_request(:post, scsb_url)).to have_been_made.twice
+        expect(a_request(:post, alma_url)).not_to have_been_made
+        expect(a_request(:post, alma2_url)).not_to have_been_made
       end
 
       it "captures errors when response is a 200 but the request is unsuccessful" do
-        stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem").
+        stub_request(:post, scsb_url).
           # with(body: good_request, headers: { 'Accept' => '*/*', 'Content-Type' => "application/json", 'api_key' => 'TESTME' }).
           to_return(status: 200, body: bad_response, headers: {})
         expect(recap_request.submitted.size).to eq(0)
         expect(recap_request.errors.size).to eq(2)
+        expect(a_request(:post, scsb_url)).to have_been_made.twice
+        expect(a_request(:post, alma_url)).not_to have_been_made
+        expect(a_request(:post, alma2_url)).not_to have_been_made
       end
 
       it "captures successful request submissions." do
-        stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem").
+        stub_request(:post, scsb_url).
           # with(body: good_request, headers: { 'Accept' => '*/*', 'Content-Type' => "application/json", 'api_key' => 'TESTME' }).
           to_return(status: 200, body: good_response, headers: {})
+        stub_request(:post, alma_url)
+          .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "firestone"))
+          .to_return(status: 200, body: fixture("alma_hold_response.json"), headers: { 'content-type': 'application/json' })
+        stub_request(:post, alma2_url)
+          .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "mudd"))
+          .to_return(status: 200, body: fixture("alma_hold_response.json"), headers: { 'content-type': 'application/json' })
         expect(recap_request.submitted.size).to eq(2)
         expect(recap_request.errors.size).to eq(0)
+        expect(a_request(:post, scsb_url)).to have_been_made.twice
+        expect(a_request(:post, alma_url)).to have_been_made
+        expect(a_request(:post, alma2_url)).not_to have_been_made
       end
 
       context 'when the SCSB web service responds with an invalid response' do
         subject(:recap) { described_class.new(submission) }
 
-        before(:context) do
-          stub_request(:post, "#{Requests.config[:scsb_base]}/requestItem/requestItem").to_return(status: 200, body: '{invalid', headers: {})
-        end
-
+        # rubocop:disable RSpec/MultipleExpectations
         it 'logs an error' do
+          stub_request(:post, scsb_url).to_return(status: 200, body: '{invalid', headers: {})
           allow(Rails.logger).to receive(:error)
 
           expect(recap.submitted.size).to eq(0)
           expect(recap.errors.size).to eq(2)
           expect(Rails.logger).to have_received(:error).with(/Invalid response from the SCSB server/).twice
+          expect(a_request(:post, scsb_url)).to have_been_made.twice
+          expect(a_request(:post, alma_url)).not_to have_been_made
+          expect(a_request(:post, alma2_url)).not_to have_been_made
         end
+        # rubocop:enable RSpec/MultipleExpectations
+      end
+    end
+  end
+
+  context 'ReCAP SCSB Print Request' do
+    let(:valid_patron) { { "netid" => "foo", "university_id" => "99999999" }.with_indifferent_access }
+    let(:user_info) do
+      user = instance_double(User, guest?: false, uid: 'foo')
+      Requests::Patron.new(user: user, session: {}, patron: valid_patron)
+    end
+    let(:scsb_url) { "#{Requests.config[:scsb_base]}/requestItem/requestItem" }
+    let(:alma_url) { "#{Alma.configuration.region}/almaws/v1/bibs/#{bib['id']}/holdings/#{requestable[0]['mfhd']}/items/#{requestable[0]['item_id']}/requests?user_id=99999999" }
+    let(:alma2_url) { "#{Alma.configuration.region}/almaws/v1/bibs/#{bib['id']}/holdings/#{requestable[1]['mfhd']}/items/#{requestable[1]['item_id']}/requests?user_id=99999999" }
+
+    let(:requestable) do
+      [{ "selected" => "true",
+         "mfhd" => "22113812720006421",
+         "call_number" => "HA202 .U581",
+         "location_code" => "recap$pa",
+         "item_id" => "23113812570006421",
+         "barcode" => "32101082413400",
+         "enum_display" => "1956",
+         "copy_number" => "1",
+         "status" => "Not Charged",
+         "type" => "recap",
+         "delivery_mode_23113812570006421" => "print",
+         "edd_start_page" => "",
+         "edd_end_page" => "",
+         "edd_volume_number" => "",
+         "edd_issue" => "",
+         "edd_author" => "",
+         "edd_art_title" => "",
+         "edd_note" => "",
+         "library_code" => "recap",
+         "pick_up" => "PA",
+         "pick_up_location_code" => 'firestone' },
+       { "selected" => "true",
+         "mfhd" => "22113812720006421",
+         "call_number" => "HA202 .U581",
+         "location_code" => "scsbcul",
+         "item_id" => "23113812580006421",
+         "barcode" => "32101094934260",
+         "enum_display" => "1947",
+         "copy_number" => "1",
+         "status" => "Not Charged",
+         "type" => "recap",
+         "delivery_mode_23113812580006421" => "print",
+         "edd_start_page" => "",
+         "edd_end_page" => "",
+         "edd_volume_number" => "",
+         "edd_issue" => "",
+         "edd_author" => "",
+         "edd_art_title" => "",
+         "edd_note" => "",
+         "library_code" => "recap",
+         "pick_up" => "PH",
+         "pick_up_location_code" => 'mudd' }]
+    end
+
+    let(:bib) do
+      {
+        "id" => "994916543506421",
+        "title" => "County and city data book.",
+        "author" => "United States",
+        "date" => "1949"
+      }
+    end
+
+    let(:params) do
+      {
+        request: user_info,
+        requestable: requestable,
+        bib: bib
+      }
+    end
+
+    let(:submission) do
+      Requests::Submission.new(params, user_info)
+    end
+
+    let(:recap_request) { described_class.new(submission) }
+    let(:good_request) { fixture('/scsb_find_request.json') }
+    let(:good_response) { fixture('/scsb_request_item_response.json') }
+
+    describe 'All ReCAP Requests' do
+      it "captures successful request submissions." do
+        stub_request(:post, scsb_url).
+          # with(body: good_request, headers: { 'Accept' => '*/*', 'Content-Type' => "application/json", 'api_key' => 'TESTME' }).
+          to_return(status: 200, body: good_response, headers: {})
+        stub_request(:post, alma_url)
+          .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "firestone"))
+          .to_return(status: 200, body: fixture("alma_hold_response.json"), headers: { 'content-type': 'application/json' })
+        stub_request(:post, alma2_url)
+          .with(body: hash_including(request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "mudd"))
+          .to_return(status: 200, body: fixture("alma_hold_response.json"), headers: { 'content-type': 'application/json' })
+        expect(recap_request.submitted.size).to eq(2)
+        expect(recap_request.errors.size).to eq(0)
+        expect(a_request(:post, scsb_url)).to have_been_made.twice
+        expect(a_request(:post, alma_url)).to have_been_made
+        expect(a_request(:post, alma2_url)).not_to have_been_made
       end
     end
   end


### PR DESCRIPTION
Only do it for requests where the book leaves ReCap

Move the hold call in HoldItem to a separate call from the initialized to allow for calling it from ReCAP.

fixes #975 