### PR TITLE
Changing bad user response to be empty hash

### DIFF
--- a/app/models/requests/illiad_patron.rb
+++ b/app/models/requests/illiad_patron.rb
@@ -32,9 +32,9 @@ module Requests
     private
 
       def illiad_patron_attributes
-        return nil if patron.status.blank?
+        return {} if patron.status.blank?
         illiad_status = illiad_status(ldap_status: patron.status, ldap_pustatus: patron.pustatus, ldap_department: patron.department, ldap_title: patron.title)
-        return nil if illiad_status.blank?
+        return {} if illiad_status.blank?
         addresses = patron.address&.split('$')
         {
           "Username" => patron.netid, "ExternalUserId" => patron.netid, "FirstName" => patron.first_name,

--- a/spec/models/requests/illiad_patron_spec.rb
+++ b/spec/models/requests/illiad_patron_spec.rb
@@ -114,4 +114,18 @@ describe Requests::IlliadPatron, type: :controller do
       expect(patron).to be_blank
     end
   end
+
+  context "ldap data is blank" do
+    let(:ldap_data) { {} }
+    it "returns empty attributes when illiad user is not present" do
+      expect(illiad_patron.attributes).to eq({})
+    end
+  end
+
+  context "ldap data is blank except for status" do
+    let(:ldap_data) { { status: 'faculty' } }
+    it "returns empty attributes when illiad user is not present" do
+      expect(illiad_patron.attributes).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
Will stop nil exceptions when trying to refrence the hash in email templates
fixes #1004