### PR TITLE
Changing the offsite location to be recap

### DIFF
--- a/app/models/requests/requestable_decorator.rb
+++ b/app/models/requests/requestable_decorator.rb
@@ -92,6 +92,8 @@ module Requests
         "clancy_unavailable" # at clancy but not available
       elsif recap? && (holding_library == "marquand" || requestable.cul_avery?)
         "recap_marquand"
+      elsif recap?
+        "recap"
       else
         library_code
       end

--- a/spec/models/requests/requestable_decorator_spec.rb
+++ b/spec/models/requests/requestable_decorator_spec.rb
@@ -1470,7 +1470,7 @@ describe Requests::RequestableDecorator do
     context "at recap" do
       let(:stubbed_questions) { default_stubbed_questions.merge(recap?: true, library_code: 'abc', holding_library: 'abc') }
       it 'is off site' do
-        expect(decorator.off_site_location).to eq('abc')
+        expect(decorator.off_site_location).to eq('recap')
       end
     end
 


### PR DESCRIPTION
Now that some items that are stored in recap are now showing their library (like firestone) instead of recap for thier libray codes we need to just respond with the off site location of recap if the item is out at recap

fixes #990 