### PR TITLE
Adding tests for Columbia Art and Music items

### DIFF
--- a/spec/cassettes/request_features.yml
+++ b/spec/cassettes/request_features.yml
@@ -5217,4 +5217,330 @@ http_interactions:
       encoding: UTF-8
       string: "[]"
   recorded_at: Fri, 06 Aug 2021 12:06:23 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/SCSB-9726156/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Fri, 20 Aug 2021 16:33:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - bbea9496-8041-4c84-ab06-a0ebd85f1d83
+      X-Download-Options:
+      - noopen
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"0bd49321c09671a437adb909be0bda24"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.017464'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.10
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Origin
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6IlNDU0ItOTcyNjE1NiIsIm51bWVyaWNfaWRfYiI6ZmFsc2UsIm90aGVyX2lkX3MiOlsiMTQ1Nzc0NjIiXSwiYXV0aG9yX2NpdGF0aW9uX2Rpc3BsYXkiOlsiQ29zdHVtZSBCbHVlIChNdXNpY2FsIGdyb3VwKSJdLCJhdXRob3Jfcm9sZXNfMWRpc3BsYXkiOiJ7XCJzZWNvbmRhcnlfYXV0aG9yc1wiOltcIkNvc3R1bWUgQmx1ZSAoTXVzaWNhbCBncm91cClcIl0sXCJ0cmFuc2xhdG9yc1wiOltdLFwiZWRpdG9yc1wiOltdLFwiY29tcGlsZXJzXCI6W119IiwiYXV0aG9yX3MiOlsiQ29zdHVtZSBCbHVlIChNdXNpY2FsIGdyb3VwKSJdLCJ0aXRsZV9kaXNwbGF5IjoiQXVzZcyCbmNpYSAvIENvc3R1bWUgQmx1ZSIsInRpdGxlX3QiOlsiQXVzZcyCbmNpYSAvIENvc3R1bWUgQmx1ZSJdLCJ0aXRsZV9jaXRhdGlvbl9kaXNwbGF5IjpbIkF1c2XMgm5jaWEiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIkF1c2XMgm5jaWEgLyBDb3N0dW1lIEJsdWUiXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJbQnJhemlsXSA6IENvc3R1bWUgQmx1ZSwgWzIwMTldIiwi4oSXMjAxOSJdLCJwdWJfY3JlYXRlZF9zIjpbIltCcmF6aWxdIDogQ29zdHVtZSBCbHVlLCBbMjAxOV0iLCLihJcyMDE5Il0sInB1Yl9jaXRhdGlvbl9kaXNwbGF5IjpbIkJyYXppbDogQ29zdHVtZSBCbHVlIl0sInB1Yl9kYXRlX2Rpc3BsYXkiOlsiMjAxOSJdLCJwdWJfZGF0ZV9zdGFydF9zb3J0IjoyMDE5LCJwdWJfZGF0ZV9lbmRfc29ydCI6MjAxOSwiZm9ybWF0IjpbIkF1ZGlvIl0sIm1lZGl1bV9zdXBwb3J0X2Rpc3BsYXkiOlsiNCAzLzQgaW4uIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMSBhdWRpbyBkaXNjIDsgNCAzLzQgaW4uIl0sImRlc2NyaXB0aW9uX3QiOlsiMSBhdWRpbyBkaXNjIDsgNCAzLzQgaW4uIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjEgYXVkaW8gZGlzYyJdLCJnZW9jb2RlX2Rpc3BsYXkiOlsiQnJhemlsIl0sIm5vdGVzX2Rpc3BsYXkiOlsiVGl0bGUgZnJvbSBkaXNjIGxhYmVsIiwiTHlyaWNzIGluIFBvcnR1Z3Vlc2UgKDEyIHVubnVtYmVyZWQgcGFnZXMpIGluc2VydGVkIGluIGNvbnRhaW5lciJdLCJwYXJ0aWNpcGFudF9wZXJmb3JtZXJfZGlzcGxheSI6WyJDb3N0dW1lIEJsdWUgKFJpY2FyZG8gTWFyaW5zLCBwaWFubywgb3JnYW4sIGtleWJvYXJkLCBzeW50aGVzaXplcnMsIGd1aXRhciwgdm9jYWxzIDsgTWFyY2VsbyBCdWxob8yDZXMsIHZvY2FscywgZ3VpdGFyczsgYWxmYWlhLCB0cmlhbmdsZSwgdmlvbGHMg28gOyBDcmlzdGlhbm8gQXJhanVvLCBkcnVtcywgZWZmZWN0cywgdWR1LCBhbGZhaWEsIHJvzIFpLXJvzIFpLCBwZXJjdXNzaW9uIDsgQ2Vsc28gXCJCbHVlc1wiIEZlcnJlaXJhLCBiYXNzIDsgQWxlc3NhbmRybyBTYcyBLCBndWl0YXIsIGJhc3MgKHRyYWNrIDkpIl0sImxhbmd1YWdlX2Rpc3BsYXkiOlsiU3VuZyBpbiBQb3J0dWd1ZXNlIl0sImxhbmd1YWdlX2ZhY2V0IjpbIlBvcnR1Z3Vlc2UiXSwibGFuZ3VhZ2VfY29kZV9zIjpbInBvciJdLCJsYW5ndWFnZV9pYW5hX3MiOlsicHQiXSwiY29udGVudHNfZGlzcGxheSI6WyJJbnRybyAtLSBGZWJyZSAtLSBTZSB2aWVzc2Ugdm9sdGFyIC0tIEZ1bGlnZW0gLS0gRW50dWxobyBkbyB0ZW1wbyAtLSBGb8yBc2Zvcm8gLS0gQXF1aSwgbmHMg28gbGHMgSAtLSBQb2VzaXRlIC0tIEZvZ28gLS0gTyBjYWRlcm5vIHNlY3JldG8gZGUgQWxleGFuZGVyIE1jUXVlZW4gLS0gQ29udGFudG8gcXVlIGV1IHZhzIEgLS0gVmlvbGHMg28gYXp1bCAtLSBDaGHMg28gLS0gQXVzZcyCbmNpYSJdLCJsY19zdWJqZWN0X2Rpc3BsYXkiOlsiUm9jayBtdXNpY+KAlEJyYXppbOKAlDIwMTEtMjAyMCIsIlBvcHVsYXIgbXVzaWPigJRCcmF6aWzigJQyMDExLTIwMjAiLCJXb3JsZCBtdXNpYyJdLCJzdWJqZWN0X2ZhY2V0IjpbIlJvY2sgbXVzaWPigJRCcmF6aWzigJQyMDExLTIwMjAiLCJQb3B1bGFyIG11c2lj4oCUQnJhemls4oCUMjAxMS0yMDIwIiwiV29ybGQgbXVzaWMiLCJSb2NrIG11c2ljIiwiUG9wdWxhciBtdXNpYyJdLCJsY2dmdF9zIjpbIlJvY2sgbXVzaWMiLCJQb3B1bGFyIG11c2ljIl0sInJlbGF0ZWRfbmFtZV9qc29uXzFkaXNwbGF5Ijoie1wiUGVyZm9ybWVyXCI6W1wiQ29zdHVtZSBCbHVlIChNdXNpY2FsIGdyb3VwKVwiXX0iLCJwdWJsaXNoZXJfbm9fZGlzcGxheSI6WyJDQkNEMDAyLzE5Il0sInN0YW5kYXJkX25vXzFkaXNwbGF5Ijoie1wiSW50ZXJuYXRpb25hbCBBcnRpY2xlIE51bWJlclwiOltcIjc4OTgyNTQ5Nzg4OTJcIl19Iiwib2NsY19zIjpbIjExMTk3MzY1ODEiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9uMTExOTczNjU4MSJdLCJzdWJqZWN0X2VyYV9mYWNldCI6WyIyMDExLTIwMjAiXSwiaG9sZGluZ3NfMWRpc3BsYXkiOiJ7XCIxMDM2Njk2NlwiOntcImNhbGxfbnVtYmVyXCI6XCJDT01QQUNUIERJU0NcIixcImNhbGxfbnVtYmVyX2Jyb3dzZVwiOlwiQ09NUEFDVCBESVNDXCIsXCJsb2NhdGlvbl9jb2RlXCI6XCJzY3NiY3VsXCIsXCJsb2NhdGlvblwiOlwiUmVDQVBcIixcImxpYnJhcnlcIjpcIlJlQ0FQXCIsXCJpdGVtc1wiOlt7XCJob2xkaW5nX2lkXCI6XCIxMDM2Njk2NlwiLFwiaWRcIjpcIjE2MTAxNDM2XCIsXCJ1c2Vfc3RhdGVtZW50XCI6XCJJbiBMaWJyYXJ5IFVzZVwiLFwic3RhdHVzX2F0X2xvYWRcIjpcIkF2YWlsYWJsZVwiLFwiYmFyY29kZVwiOlwiTVIwMDM5MzIyM1wiLFwiY29weV9udW1iZXJcIjpcIjFcIixcImNnY1wiOlwiT3BlblwiLFwiY29sbGVjdGlvbl9jb2RlXCI6XCJNUlwifV19fSIsInJlY2FwX25vdGVzX2Rpc3BsYXkiOlsiQyAtIE8iXSwibG9jYXRpb25fY29kZV9zIjpbInNjc2JjdWwiXSwibG9jYXRpb24iOlsiUmVDQVAiXSwibG9jYXRpb25fZGlzcGxheSI6WyJSZUNBUCJdLCJhZHZhbmNlZF9sb2NhdGlvbl9zIjpbInNjc2JjdWwiLCJSZUNBUCJdLCJfdmVyc2lvbl8iOjE3MDYwMjc5MzQ5MDU1MzI0MTYsInRpbWVzdGFtcCI6IjIwMjEtMDctMjJUMjM6MDM6NDMuODA4WiJ9
+  recorded_at: Fri, 20 Aug 2021 16:33:07 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/hathi/access?oclc=1119736581
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Fri, 20 Aug 2021 16:33:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 404 Not Found
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Runtime:
+      - '0.008417'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - ec2a74ea-39c9-4dd7-88b1-f39dccc8ae2c
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.9
+    body:
+      encoding: UTF-8
+      string: "[]"
+  recorded_at: Fri, 20 Aug 2021 16:33:07 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/bibliographic/SCSB-9726156/holdings/10366966/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Fri, 20 Aug 2021 16:33:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Runtime:
+      - '0.563450'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - b8410fbf-adb2-467a-b281-ec839ac05e15
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.9
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 20 Aug 2021 16:33:08 GMT
+- request:
+    method: get
+    uri: https://catalog.princeton.edu/catalog/SCSB-5595350/raw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Fri, 20 Aug 2021 16:33:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - 48eb30bf-01be-4cc5-8593-2e3519ad85e0
+      X-Download-Options:
+      - noopen
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      Etag:
+      - W/"0ac888bb40ccbbc854cea53e487cec30"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.013319'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.10
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Origin
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJpZCI6IlNDU0ItNTU5NTM1MCIsIm51bWVyaWNfaWRfYiI6ZmFsc2UsIm90aGVyX2lkX3MiOlsiOTAwODg2NSJdLCJhdXRob3JfY2l0YXRpb25fZGlzcGxheSI6WyJSb3Vzc2VhdSwgSGVucmkiLCJZb21pdXJpIFNoaW5idW5zaGEiXSwiYXV0aG9yX3JvbGVzXzFkaXNwbGF5Ijoie1wic2Vjb25kYXJ5X2F1dGhvcnNcIjpbXCJSb3Vzc2VhdSwgSGVucmlcIixcIllvbWl1cmkgU2hpbmJ1bnNoYVwiLFwi6Kqt5aOy5paw6IGe56S+LlwiXSxcInRyYW5zbGF0b3JzXCI6W10sXCJlZGl0b3JzXCI6W10sXCJjb21waWxlcnNcIjpbXX0iLCJhdXRob3JfcyI6WyJSb3Vzc2VhdSwgSGVucmksIDE4NDQtMTkxMCIsIllvbWl1cmkgU2hpbmJ1bnNoYSIsIuiqreWjsuaWsOiBnuekvi4iXSwidGl0bGVfZGlzcGxheSI6IlwiIEFucmkgUnVzb8yEIG5vIHlha2FpXCIgdGVuIDogMTkwOC1uZW4gLS0gUGlrYXNvIG5vIGF0b3JpZSBkZSA9IExlIGJhbnF1ZXQgZHUgRG91YW5pZXIgUm91c3NlYXUgLyBbaGVuc2h1zIQgWW9taXVyaSBTaGluYnVuc2hhXS4iLCJ0aXRsZV92ZXJuX2Rpc3BsYXkiOiLjgIzjgqLjg7Pjg6rjg7vjg6vjgr3jg7zjga7lpJzkvJrjgI3lsZUgOiAxOTA4IOW5tCAtLSDjg5Tjgqvjgr3jga7jgqLjg4jjg6rjgqjjgacgPSBMZSBiYW5xdWV0IGR1IERvdWFuaWVyIFJvdXNzZWF1IC8gW+e3qOmbhuiqreWjsuaWsOiBnuekvl0uIiwidGl0bGVfdCI6WyJcIiBBbnJpIFJ1c2/MhCBubyB5YWthaVwiIHRlbiA6IDE5MDgtbmVuIC0tIFBpa2FzbyBubyBhdG9yaWUgZGUgPSBMZSBiYW5xdWV0IGR1IERvdWFuaWVyIFJvdXNzZWF1IC8gW2hlbnNodcyEIFlvbWl1cmkgU2hpbmJ1bnNoYV0uIl0sInRpdGxlX2NpdGF0aW9uX2Rpc3BsYXkiOlsiXCIgQW5yaSBSdXNvzIQgbm8geWFrYWlcIiB0ZW4gOiAxOTA4LW5lbiAtLSBQaWthc28gbm8gYXRvcmllIGRlID0gTGUgYmFucXVldCBkdSBEb3VhbmllciBSb3Vzc2VhdSIsIuOAjOOCouODs+ODquODu+ODq+OCveODvOOBruWknOS8muOAjeWxlSA6IDE5MDgg5bm0IC0tIOODlOOCq+OCveOBruOCouODiOODquOCqOOBpyA9IExlIGJhbnF1ZXQgZHUgRG91YW5pZXIgUm91c3NlYXUiXSwiY29tcGlsZWRfY3JlYXRlZF90IjpbIlwiIEFucmkgUnVzb8yEIG5vIHlha2FpXCIgdGVuIDogMTkwOC1uZW4gLS0gUGlrYXNvIG5vIGF0b3JpZSBkZSA9IExlIGJhbnF1ZXQgZHUgRG91YW5pZXIgUm91c3NlYXUgLyBbaGVuc2h1zIQgWW9taXVyaSBTaGluYnVuc2hhXS4iLCLjgIzjgqLjg7Pjg6rjg7vjg6vjgr3jg7zjga7lpJzkvJrjgI3lsZUgOiAxOTA4IOW5tCAtLSDjg5Tjgqvjgr3jga7jgqLjg4jjg6rjgqjjgacgPSBMZSBiYW5xdWV0IGR1IERvdWFuaWVyIFJvdXNzZWF1IC8gW+e3qOmbhuiqreWjsuaWsOiBnuekvl0uIl0sInB1Yl9jcmVhdGVkX3Zlcm5fZGlzcGxheSI6WyJbVG9reW9dIDog6Kqt5aOy5paw6IGe56S+LCBjMTk4NS4iXSwicHViX2NyZWF0ZWRfZGlzcGxheSI6WyJbVG9reW9dIDogWW9taXVyaSBTaGluYnVuc2hhLCBjMTk4NS4iLCJbVG9reW9dIDog6Kqt5aOy5paw6IGe56S+LCBjMTk4NS4iXSwicHViX2NyZWF0ZWRfcyI6WyJbVG9reW9dIDogWW9taXVyaSBTaGluYnVuc2hhLCBjMTk4NS4iLCJbVG9reW9dIDog6Kqt5aOy5paw6IGe56S+LCBjMTk4NS4iXSwicHViX2NpdGF0aW9uX2Rpc3BsYXkiOlsiVG9reW86IFlvbWl1cmkgU2hpbmJ1bnNoYSIsIlRva3lvOiDoqq3lo7LmlrDogZ7npL4iXSwicHViX2RhdGVfZGlzcGxheSI6WyIxOTg1Il0sInB1Yl9kYXRlX3N0YXJ0X3NvcnQiOjE5ODUsImZvcm1hdCI6WyJCb29rIl0sImRlc2NyaXB0aW9uX2Rpc3BsYXkiOlsiMTYxIHAuIDogaWxsLiAoc29tZSBjb2wuKSwgcG9ydHMuIDsgMjcgY20uIl0sImRlc2NyaXB0aW9uX3QiOlsiMTYxIHAuIDogaWxsLiAoc29tZSBjb2wuKSwgcG9ydHMuIDsgMjcgY20uIl0sIm51bWJlcl9vZl9wYWdlc19jaXRhdGlvbl9kaXNwbGF5IjpbIjE2MSBwLiJdLCJub3Rlc19kaXNwbGF5IjpbIk5DQyBKQUNXUCB0aXRsZTsgbWF5IGJlIGxvYW5lZCB0aHJvdWdoIElMTC4iXSwibGFuZ3VhZ2VfZGlzcGxheSI6WyJJbiBKYXBhbmVzZSB3aXRoIHNvbWUgRnJlbmNoLiJdLCJsYW5ndWFnZV9mYWNldCI6WyJKYXBhbmVzZSIsIkZyZW5jaCJdLCJsYW5ndWFnZV9jb2RlX3MiOlsianBuIiwiZnJlIl0sImxhbmd1YWdlX2lhbmFfcyI6WyJqYSIsImZyIl0sImxjX3N1YmplY3RfZGlzcGxheSI6WyJSb3Vzc2VhdSwgSGVucmksIDE4NDQtMTkxMOKAlEluZmx1ZW5jZeKAlEV4aGliaXRpb25zIiwiUHJpbWl0aXZpc20gaW4gYXJ04oCURnJhbmNl4oCURXhoaWJpdGlvbnMiLCJQYWludGluZywgRnJlbmNo4oCUMjB0aCBjZW50dXJ54oCURXhoaWJpdGlvbnMiLCJQYWludGluZywgRnJlbmNo4oCUMTl0aCBjZW50dXJ54oCURXhoaWJpdGlvbnMiXSwic3ViamVjdF9mYWNldCI6WyJSb3Vzc2VhdSwgSGVucmksIDE4NDQtMTkxMOKAlEluZmx1ZW5jZeKAlEV4aGliaXRpb25zIiwiUHJpbWl0aXZpc20gaW4gYXJ04oCURnJhbmNl4oCURXhoaWJpdGlvbnMiLCJQYWludGluZywgRnJlbmNo4oCUMjB0aCBjZW50dXJ54oCURXhoaWJpdGlvbnMiLCJQYWludGluZywgRnJlbmNo4oCUMTl0aCBjZW50dXJ54oCURXhoaWJpdGlvbnMiXSwicmVsYXRlZF9uYW1lX2pzb25fMWRpc3BsYXkiOiJ7XCJSZWxhdGVkIG5hbWVcIjpbXCJSb3Vzc2VhdSwgSGVucmksIDE4NDQtMTkxMFwiLFwiWW9taXVyaSBTaGluYnVuc2hhXCIsXCLoqq3lo7LmlrDogZ7npL4uXCJdfSIsIm90aGVyX3RpdGxlX2Rpc3BsYXkiOlsiQmFucXVldCBkdSBEb3VhbmllciBSb3Vzc2VhdSJdLCJhbHRfdGl0bGVfMjQ2X2Rpc3BsYXkiOlsiQmFucXVldCBkdSBEb3VhbmllciBSb3Vzc2VhdSJdLCJvY2xjX3MiOlsiODI5MTE1OTAiXSwib3RoZXJfdmVyc2lvbl9zIjpbIm9jbTgyOTExNTkwIl0sInN1YmplY3RfZXJhX2ZhY2V0IjpbIjIwdGggY2VudHVyeSIsIjE5dGggY2VudHVyeSJdLCJob2xkaW5nc18xZGlzcGxheSI6IntcIjU1ODk3ODRcIjp7XCJjYWxsX251bWJlclwiOlwiTkQ1NTMuUjY3IEE0IDE5ODVnXCIsXCJjYWxsX251bWJlcl9icm93c2VcIjpcIk5ENTUzLlI2NyBBNCAxOTg1Z1wiLFwibG9jYXRpb25fY29kZVwiOlwic2NzYmN1bFwiLFwibG9jYXRpb25cIjpcIlJlQ0FQXCIsXCJsaWJyYXJ5XCI6XCJSZUNBUFwiLFwiaXRlbXNcIjpbe1wiaG9sZGluZ19pZFwiOlwiNTU4OTc4NFwiLFwiaWRcIjpcIjgyNjQ4NDRcIixcInVzZV9zdGF0ZW1lbnRcIjpcIkluIExpYnJhcnkgVXNlXCIsXCJzdGF0dXNfYXRfbG9hZFwiOlwiQXZhaWxhYmxlXCIsXCJiYXJjb2RlXCI6XCJBUjAxMjIwNTUxXCIsXCJjb3B5X251bWJlclwiOlwiMVwiLFwiY2djXCI6XCJPcGVuXCIsXCJjb2xsZWN0aW9uX2NvZGVcIjpcIkFSXCJ9XX19IiwicmVjYXBfbm90ZXNfZGlzcGxheSI6WyJDIC0gTyJdLCJsb2NhdGlvbl9jb2RlX3MiOlsic2NzYmN1bCJdLCJsb2NhdGlvbiI6WyJSZUNBUCJdLCJsb2NhdGlvbl9kaXNwbGF5IjpbIlJlQ0FQIl0sImFkdmFuY2VkX2xvY2F0aW9uX3MiOlsic2NzYmN1bCIsIlJlQ0FQIl0sIl92ZXJzaW9uXyI6MTcwNjAyNjMwMDIwOTEwMjg0OCwidGltZXN0YW1wIjoiMjAyMS0wNy0yMlQyMjozNzo0NS41MzJaIn0=
+  recorded_at: Fri, 20 Aug 2021 16:33:19 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/hathi/access?oclc=82911590
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Fri, 20 Aug 2021 16:33:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 404 Not Found
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Runtime:
+      - '0.006088'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - b346148e-b795-49d2-bf93-bfa9684aecf3
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.9
+    body:
+      encoding: UTF-8
+      string: "[]"
+  recorded_at: Fri, 20 Aug 2021 16:33:19 GMT
+- request:
+    method: get
+    uri: https://bibdata.princeton.edu/bibliographic/SCSB-5595350/holdings/5589784/availability.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx/1.19.10
+      Date:
+      - Fri, 20 Aug 2021 16:33:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 400 Bad Request
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Cache-Control:
+      - no-cache
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Runtime:
+      - '0.270977'
+      Access-Control-Request-Method:
+      - GET
+      X-Request-Id:
+      - f01cd212-3013-4723-98c1-99e5925dd028
+      X-Powered-By:
+      - Phusion Passenger(R) 6.0.9
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Fri, 20 Aug 2021 16:33:20 GMT
 recorded_with: VCR 6.0.0

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -1169,6 +1169,20 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
           expect(confirm_email.html_part.body.to_s).to have_content("Ḍaḥāyā al-zawāj")
           expect(confirm_email.html_part.body.to_s).to have_content("Remain only in the designated pick-up area")
         end
+
+        it "Delivers scsb in library use art items only to marquand" do
+          stub_scsb_availability(bib_id: "9008865", institution_id: "CUL", barcode: 'AR01220551')
+          visit '/requests/SCSB-5595350'
+          expect(page).to have_content 'Available for In Library Use'
+          expect(page).to have_content 'Pick-up location: Marquand Library at Firestone'
+        end
+
+        it "Delivers scsb in library use music items only to mendel" do
+          stub_scsb_availability(bib_id: "14577462", institution_id: "CUL", barcode: 'MR00393223')
+          visit '/requests/SCSB-9726156'
+          expect(page).to have_content 'Available for In Library Use'
+          expect(page).to have_content 'Pick-up location: Mendel Music Library'
+        end
       end
     end
 


### PR DESCRIPTION
Adding tests so we do not have a regression and lose the special processing for inlibrary use art and music items.
They need to be routed to Marquand and Mendel instead of Firestone

fixes #904