### PR TITLE
Default status to In Process for ReCAP items with no status in ReCAP

### DIFF
--- a/app/models/concerns/requests/bibdata.rb
+++ b/app/models/concerns/requests/bibdata.rb
@@ -19,7 +19,7 @@ module Requests
       parse_response(response)
     end
 
-    def get_location(location_code)
+    def get_location_data(location_code)
       response = bibdata_conn.get "/locations/holding_locations/#{location_code}.json"
       parse_response(response)
     end
@@ -69,7 +69,7 @@ module Requests
 
     # get the location contact email from thr delivery locations via the library code
     def get_location_contact_email(location_code)
-      code = get_location(location_code)
+      code = get_location_data(location_code)
       library_code = code[:library]["code"]
       return I18n.t('requests.on_shelf.email') if library_code == "firestone"
       delivery_location = Requests::BibdataService.delivery_locations.select { |_key, value| value[:library][:code] == library_code }

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -299,7 +299,7 @@ module Requests
       end
 
       def in_process_statuses
-        ["Acquisition technical services", "Acquisitions and Cataloging"]
+        ["Acquisition technical services", "Acquisitions and Cataloging", "In Process"]
       end
   end
 end

--- a/app/models/requests/requestable/item.rb
+++ b/app/models/requests/requestable/item.rb
@@ -67,15 +67,16 @@ class Requests::Requestable
     end
 
     def charged?
-      unavailable_statuses.include?(status_label) || scsb? && unavailable_statuses.include?(scsb_status)
+      unavailable_statuses.include?(status_label)
     end
 
     def status
-      self[:status]
-    end
-
-    def scsb_status
-      self[:scsb_status] || self[:status]
+      return self[:status] if self[:status].present?
+      if available?
+        "Available"
+      else
+        "Not Available"
+      end
     end
 
     def status_label
@@ -83,7 +84,7 @@ class Requests::Requestable
     end
 
     def available?
-      available_statuses.include?(status_label) || scsb? && available_statuses.include?(scsb_status)
+      available_statuses.include?(status_label)
     end
 
     def barcode?

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -95,9 +95,9 @@ module Requests
       def calculate_recap_services
         if !requestable.item_data?
           ['recap_no_items']
-        elsif requestable.scsb_in_library_use? && requestable.item[:collection_code] != "MR" && requestable.campus_authorized
+        elsif (requestable.scsb_in_library_use? && requestable.item[:collection_code] != "MR" && requestable.campus_authorized) || (!requestable.circulates? && !requestable.recap_edd?)
           ['recap_in_library']
-        elsif (!requestable.circulates? && !requestable.recap_edd?) || (requestable.scsb_in_library_use? && (!requestable.eligible_to_pickup? || requestable.etas?))
+        elsif requestable.scsb_in_library_use? && (!requestable.eligible_to_pickup? || requestable.etas?)
           ['ask_me']
         elsif auth_user?
           services = []

--- a/spec/cassettes/request_controller.yml
+++ b/spec/cassettes/request_controller.yml
@@ -1232,4 +1232,44 @@ http_interactions:
       string: '{"label":"Graphic Arts Reference Collection","code":"rare$garf","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"remote_storage":"","library":{"label":"Special
         Collections","code":"rare","order":0},"holding_library":null,"hours_location":null,"delivery_locations":[]}'
   recorded_at: Wed, 07 Jul 2021 17:53:23 GMT
+- request:
+    method: post
+    uri: https://uat-recap.htcinc.com:9093/requestItem/requestItem
+    body:
+      encoding: UTF-8
+      string: '{"author":"","bibId":"9995904203506421","callNumber":"PN1995.9.A76
+        P7613 2015","chapterTitle":"test","deliveryLocation":"","emailAddress":"a@b.com","endPage":"1","issue":"1","itemBarcodes":["32101098797010"],"itemOwningInstitution":"PUL","patronBarcode":"22101008199999","requestNotes":"","requestType":"EDD","requestingInstitution":"PUL","startPage":"1","titleIdentifier":null,"username":"jstudent","volume":"1"}'
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - TESTME
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: ''
+    headers:
+      Date:
+      - Wed, 14 Jul 2021 19:19:13 GMT
+      Content-Length:
+      - '22'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - AWSALB=7cxAefq4MU+k3UbmP8E+IvBiNLvG17wVnqA963V3365tinIohJ7pasGHh01Whps/kTAkYBTnIb/PJ6ClVkuJcBjTYBK1BEYOW3gV9eMonnfHQ0NydVg+dZ5OFWce;
+        Expires=Wed, 21 Jul 2021 19:19:13 GMT; Path=/
+      - AWSALBCORS=7cxAefq4MU+k3UbmP8E+IvBiNLvG17wVnqA963V3365tinIohJ7pasGHh01Whps/kTAkYBTnIb/PJ6ClVkuJcBjTYBK1BEYOW3gV9eMonnfHQ0NydVg+dZ5OFWce;
+        Expires=Wed, 21 Jul 2021 19:19:13 GMT; Path=/; SameSite=None; Secure
+    body:
+      encoding: UTF-8
+      string: 'Authentication Failed
+
+        '
+  recorded_at: Wed, 14 Jul 2021 19:19:13 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/request_features.yml
+++ b/spec/cassettes/request_features.yml
@@ -5585,4 +5585,416 @@ http_interactions:
         </body>
         </html>
   recorded_at: Mon, 12 Jul 2021 12:13:25 GMT
+- request:
+    method: post
+    uri: https://uat-recap.htcinc.com:9093/sharedCollection/bibAvailabilityStatus
+    body:
+      encoding: UTF-8
+      string: '{"bibliographicId":"99105873133506421","institutionId":"PUL"}'
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - TESTME
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: ''
+    headers:
+      Date:
+      - Wed, 14 Jul 2021 19:51:21 GMT
+      Content-Length:
+      - '22'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - AWSALB=2rcBRG2D78Urc/kWOjAhi3N7447q3xSQp1FRAqg6Wl3zMDRY5HETPBPHR4YR7NavJaISBgbokY95Rm7hssH9gp5h1urnDT0F0DgzHrUsm/stifUAfzQMWfX8BBD5;
+        Expires=Wed, 21 Jul 2021 19:51:21 GMT; Path=/
+      - AWSALBCORS=2rcBRG2D78Urc/kWOjAhi3N7447q3xSQp1FRAqg6Wl3zMDRY5HETPBPHR4YR7NavJaISBgbokY95Rm7hssH9gp5h1urnDT0F0DgzHrUsm/stifUAfzQMWfX8BBD5;
+        Expires=Wed, 21 Jul 2021 19:51:21 GMT; Path=/; SameSite=None; Secure
+    body:
+      encoding: UTF-8
+      string: 'Authentication Failed
+
+        '
+  recorded_at: Wed, 14 Jul 2021 19:51:21 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-2879197/holdings/2856807/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 19:52:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - ab378b0b-1c7b-4ebd-a5db-d491865544a5
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.263845'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 19:52:02 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-4634001/holdings/4641780/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 19:52:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - e4249523-d9a3-463a-9c57-b521372f8c00
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.562394'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 19:52:03 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-2879206/holdings/2856817/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 19:52:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 0cd11f7d-19b4-4077-b436-a1f213990f87
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.613979'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 19:52:04 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-8953469/holdings/9159920/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 19:52:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - e97f2c4f-4508-48b0-a452-adfb5b0b1357
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.610283'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 19:52:06 GMT
+- request:
+    method: get
+    uri: https://catalog-alma-qa.princeton.edu/catalog/99118892553506421/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 19:52:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 8eab0ce0-5877-4f5d-b62b-cba2f68b6f1b
+      X-Download-Options:
+      - noopen
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"2d3e02b6668e3f6eddb481dc41339403"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.023432'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.8
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Origin
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6Ijk5MTE4ODkyNTUzNTA2NDIxIiwibnVtZXJpY19pZF9iIjp0cnVlLCJhdXRob3JfZGlzcGxheSI6WyJQcmluY2V0b24gVW5pdmVyc2l0eS4gR2xlZSBDbHViIl0sImF1dGhvcl9jaXRhdGlvbl9kaXNwbGF5IjpbIlByaW5jZXRvbiBVbml2ZXJzaXR5IiwiQ3JvdWNoLCBHYWJyaWVsIiwiVHViaW9sbywgU3RlcGhhbmllIl0sImF1dGhvcl9yb2xlc18xZGlzcGxheSI6IntcInNlY29uZGFyeV9hdXRob3JzXCI6W1wiQ3JvdWNoLCBHYWJyaWVsXCIsXCJUdWJpb2xvLCBTdGVwaGFuaWVcIixcIlByaW5jZXRvbiBVbml2ZXJzaXR5XCIsXCJQcmluY2V0b24gVW5pdmVyc2l0eVwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXSxcInByaW1hcnlfYXV0aG9yXCI6XCJQcmluY2V0b24gVW5pdmVyc2l0eVwifSIsImF1dGhvcl9zIjpbIlByaW5jZXRvbiBVbml2ZXJzaXR5LiBHbGVlIENsdWIiLCJDcm91Y2gsIEdhYnJpZWwsIDE5NzMtIiwiVHViaW9sbywgU3RlcGhhbmllIiwiUHJpbmNldG9uIFVuaXZlcnNpdHkuIENoYW1iZXIgQ2hvaXIiLCJQcmluY2V0b24gVW5pdmVyc2l0eS4gRGVwYXJ0bWVudCBvZiBNdXNpYyJdLCJtYXJjX3JlbGF0b3JfZGlzcGxheSI6WyJBdXRob3IiXSwidGl0bGVfZGlzcGxheSI6IltDb25jZXJ0LCAyMDE5LCBEZWNlbWJlciAwOF0gW3NvdW5kIHJlY29yZGluZ10iLCJ0aXRsZV90IjpbIltDb25jZXJ0LCAyMDE5LCBEZWNlbWJlciAwOF0gW3NvdW5kIHJlY29yZGluZ10iXSwidGl0bGVfY2l0YXRpb25fZGlzcGxheSI6WyJDb25jZXJ0LCAyMDE5LCBEZWNlbWJlciAwOCJdLCJjb21waWxlZF9jcmVhdGVkX3QiOlsiW0NvbmNlcnQsIDIwMTksIERlY2VtYmVyIDA4XSBbc291bmQgcmVjb3JkaW5nXSJdLCJwdWJfY3JlYXRlZF9kaXNwbGF5IjpbIlByaW5jZXRvbiwgTkouIDogUHJpbmNldG9uIFVuaXZlcnNpdHksIERlcHQuIG9mIE11c2ljLCAyMDE5LiJdLCJwdWJfY3JlYXRlZF9zIjpbIlByaW5jZXRvbiwgTkouIDogUHJpbmNldG9uIFVuaXZlcnNpdHksIERlcHQuIG9mIE11c2ljLCAyMDE5LiJdLCJwdWJfY2l0YXRpb25fZGlzcGxheSI6WyJQcmluY2V0b24sIE5KLjogUHJpbmNldG9uIFVuaXZlcnNpdHksIERlcHQuIG9mIE11c2ljIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxOSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE5LCJjYXRhbG9nZWRfdGR0IjoiMjAyMC0xMi0wMlQxNDoyNzoxOVoiLCJmb3JtYXQiOlsiQXVkaW8iXSwiZWxlY3Ryb25pY19hY2Nlc3NfMWRpc3BsYXkiOiJ7XCJodHRwOi8vbGliLWRic2VydmVyLnByaW5jZXRvbi5lZHUvbXVzaWMvcHJvZ3JhbXMvMjAxOS0xMi0wOF9QVUdDLnBkZlwiOltcIlByb2dyYW0uXCJdfSIsImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMiBzb3VuZCBkaXNjcyA6IGRpZ2l0YWwgOyA0IDMvNCBpbi4iXSwiZGVzY3JpcHRpb25fdCI6WyIyIHNvdW5kIGRpc2NzIDogZGlnaXRhbCA7IDQgMy80IGluLiJdLCJudW1iZXJfb2ZfcGFnZXNfY2l0YXRpb25fZGlzcGxheSI6WyIyIHNvdW5kIGRpc2NzIl0sIm5vdGVzX2Rpc3BsYXkiOlsiQSBjb21wbGV0ZSBwcm9ncmFtIGlzIGF2YWlsYWJsZSBvbmxpbmUuIiwiUFVHQyJdLCJkYXRlX3BsYWNlX2V2ZW50X25vdGVzX2Rpc3BsYXkiOlsiUmVjb3JkZWQgaW4gUmljaGFyZHNvbiBBdWRpdG9yaXVtLCBBbGV4YW5kZXIgSGFsbC4iXSwicGFydGljaXBhbnRfcGVyZm9ybWVyX2Rpc3BsYXkiOlsiUHJpbmNldG9uIFVuaXZlcnNpdHkgR2xlZSBDbHViIGFuZCBDaGFtYmVyIENob2lyLCBHYWJyaWVsIENyb3VjaCwgZGlyZWN0b3IgOyBTdGVwaGFuaWUgVHViaW9sbywgYXNzb2NpYXRlIGRpcmVjdG9yIFtkaXNjIDEsIDJuZCB3b3JrXSA7IFByaW5jZXRvbiBVbml2ZXJzaXR5IENoYW1iZXIgQ2hvaXIgW2Rpc2MgMSwgNHRoIHdvcmsgLyBkaXNjIDIsIDFzdCB3b3JrXSA7IE1hZGR5IEt1c2hhbiwgU2xvYW4gSHVlYm5lciwgQ29yaW5uYSBCcnVlY2tuZXIgRGFubnkgUGludG8sIGFuZCBSdXBlcnQgUGVhY29jaywgc29sb2lzdHMgW2Rpc2MgMSwgNXRoIHdvcmtdIDsgTHVsdSBIYW8sIElzaGFuaSBLdWxrYXJuaSwgVEogTGksIGFuZCBLZXZpbiBXaWxsaWFtcywgc29sb2lzdHMgW2Rpc2MgMSwgNnRoIHdvcmtdIDsgQWxleGFuZHJhIFJpY2UgYW5kIEdsb3JpYSBZaW4sIHBpYW5vIFtkaXNjIDIsIDJuZCB3b3JrXSJdLCJsYW5ndWFnZV9jb2RlX3MiOlsidW5kIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJ1bmQiXSwiY29udGVudHNfZGlzcGxheSI6WyJEaXNjIDEuIFBzYWxtcyBvZiBIb3BlLiBQc2FsbSAxMjEgLyBJLiBCYXJkYW5hc2h2aWxpIC0tIEdvdHQgaXN0IG1laW4gSGlydCAvIEYuIFNjaHViZXJ0IC0tIGFuZCB0aGUgc3dhbGxvdyAvIEMuIFNoYXcgLS0gTGF1ZGlidXMgaW4gc2FuY3RpcyAvIFcuIEJ5cmQgLS0gUHJvZ3JhbSBub3RlcyBieSBHYWJyaWVsIENyb3VjaCAtLSBQc2FsbXMgb2YgUGVuaXRlbmNlLiBNaXNlcmVyZSAvIEcuIEFsbGVncmkgLS0gTWlzZXJlcmUgLyBKLiBNYWNtaWxsYW4gLS0iLCJEaXNjIDIuIERhIHBhY2VtLCBEb21pbmUgLyBBLiBQYcyIcnQgLS0gU3ltcGhvbnkgb2YgUHNhbG1zIC8gSS4gU3RyYXZpbnNreS4iXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJEaXJlY3RvclwiOltcIkNyb3VjaCwgR2FicmllbCwgMTk3My1cIl0sXCJDb25kdWN0b3JcIjpbXCJUdWJpb2xvLCBTdGVwaGFuaWVcIl0sXCJSZWxhdGVkIG5hbWVcIjpbXCJQcmluY2V0b24gVW5pdmVyc2l0eS4gQ2hhbWJlciBDaG9pclwiLFwiUHJpbmNldG9uIFVuaXZlcnNpdHkuIERlcGFydG1lbnQgb2YgTXVzaWNcIl19IiwiYWx0X3RpdGxlXzI0Nl9kaXNwbGF5IjpbIlN5bXBob255IG9mIHBzYWxtcy4iXSwib3RoZXJfdGl0bGVfMWRpc3BsYXkiOiJ7XCJQcm9ncmFtIHRpdGxlXCI6W1wiU3ltcGhvbnkgb2YgcHNhbG1zLlwiXX0iLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjIyNDEwODY1NzAwMDY0MjFcIjp7XCJsb2NhdGlvbl9jb2RlXCI6XCJtZW5kZWwkcGtcIixcImxvY2F0aW9uXCI6XCJSZW1vdGUgU3RvcmFnZSAoUmVDQVApXCIsXCJsaWJyYXJ5XCI6XCJNZW5kZWwgTXVzaWMgTGlicmFyeVwiLFwiY2FsbF9udW1iZXJcIjpcIkNELSAyMDE5LTEyLTA4IE1BU1RFUlwiLFwiY2FsbF9udW1iZXJfYnJvd3NlXCI6XCJDRC0gMjAxOS0xMi0wOCBNQVNURVJcIixcIml0ZW1zXCI6W3tcImhvbGRpbmdfaWRcIjpcIjIyNDEwODY1NzAwMDY0MjFcIixcImlkXCI6XCIyMzQxMDg2NTYwMDA2NDIxXCIsXCJzdGF0dXNfYXRfbG9hZFwiOlwiMVwiLFwiY29sbGVjdGlvbl9jb2RlXCI6XCJwa1wiLFwiYmFyY29kZVwiOlwiMzIxMDEwOTQzOTk3NzlcIixcImNvcHlfbnVtYmVyXCI6XCIwXCJ9XX0sXCIyMjQxMDg2NTkwMDA2NDIxXCI6e1wibG9jYXRpb25fY29kZVwiOlwibWVuZGVsJHJlc1wiLFwibG9jYXRpb25cIjpcIlJlc2VydmVcIixcImxpYnJhcnlcIjpcIk1lbmRlbCBNdXNpYyBMaWJyYXJ5XCIsXCJjYWxsX251bWJlclwiOlwiQ0QtIDIwMTktMTItMDhcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiQ0QtIDIwMTktMTItMDhcIixcIml0ZW1zXCI6W3tcImhvbGRpbmdfaWRcIjpcIjIyNDEwODY1OTAwMDY0MjFcIixcImlkXCI6XCIyMzQxMDg2NTgwMDA2NDIxXCIsXCJzdGF0dXNfYXRfbG9hZFwiOlwiMVwiLFwiY29sbGVjdGlvbl9jb2RlXCI6XCJyZXNcIixcImJhcmNvZGVcIjpcIjMyMTAxMDk0Mzk5Nzg3XCIsXCJjb3B5X251bWJlclwiOlwiMFwifV19fSIsImxvY2F0aW9uX2NvZGVfcyI6WyJtZW5kZWwkcGsiLCJtZW5kZWwkcmVzIl0sImxvY2F0aW9uIjpbIk1lbmRlbCBNdXNpYyBMaWJyYXJ5Il0sImxvY2F0aW9uX2Rpc3BsYXkiOlsiUmVtb3RlIFN0b3JhZ2UgKFJlQ0FQKSIsIlJlc2VydmUiXSwiYWR2YW5jZWRfbG9jYXRpb25fcyI6WyJtZW5kZWwkcGsiLCJtZW5kZWwkcmVzIiwiTWVuZGVsIE11c2ljIExpYnJhcnkiXSwibmFtZV90aXRsZV9icm93c2VfcyI6WyJQcmluY2V0b24gVW5pdmVyc2l0eS4gR2xlZSBDbHViLiBDb25jZXJ0LCAyMDE5LCBEZWNlbWJlciAwOCJdLCJjYWxsX251bWJlcl9kaXNwbGF5IjpbIkNELSAyMDE5LTEyLTA4IE1BU1RFUiAiLCJDRC0gMjAxOS0xMi0wOCAiXSwiY2FsbF9udW1iZXJfYnJvd3NlX3MiOlsiQ0QtIDIwMTktMTItMDggTUFTVEVSICIsIkNELSAyMDE5LTEyLTA4ICJdLCJjYWxsX251bWJlcl9sb2NhdG9yX2Rpc3BsYXkiOlsiQ0QtIDIwMTktMTItMDggTUFTVEVSIiwiQ0QtIDIwMTktMTItMDgiXSwiX3ZlcnNpb25fIjoxNzA0ODM1OTM0MDcyMDc4MzM2LCJ0aW1lc3RhbXAiOiIyMDIxLTA3LTA5VDE5OjE3OjIyLjAwM1oifQ==
+  recorded_at: Wed, 14 Jul 2021 19:52:07 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/locations/holding_locations/mendel$pk.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 19:52:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 23188755-733a-40e6-9dba-b589b5acb1b8
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Etag:
+      - W/"9cd9f58996c0dc274dad2287514c152b"
+      X-Runtime:
+      - '0.065197'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: '{"label":"Remote Storage (ReCAP)","code":"mendel$pk","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"remote_storage":"recap_rmt","library":{"label":"Mendel
+        Music Library","code":"mendel","order":0},"holding_library":{"label":"Mendel
+        Music Library","code":"mendel","order":0},"hours_location":null,"delivery_locations":[{"label":"Technical
+        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"library":{"label":"Firestone
+        Library","code":"firestone","order":0}},{"label":"Mendel Music Library","address":"Woolworth
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"library":{"label":"Mendel
+        Music Library","code":"mendel","order":0}},{"label":"Firestone Library, Resource
+        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"library":{"label":"Firestone
+        Library","code":"firestone","order":0}},{"label":"Technical Services HMT","address":"One
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"library":{"label":"Firestone
+        Library","code":"firestone","order":0}},{"label":"Preservation","address":"One
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"library":{"label":"Firestone
+        Library","code":"firestone","order":0}}]}'
+  recorded_at: Wed, 14 Jul 2021 19:52:07 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/99118892553506421/holdings/2241086570006421/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 19:52:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 154d46a0-59c5-4f79-a1e4-0d72b0358bb8
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Etag:
+      - W/"b1748919756d5d7782dd500af7db867d"
+      X-Runtime:
+      - '1.464452'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: '[{"barcode":"32101094399779","id":"2341086560006421","holding_id":"2241086570006421","copy_number":"0","status":"Available","status_label":"Item
+        in place","status_source":"base_status","process_type":null,"on_reserve":"N","item_type":"Closed","pickup_location_id":"mendel","pickup_location_code":"mendel","location":"mendel$pk","label":"Mendel
+        Music Library - Remote Storage (ReCAP)","description":"","enum_display":"","chron_display":"","in_temp_library":false}]'
+  recorded_at: Wed, 14 Jul 2021 19:52:09 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/request_models.yml
+++ b/spec/cassettes/request_models.yml
@@ -9960,4 +9960,187 @@ http_interactions:
         Collections","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"library":{"label":"Firestone
         Library","code":"firestone","order":0}}]}'
   recorded_at: Wed, 07 Jul 2021 20:02:59 GMT
+- request:
+    method: post
+    uri: https://uat-recap.htcinc.com:9093/sharedCollection/bibAvailabilityStatus
+    body:
+      encoding: UTF-8
+      string: '{"bibliographicId":"994916543506421","institutionId":"PUL"}'
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - TESTME
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: ''
+    headers:
+      Date:
+      - Wed, 14 Jul 2021 16:06:17 GMT
+      Content-Length:
+      - '22'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - AWSALB=immgH0it3nm6r4ejfwFOPV/lj9ay7awG3vJT5ZeY4R0diCzwlcCyEwWjmWrEuKbWmAaCALXrpFoZ7hH4nwfqphU719xXwGabVIEGqquFkhn3fel6oeArKm21Cafk;
+        Expires=Wed, 21 Jul 2021 16:06:17 GMT; Path=/
+      - AWSALBCORS=immgH0it3nm6r4ejfwFOPV/lj9ay7awG3vJT5ZeY4R0diCzwlcCyEwWjmWrEuKbWmAaCALXrpFoZ7hH4nwfqphU719xXwGabVIEGqquFkhn3fel6oeArKm21Cafk;
+        Expires=Wed, 21 Jul 2021 16:06:17 GMT; Path=/; SameSite=None; Secure
+    body:
+      encoding: UTF-8
+      string: 'Authentication Failed
+
+        '
+  recorded_at: Wed, 14 Jul 2021 16:06:17 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-5290772/holdings/5278611/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 18:23:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 68e39f6e-209d-4c47-b12d-84505b1acf13
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.259578'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 18:23:49 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-5640725/holdings/5630217/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 18:23:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 973cfdaf-a9bb-497d-b1e5-f613a1710d17
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.405858'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 18:23:51 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-7935196/holdings/8076325/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 18:23:52 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 46d129a6-5d74-4c92-9c7a-b43ace187b60
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.570162'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 18:23:52 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/requestable.yml
+++ b/spec/cassettes/requestable.yml
@@ -7562,4 +7562,235 @@ http_interactions:
         258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"library":{"label":"Firestone
         Library","code":"firestone","order":0}}]}'
   recorded_at: Wed, 07 Jul 2021 19:30:16 GMT
+- request:
+    method: post
+    uri: https://uat-recap.htcinc.com:9093/sharedCollection/bibAvailabilityStatus
+    body:
+      encoding: UTF-8
+      string: '{"bibliographicId":"9967949663506421","institutionId":"PUL"}'
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Api-Key:
+      - TESTME
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: ''
+    headers:
+      Date:
+      - Wed, 14 Jul 2021 16:06:43 GMT
+      Content-Length:
+      - '22'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - AWSALB=ocBY4kMFFhGeepWG3WarUCqD4hB1XcWp2HE/GKChzsPtSkQVUEdmKU6jfqhi7lwBuOulfj1xZihOuI16RtrkQLR7eCy9VG9COUkEEx/lIy7p9SwTtukZZGHYcj97;
+        Expires=Wed, 21 Jul 2021 16:06:43 GMT; Path=/
+      - AWSALBCORS=ocBY4kMFFhGeepWG3WarUCqD4hB1XcWp2HE/GKChzsPtSkQVUEdmKU6jfqhi7lwBuOulfj1xZihOuI16RtrkQLR7eCy9VG9COUkEEx/lIy7p9SwTtukZZGHYcj97;
+        Expires=Wed, 21 Jul 2021 16:06:43 GMT; Path=/; SameSite=None; Secure
+    body:
+      encoding: UTF-8
+      string: 'Authentication Failed
+
+        '
+  recorded_at: Wed, 14 Jul 2021 16:06:43 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-5235419/holdings/5222238/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 18:24:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - cabc1776-dfa5-4799-b327-2343a3613167
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.274045'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 18:24:10 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-5396104/holdings/5386007/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 18:24:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - f275972c-6cd1-4483-86c0-2dc687eb61a8
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.632912'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 18:24:11 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-2650865/holdings/2628739/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 18:24:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 0aa55bcc-49c0-4ea0-a5ee-6bfd5776e21f
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.283984'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 18:24:12 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-2901229/holdings/2878971/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 18:24:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - a6d05354-727a-43ff-bd32-7cd6b11fdfd9
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.605532'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 18:24:13 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/requests_router.yml
+++ b/spec/cassettes/requests_router.yml
@@ -516,4 +516,52 @@ http_interactions:
         </body>
         </html>
   recorded_at: Mon, 24 May 2021 18:33:32 GMT
+- request:
+    method: get
+    uri: https://bibdata-alma-staging.princeton.edu/bibliographic/SCSB-2635660/holdings/2613391/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Wed, 14 Jul 2021 18:24:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 9f2af8c1-39eb-458e-9755-ae8da46edc74
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      X-Runtime:
+      - '0.571156'
+      Access-Control-Request-Method:
+      - GET
+      X-Powered-By:
+      - Phusion Passenger 6.0.7
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Wed, 14 Jul 2021 18:24:15 GMT
 recorded_with: VCR 6.0.0

--- a/spec/controllers/requests/request_controller_spec.rb
+++ b/spec/controllers/requests/request_controller_spec.rb
@@ -27,6 +27,7 @@ describe Requests::RequestController, type: :controller, vcr: { cassette_name: '
       end
 
       it 'sets the current request mode to trace when supplied' do
+        stub_scsb_availability(bib_id: "9996764833506421", institution_id: "PUL", barcode: '32101099103457')
         get :generate, params: {
           source: 'pulsearch',
           system_id: '9996764833506421',
@@ -36,6 +37,7 @@ describe Requests::RequestController, type: :controller, vcr: { cassette_name: '
         expect(assigns(:mode)).to eq('trace')
       end
       it 'uses the default request mode and does not set a flash' do
+        stub_scsb_availability(bib_id: "9996764833506421", institution_id: "PUL", barcode: '32101099103457')
         get :generate, params: {
           source: 'pulsearch',
           system_id: '9996764833506421',

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -46,6 +46,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
     context 'all patrons' do
       describe 'When unauthenticated patron visits a request item', js: true do
         it "displays three authentication options" do
+          stub_scsb_availability(bib_id: "9999443553506421", institution_id: "PUL", barcode: '32101098722844')
           visit '/requests/9999443553506421?mfhd=22202822560006421'
           expect(page).to have_content(I18n.t('requests.account.netid_login_msg'))
           expect(page).not_to have_content(I18n.t('requests.account.barcode_login_msg'))
@@ -79,6 +80,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
     context 'unauthenticated patron' do
       describe 'When visiting a request item without logging in', js: true do
         it 'allows guest patrons to identify themselves and view the form' do
+          stub_scsb_availability(bib_id: "9999443553506421", institution_id: "PUL", barcode: '32101098722844')
           visit '/requests/9999443553506421?mfhd=22202822560006421'
           pending "Guest have no access during COVID-19 pandemic"
           click_link(I18n.t('requests.account.other_user_login_msg'))
@@ -103,6 +105,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         # TODO: Activate test when campus has re-opened
         it 'allows guest patrons to request a physical recap item' do
           pending "Guest have no access during COVID-19 pandemic"
+          stub_scsb_availability(bib_id: "9999443553506421", institution_id: "PUL", barcode: '32101098722844')
           visit '/requests/9999443553506421?mfhd=22202822560006421'
           click_link(I18n.t('requests.account.other_user_login_msg'))
           fill_in 'request_email', with: 'name@email.com'
@@ -216,6 +219,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
       describe 'When visiting a voyager ID as a CAS User' do
         it 'allow CAS patrons to request an available ReCAP item.' do
+          stub_scsb_availability(bib_id: "9994933183506421", institution_id: "PUL", barcode: '32101095798938')
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
           stub_request(:post, scsb_url)
             .with(body: hash_including(author: "", bibId: "9994933183506421", callNumber: "PJ7962.A5495 A95 2016", chapterTitle: "", deliveryLocation: "PA", emailAddress: 'a@b.com', endPage: "", issue: "", itemBarcodes: ["32101095798938"], itemOwningInstitution: "PUL", patronBarcode: "22101008199999",
@@ -360,9 +364,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
             .with(body: hash_including(author: "", bibId: "9999443553506421", callNumber: "DT549 .E274q Oversize", chapterTitle: "ABC", deliveryLocation: "PA", emailAddress: "a@b.com", endPage: "", issue: "",
                                        itemBarcodes: ["32101098722844"], itemOwningInstitution: "PUL", patronBarcode: "22101008199999", requestNotes: "", requestType: "EDD", requestingInstitution: "PUL", startPage: "", titleIdentifier: "L'écrivain, magazine litteraire trimestriel", username: "jstudent", volume: "2016"))
             .to_return(status: 200, body: good_response, headers: {})
-          stub_request(:post, "#{Requests.config[:scsb_base]}/sharedCollection/bibAvailabilityStatus")
-            .with(body: hash_including(bibliographicId: "9999443553506421", institutionId: "PUL"))
-            .to_return(status: 200, body: "[{\"itemBarcode\":\"32101098722844\",\"itemAvailabilityStatus\":\"Available\",\"errorMessage\":null,\"collectionGroupDesignation\":\"Shared\"}]", headers: {})
+          stub_scsb_availability(bib_id: "9999443553506421", institution_id: "PUL", barcode: '32101098722844')
           visit '/requests/9999443553506421?mfhd=22202822560006421'
           expect(page).to have_content 'Electronic Delivery'
           select('Firestone Library', from: 'requestable__pick_up')
@@ -417,6 +419,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         it 'allows patrons to request a Lewis recap item digitally' do
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
+          stub_scsb_availability(bib_id: "9970533073506421", institution_id: "PUL", barcode: '32101051217659')
           stub_request(:post, scsb_url)
             .to_return(status: 200, body: good_response, headers: {})
           visit '/requests/9970533073506421?mfhd=22214952010006421'
@@ -438,6 +441,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         end
 
         it 'allows patrons to request a Lewis' do
+          stub_scsb_availability(bib_id: "9994933183506421", institution_id: "PUL", barcode: '32101095798938')
           stub_alma_hold_success('9970533073506421', '22214952030006421', '23214952020006421', '960594184')
           visit '/requests/9970533073506421?mfhd=22214952030006421'
           expect(page).to have_content 'Pick-up location: Lewis Library'
@@ -563,8 +567,8 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         it 'Shows Marqaund Recap Item as an EDD option or In Library Use, no delivery' do
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
-          stub_request(:post, scsb_url)
-            .to_return(status: 200, body: good_response, headers: {})
+          stub_request(:post, scsb_url).to_return(status: 200, body: good_response, headers: {})
+          stub_scsb_availability(bib_id: "99117809653506421", institution_id: "PUL", barcode: '32101106347378')
           visit '/requests/99117809653506421?mfhd=22203397510006421'
           choose('requestable__delivery_mode_23203397500006421_edd') # chooses 'edd' radio button
           expect(page).to have_content I18n.t('requests.recap_edd.brief_msg')
@@ -603,6 +607,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         it "allows requests of recap pick-up only items" do
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
+          stub_scsb_availability(bib_id: "99115783193506421", institution_id: "PUL", barcode: '32101108035435')
           stub_request(:post, scsb_url)
             .with(body: hash_including(author: nil, bibId: "99115783193506421", callNumber: "DVD", chapterTitle: nil, deliveryLocation: "PA", emailAddress: "a@b.com", endPage: nil, issue: nil, itemBarcodes: ["32101108035435"], itemOwningInstitution: "PUL", patronBarcode: "22101008199999", requestNotes: nil, requestType: "RETRIEVAL", requestingInstitution: "PUL", startPage: nil, titleIdentifier: "Chernobyl : a 5-part miniseries", username: "jstudent", volume: nil))
             .to_return(status: 200, body: good_response, headers: {})
@@ -865,6 +870,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         # need to check on CUL etas
         it "allows a columbia item that is not in hathi etas to be picked up or digitized" do
+          stub_scsb_availability(bib_id: "1000060", institution_id: "CUL", barcode: 'CU01805363')
           stub_request(:get, "#{Requests.config[:bibdata_base]}/hathi/access?oclc=21154437")
             .to_return(status: 200, body: '[]')
           stub_request(:get, "#{Requests.config[:pulsearch_base]}/catalog/SCSB-2879197/raw")
@@ -1109,6 +1115,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         end
 
         it 'Shows marqaund recap item as an EDD or In Library Use' do
+          stub_scsb_availability(bib_id: "99117809653506421", institution_id: "PUL", barcode: '32101106347378')
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
           stub_request(:post, scsb_url)
             .with(body: hash_including(author: "", bibId: "99117809653506421", callNumber: "N6923.B257 H84 2020", chapterTitle: "", deliveryLocation: "PJ", emailAddress: "a@b.com", endPage: "", issue: "", itemBarcodes: ["32101106347378"], itemOwningInstitution: "PUL", patronBarcode: "22101008199999", requestNotes: "", requestType: "RETRIEVAL", requestingInstitution: "PUL", startPage: "", titleIdentifier: "Alesso Baldovinetti und die Florentiner Malerei der Frührenaissance", username: "jstudent", volume: ""))
@@ -1132,6 +1139,27 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
           expect(confirm_email.html_part.body.to_s).to have_content("2-4 business days")
           expect(confirm_email.html_part.body.to_s).to have_content("Book your appointment")
           expect(confirm_email.html_part.body.to_s).to have_content("Alesso Baldovinetti und die Florentiner Malerei der Frührenaissance")
+          expect(confirm_email.html_part.body.to_s).to have_content("Wear a mask or face covering")
+          expect(confirm_email.html_part.body.to_s).to have_content("Please do not use disinfectant or cleaning product on books")
+        end
+
+        it 'Shows recap item that has not made it to recap yet as in process' do
+          visit '/requests/99118892553506421?mfhd=2241086570006421'
+          expect(page).to have_content 'In Process'
+          expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(2)
+          expect(page).to have_content I18n.t("requests.submit.in_process_success")
+          email = ActionMailer::Base.deliveries[ActionMailer::Base.deliveries.count - 2]
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(email.subject).to eq("In Process Request")
+          expect(email.to).to eq(["fstcirc@princeton.edu"])
+          expect(email.cc).to be_blank
+          expect(email.html_part.body.to_s).to have_content("Concert, 2019, December 08")
+          expect(confirm_email.subject).to eq("In Process Request")
+          expect(confirm_email.html_part.body.to_s).not_to have_content("translation missing")
+          expect(confirm_email.text_part.body.to_s).not_to have_content("translation missing")
+          expect(confirm_email.to).to eq(["a@b.com"])
+          expect(confirm_email.cc).to be_blank
+          expect(confirm_email.html_part.body.to_s).to have_content("Concert, 2019, December 08")
           expect(confirm_email.html_part.body.to_s).to have_content("Wear a mask or face covering")
           expect(confirm_email.html_part.body.to_s).to have_content("Please do not use disinfectant or cleaning product on books")
         end
@@ -1159,6 +1187,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
       let(:user) { FactoryGirl.create(:valid_barcode_patron) }
       # change this back #438
       it 'displays a request form for a ReCAP item.' do
+        stub_scsb_availability(bib_id: "9994933183506421", institution_id: "PUL", barcode: '32101095798938')
         stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/#{user.uid}?ldap=true")
           .to_return(status: 200, body: valid_barcode_patron_response, headers: {})
         login_as user
@@ -1172,6 +1201,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
     context 'A covid-trained pick-up only user' do
       let(:user) { FactoryGirl.create(:user) }
       it 'displays a request form for a ReCAP item.' do
+        stub_scsb_availability(bib_id: "9994933183506421", institution_id: "PUL", barcode: '32101095798938')
         stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/#{user.uid}?ldap=true")
           .to_return(status: 200, body: valid_barcode_patron_pick_up_only_response, headers: {})
         login_as user
@@ -1185,6 +1215,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
     context 'An undergraduate student who has not taken the training' do
       let(:user) { FactoryGirl.create(:user) }
       it 'displays a request form for a ReCAP item.' do
+        stub_scsb_availability(bib_id: "9994933183506421", institution_id: "PUL", barcode: '32101095798938')
         stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/#{user.uid}?ldap=true")
           .to_return(status: 200, body: valid_patron_no_campus_response, headers: {})
         login_as user
@@ -1199,6 +1230,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
     context 'An graduate student who has not taken the training' do
       let(:user) { FactoryGirl.create(:user) }
       it 'displays a request form for a ReCAP item.' do
+        stub_scsb_availability(bib_id: "9994933183506421", institution_id: "PUL", barcode: '32101095798938')
         stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/#{user.uid}?ldap=true")
           .to_return(status: 200, body: valid_graduate_student_no_campus_response, headers: {})
         login_as user
@@ -1242,6 +1274,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
       describe 'When visiting a voyager ID as a CAS User' do
         it 'allow CAS patrons to request an available ReCAP item.' do
+          stub_scsb_availability(bib_id: "9994933183506421", institution_id: "PUL", barcode: '32101095798938')
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
           stub_request(:post, scsb_url)
             .with(body: hash_including(author: "", bibId: "9994933183506421", callNumber: "PJ7962.A5495 A95 2016", chapterTitle: "", deliveryLocation: "PA", emailAddress: 'a@b.com', endPage: "", issue: "", itemBarcodes: ["32101095798938"], itemOwningInstitution: "PUL", patronBarcode: "22101008199999",
@@ -1388,6 +1421,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         let(:good_response) { fixture('/scsb_request_item_response.json') }
         it 'allows patrons to request a physical recap item' do
+          stub_scsb_availability(bib_id: "9999443553506421", institution_id: "PUL", barcode: '32101098722844')
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
           stub_request(:post, scsb_url)
             .with(body: hash_including(author: "", bibId: "9999443553506421", callNumber: "DT549 .E274q Oversize", chapterTitle: "ABC", deliveryLocation: "", emailAddress: "a@b.com", endPage: "", issue: "", itemBarcodes: ["32101098722844"], itemOwningInstitution: "PUL", patronBarcode: '198572131', requestNotes: "", requestType: "EDD", requestingInstitution: "PUL", startPage: "", titleIdentifier: "L'écrivain, magazine litteraire trimestriel", username: "jstudent", volume: "2016"))
@@ -1417,6 +1451,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         end
 
         it 'allows patrons to request a Lewis recap item digitally' do
+          stub_scsb_availability(bib_id: "9970533073506421", institution_id: "PUL", barcode: '32101051217659')
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
           stub_request(:post, scsb_url)
             .to_return(status: 200, body: good_response, headers: {})
@@ -1514,6 +1549,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
 
         # TODO: once Marquad in library use is available again it should show pick-up at marquand also
         it 'Shows ReCAP marqaund as an EDD option only' do
+          stub_scsb_availability(bib_id: "99117809653506421", institution_id: "PUL", barcode: '32101106347378')
           scsb_url = "#{Requests.config[:scsb_base]}/requestItem/requestItem"
           stub_request(:post, scsb_url)
             .to_return(status: 200, body: good_response, headers: {})
@@ -1552,6 +1588,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :new_episo
         end
 
         it "disallows requests of recap pick-up only items" do
+          stub_scsb_availability(bib_id: "99115783193506421", institution_id: "PUL", barcode: '32101108035435')
           visit '/requests/99115783193506421?mfhd=22155047580006421'
           expect(page).not_to have_button('Request this Item')
           expect(page).to have_content(I18n.t("requests.account.cas_user_no_barcode_no_choice_msg"))

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -116,10 +116,9 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
       end
     end
 
-    describe "#load_locations" do
-      it "provides a list of location data" do
-        expect(request_with_holding_item.locations.size).to eq(1)
-        expect(request_with_holding_item.locations.key?('arch$stacks')).to be_truthy
+    describe "#load_location" do
+      it "provides the location of the data" do
+        expect(request_with_holding_item.location[:code]).to eq('arch$stacks')
       end
     end
 
@@ -945,6 +944,10 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :new
     let(:request) { described_class.new(params) }
 
     describe "#requestable" do
+      before do
+        stub_scsb_availability(bib_id: "9996764833506421", institution_id: "PUL", barcode: '32101099103457')
+      end
+
       it "has an requestable items" do
         expect(request.requestable.size).to be >= 1
       end

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -620,7 +620,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
   context 'A Non-Recap Marquand holding' do
     let(:valid_patron_response) { '{"netid":"foo","first_name":"Foo","last_name":"Request","barcode":"22101007797777","university_id":"9999999","patron_group":"staff","patron_id":"99999","active_email":"foo@princeton.edu"}' }
     let(:user) { FactoryGirl.build(:user) }
-    let(:item) { { status: "Available", location_code: "scsbnypl" }.with_indifferent_access }
+    let(:item) { { status_label: "Available", location_code: "scsbnypl" }.with_indifferent_access }
     let(:location) { { "holding_library" => { "code" => "marquand" }, "library" => { "code" => "marquand" } } }
     let(:requestable) { Requests::Requestable.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'blah' } }], location: location, patron: patron, item: item) }
 
@@ -924,6 +924,10 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     let(:requestable) { request.requestable.first }
 
     describe '# offsite requestable' do
+      before do
+        stub_scsb_availability(bib_id: "9999998003506421", institution_id: "PUL", barcode: '32101099186403')
+      end
+
       it "has recap request service available" do
         expect(requestable.services.include?('recap')).to be true
       end
@@ -1040,6 +1044,10 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :ne
     let(:requestable) { request.requestable.first }
 
     describe '#requestable' do
+      before do
+        stub_scsb_availability(bib_id: "9999998003506421", institution_id: "PUL", barcode: '32101099186403')
+      end
+
       # TODO: Activate test when campus has re-opened
       it "has recap request service available" do
         expect(requestable.services.include?('recap')).to be true

--- a/spec/support/stub_helpers.rb
+++ b/spec/support/stub_helpers.rb
@@ -34,9 +34,9 @@ def stub_clancy_status(barcode:, status: "Item not Found")
     .to_return(status: 200, body: "{\"success\":true,\"error\":\"\",\"barcode\":\"#{barcode}\",\"status\":\"#{status}\"}", headers: {})
 end
 
-def stub_scsb_availability(bib_id:, institution_id:, barcode:)
+def stub_scsb_availability(bib_id:, institution_id:, barcode:, item_availability_status: "Available")
   scsb_availability_params = { bibliographicId: bib_id, institutionId: institution_id }
-  scsb_response = [{ itemBarcode: barcode, itemAvailabilityStatus: "Available", errorMessage: nil }]
+  scsb_response = [{ itemBarcode: barcode, itemAvailabilityStatus: item_availability_status, errorMessage: nil }]
   stub_request(:post, "#{Requests.config[:scsb_base]}/sharedCollection/bibAvailabilityStatus")
     .with(headers: { Accept: 'application/json', api_key: 'TESTME' }, body: scsb_availability_params)
     .to_return(status: 200, body: scsb_response.to_json)

--- a/spec/support/vcr_setup.rb
+++ b/spec/support/vcr_setup.rb
@@ -5,7 +5,7 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.ignore_localhost = true
   c.configure_rspec_metadata!
-  c.ignore_hosts 'webvoyage.princeton.edu', 'uat-recap.htcinc.com', 'scsb.recaplib.org', BorrowDirect::Defaults.api_base, 'chromedriver.storage.googleapis.com'
+  c.ignore_hosts 'webvoyage.princeton.edu', 'https://uat-recap.htcinc.com.htcinc.com', 'scsb.recaplib.org', BorrowDirect::Defaults.api_base, 'chromedriver.storage.googleapis.com'
   c.ignore_request do |request|
     request.uri.include? 'patron'
   end


### PR DESCRIPTION
Updated the location information in a request to be singular, since we are only dealing with one mfhd (or location) now.
Availability was not getting queried for the new locations where the library code was not equal to recap, so we updated the check in the request model
Having Recap availability being queried change a number of tests