### PR TITLE
Upgrading apt to fix build error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,12 @@ jobs:
       - run:
           name: Install system packages
           command: |
+            sudo apt-get clean
             sudo apt update -y
-            sudo apt install -y postgresql-client phantomjs
+            sudo apt upgrade -y
+            sudo apt install -y postgresql-client
+            wget "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2"
+            sudo tar -xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share/
 
       # Install the Gem dependencies
       - restore_cache:


### PR DESCRIPTION
Fixes `E: Package 'phantomjs' has no installation candidate` error on circle ci