### PR TITLE
Extending the Requests::Patron#current_patron method to handle 429 HTTP responses from the BibData endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,10 @@ Metrics/BlockLength:
     - 'spec/models/requests/request_spec.rb'
     - 'spec/models/requests/requestable_spec.rb'
 
+Metrics/MethodLength:
+  Exclude:
+    - 'app/models/requests/patron.rb'
+
 Metrics/PerceivedComplexity:
   Exclude:
     - 'app/models/requests/router.rb'

--- a/app/models/requests/patron.rb
+++ b/app/models/requests/patron.rb
@@ -145,30 +145,22 @@ module Requests
 
         case response.status
         when 500
-          raise(ServerError)
+          Rails.logger.error('Error Patron Data Service.')
+          nil
         when 429
-          raise(PerSecondThresholdError)
+          error_message = "The maximum number of HTTP requests per second for the Alma API has been exceeded."
+          Rails.logger.error(error_message)
+          errors << error_message
+          nil
         when 404
-          raise(ResourceNotFoundError)
+          Rails.logger.error("404 Patron #{id} cannot be found in the Patron Data Service.")
+          nil
         when 403
-          raise(ForbiddenError)
+          Rails.logger.error("403 Not Authorized to Connect to Patron Data Service at #{request_uri} for patron ID #{id}")
+          nil
+        else
+          response
         end
-
-        response
-      rescue ServerError
-        Rails.logger.error('Error Patron Data Service.')
-        nil
-      rescue PerSecondThresholdError
-        error_message = "The maximum number of HTTP requests per second for the Alma API has been exceeded."
-        Rails.logger.error(error_message)
-        errors << error_message
-        nil
-      rescue ResourceNotFoundError
-        Rails.logger.error("404 Patron #{id} cannot be found in the Patron Data Service.")
-        nil
-      rescue ForbiddenError
-        Rails.logger.error("403 Not Authorized to Connect to Patron Data Service at #{request_uri} for patron ID #{id}")
-        nil
       rescue Faraday::Error::ConnectionFailed
         Rails.logger.error("Unable to connect to #{bibdata_uri}")
         nil

--- a/app/models/requests/patron.rb
+++ b/app/models/requests/patron.rb
@@ -2,11 +2,6 @@ require 'faraday'
 
 module Requests
   class Patron
-    class ServerError < StandardError; end
-    class PerSecondThresholdError < StandardError; end
-    class ResourceNotFoundError < StandardError; end
-    class ForbiddenError < StandardError; end
-
     attr_reader :user, :session, :patron, :errors
 
     delegate :guest?, to: :user

--- a/app/models/requests/patron.rb
+++ b/app/models/requests/patron.rb
@@ -2,6 +2,11 @@ require 'faraday'
 
 module Requests
   class Patron
+    class ServerError < StandardError; end
+    class PerSecondThresholdError < StandardError; end
+    class ResourceNotFoundError < StandardError; end
+    class ForbiddenError < StandardError; end
+
     attr_reader :user, :session, :patron, :errors
 
     delegate :guest?, to: :user
@@ -115,7 +120,7 @@ module Requests
       def load_patron(user:)
         if !user.guest?
           patron = current_patron(user.uid)
-          errors << "A problem occurred looking up your library account." if patron == false
+          errors << "A problem occurred looking up your library account." if patron.nil?
           # Uncomment to fake being a non barcoded user
           # patron[:barcode] = nil
           patron || {}
@@ -126,38 +131,71 @@ module Requests
         end
       end
 
+      def bibdata_uri
+        Requests.config[:bibdata_base]
+      end
+
+      def build_patron_uri(uid:)
+        "#{bibdata_uri}/patron/#{uid}"
+      end
+
+      def api_request_patron(id:)
+        request_uri = build_patron_uri(uid: id)
+        response = Faraday.get("#{request_uri}?ldap=true")
+
+        case response.status
+        when 500
+          raise(ServerError)
+        when 429
+          raise(PerSecondThresholdError)
+        when 404
+          raise(ResourceNotFoundError)
+        when 403
+          raise(ForbiddenError)
+        end
+
+        response
+      rescue ServerError
+        Rails.logger.error('Error Patron Data Service.')
+        nil
+      rescue PerSecondThresholdError
+        error_message = "The maximum number of HTTP requests per second for the Alma API has been exceeded."
+        Rails.logger.error(error_message)
+        errors << error_message
+        nil
+      rescue ResourceNotFoundError
+        Rails.logger.error("404 Patron #{id} cannot be found in the Patron Data Service.")
+        nil
+      rescue ForbiddenError
+        Rails.logger.error("403 Not Authorized to Connect to Patron Data Service at #{request_uri} for patron ID #{id}")
+        nil
+      rescue Faraday::Error::ConnectionFailed
+        Rails.logger.error("Unable to connect to #{bibdata_uri}")
+        nil
+      end
+
       def current_patron(uid)
-        return false unless uid
-        begin
-          patron_record = Faraday.get "#{Requests.config[:bibdata_base]}/patron/#{uid}?ldap=true"
-        rescue Faraday::Error::ConnectionFailed
-          Rails.logger.info("Unable to connect to #{Requests.config[:bibdata_base]}")
-          return false
-        end
-        return false if patron_errors?(patron_record: patron_record, uid: uid)
-        JSON.parse(patron_record.body).with_indifferent_access
+        return unless uid
+
+        api_response = api_request_patron(id: uid)
+        return if api_response.nil?
+
+        patron_resource = JSON.parse(api_response.body)
+        patron_resource.with_indifferent_access
       end
 
-      def patron_errors?(patron_record:, uid:)
-        return false if patron_record.status == 200
-        if patron_record.status == 403
-          Rails.logger.info('403 Not Authorized to Connect to Patron Data Service at '\
-                      "#{Requests.config[:bibdata_base]}/patron/#{uid}")
-        elsif patron_record.status == 404
-          Rails.logger.info("404 Patron #{uid} cannot be found in the Patron Data Service.")
-        elsif patron_record.status == 500
-          Rails.logger.info('Error Patron Data Service.')
-        end
-        true
-      end
-
-      def access_patron(email, user_name)
+      def build_access_patron(email:, user_name:)
         {
           last_name: user_name,
           active_email: email,
           barcode: 'ACCESS',
           barcode_status: 0
-        }.with_indifferent_access
+        }
+      end
+
+      def access_patron(email, user_name)
+        built = build_access_patron(email: email, user_name: user_name)
+        built.with_indifferent_access
       end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,34 +28,30 @@ require 'rspec/rails'
 require 'selenium/webdriver'
 require 'webdrivers'
 require 'webmock/rspec'
+require 'coveralls'
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
+
+SimpleCov.start('rails') do
+  add_filter '/lib/generators/requests/install_generator.rb'
+  add_filter '/lib/generators/requests/templates/borrow_direct.rb'
+  add_filter '/lib/generators/requests/templates/requests_initializer.rb'
+  add_filter '/lib/generators/requests/templates/lib/omniauth/strategies/omniauth-barcode.rb'
+  add_filter '/lib/generators/requests/templates/app/controllers/users/omniauth_callbacks_controller.rb'
+  add_filter '/lib/requests/version.rb'
+  add_filter '/lib/requests/engine.rb'
+  add_filter '/lib/requests.rb'
+  add_filter '/app/models/concerns/requests/gfa.rb' # no longer used
+  add_filter '/spec'
+  add_filter '.internal_test_app'
+end
 
 WebMock.disable_net_connect!(allow_localhost: false)
 
-if ENV['CI']
-  require 'coveralls'
-  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-end
-
-if ENV['CI'] || ENV['COVERAGE']
-  SimpleCov.start('rails') do
-    add_filter '/lib/generators/requests/install_generator.rb'
-    add_filter '/lib/generators/requests/templates/borrow_direct.rb'
-    add_filter '/lib/generators/requests/templates/requests_initializer.rb'
-    add_filter '/lib/generators/requests/templates/lib/omniauth/strategies/omniauth-barcode.rb'
-    add_filter '/lib/generators/requests/templates/app/controllers/users/omniauth_callbacks_controller.rb'
-    add_filter '/lib/requests/version.rb'
-    add_filter '/lib/requests/engine.rb'
-    add_filter '/lib/requests.rb'
-    add_filter '/app/models/concerns/requests/gfa.rb' # no longer used
-    add_filter '/spec'
-    add_filter '.internal_test_app'
-  end
-end
-
-# Capybara.register_driver :poltergeist do |app|
-#   Capybara::Poltergeist::Driver.new(app, timeout: 60)
-# end
-# Capybara.javascript_driver = :poltergeist
 Capybara.default_driver = :rack_test # This is a faster driver
 
 puts "Looking for chrome"
@@ -65,10 +61,6 @@ puts `which google-chrome`
 puts "Looking for google-chrome-stable"
 puts `which google-chrome-stable`
 puts "Selenium default #{Selenium::WebDriver::Chrome.path}"
-
-# Capybara.register_driver :chrome do |app|
-#   Capybara::Selenium::Driver.new(app, browser: :chrome)
-# end
 
 Capybara.register_driver :selenium do |app|
   Capybara::Selenium::Driver.load_selenium


### PR DESCRIPTION
Resolve #916 