### PR TITLE
Allow annex in library use items to be requested

### DIFF
--- a/app/mailers/requests/request_mailer.rb
+++ b/app/mailers/requests/request_mailer.rb
@@ -53,6 +53,17 @@ module Requests
       confirmation_email(submission: submission, subject_key: 'requests.annex.email_subject')
     end
 
+    def annex_in_library_email(submission)
+      @submission = submission
+      mail(to: I18n.t('requests.annex.email'),
+           from: I18n.t('requests.default.email_from'),
+           subject: subject_line(I18n.t('requests.annex_in_library.email_subject'), @submission.user_barcode))
+    end
+
+    def annex_in_library_confirmation(submission)
+      confirmation_email(submission: submission, subject_key: 'requests.annex_in_library.email_subject')
+    end
+
     def ppl_email(submission)
       request_email(submission: submission, subject_key: 'requests.ppl.email_subject', destination_key: 'requests.ppl.email')
     end

--- a/app/models/requests/selected_items_validator.rb
+++ b/app/models/requests/selected_items_validator.rb
@@ -2,7 +2,7 @@
 module Requests
   class SelectedItemsValidator < ActiveModel::Validator
     def mail_services
-      ["paging", "pres", "annex", "trace", "on_order", "in_process", "ppl", "lewis", "on_shelf"]
+      ["paging", "pres", "annex", "trace", "on_order", "in_process", "ppl", "lewis", "on_shelf", "annex_in_library"]
     end
 
     def validate(record)

--- a/app/models/requests/submission.rb
+++ b/app/models/requests/submission.rb
@@ -118,7 +118,7 @@ module Requests
       # rubocop:disable Metrics/MethodLength
       def service_by_type(type)
         case type
-        when 'on_shelf', 'marquand_in_library', 'annex'
+        when 'on_shelf', 'marquand_in_library', 'annex', 'annex_in_library'
           Requests::Submissions::HoldItem.new(self, service_type: type)
         when 'recall'
           Requests::Submissions::Recall.new(self)
@@ -143,14 +143,14 @@ module Requests
         library_code = item["library_code"]
         if recap_no_items?(item)
           item["type"] = "recap_no_items"
+        elsif print?(item) && library_code == 'annex'
+          item["type"] = "annex"
         elsif off_site?(library_code)
           item["type"] = library_code
           item["type"] += "_edd" if edd?(item)
           item["type"] += "_in_library" if in_library?(item)
         elsif item["type"] == "paging"
           item["type"] = "digitize" if edd?(item)
-        elsif print?(item) && library_code == 'annex'
-          item["type"] = "annex"
         elsif edd?(item) && library_code.present?
           item["type"] = "digitize"
         elsif print?(item) && library_code.present?
@@ -171,7 +171,7 @@ module Requests
       end
 
       def off_site?(library_code)
-        library_code == 'recap' || library_code == 'marquand' || library_code == 'clancy' || library_code == 'recap_marquand' || library_code == 'clancy_unavailable'
+        library_code == 'recap' || library_code == 'marquand' || library_code == 'clancy' || library_code == 'recap_marquand' || library_code == 'clancy_unavailable' || library_code == 'annex'
       end
 
       def print?(item)

--- a/app/models/requests/submissions/hold_item.rb
+++ b/app/models/requests/submissions/hold_item.rb
@@ -67,7 +67,13 @@ module Requests::Submissions
       end
 
       def payload(item)
-        { mms_id: submission.bib['id'], holding_id: item["mfhd"], item_pid: item['item_id'], user_id: submission.patron.university_id, request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: item["pick_up_location_code"] }
+        pick_up_library = if item["pick_up_location_code"] == "annex"
+                            "firestone"
+                          else
+                            item["pick_up_location_code"]
+                          end
+
+        { mms_id: submission.bib['id'], holding_id: item["mfhd"], item_pid: item['item_id'], user_id: submission.patron.university_id, request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: pick_up_library }
       end
   end
 end

--- a/app/views/requests/request_mailer/annex_in_library_confirmation.html.erb
+++ b/app/views/requests/request_mailer/annex_in_library_confirmation.html.erb
@@ -1,0 +1,23 @@
+<tr class="email-header">
+  <td colspan="2" style="padding: 18px;border-top: 6px solid #e77500;">
+    <%= render 'request_header_patron' %>
+  </td>
+</tr>
+
+<tr>
+  <td colspan="2" style="padding: 18px;">
+    <p class="body-content" style="margin-bottom:0;"><%= I18n.t('requests.annex.email_conf_msg') %></p>
+  </td>
+</tr>
+
+<tr class="bib-info">
+  <td colspan="2" style="padding: 18px;border-top:1px solid #ccc;">
+    <%= render 'bib_info_patron' %>
+  </td>
+</tr>
+
+<tr>
+  <td colspan="2" style="padding: 18px;border-top:1px solid #ccc;">
+    <%= render partial: 'item_info', locals: { show_edd_fields: false } %>
+  </td>
+</tr>

--- a/app/views/requests/request_mailer/annex_in_library_confirmation.text.erb
+++ b/app/views/requests/request_mailer/annex_in_library_confirmation.text.erb
@@ -1,0 +1,8 @@
+==============================================
+Forrestal Annex Request
+
+<%= I18n.t('requests.annex.email_conf_msg') %>
+
+<%= render 'patron_info' %>
+<%= render 'bib_info' %>
+<%= render partial: 'item_info', locals: { show_edd_fields: false } %>

--- a/app/views/requests/request_mailer/annex_in_library_email.html.erb
+++ b/app/views/requests/request_mailer/annex_in_library_email.html.erb
@@ -1,0 +1,17 @@
+<tr class="email-header">
+  <td colspan="2" style="padding: 18px">
+    <%= render 'request_header' %>
+  </td>
+</tr>
+
+<tr class="bib-info">
+  <td colspan="2" style="padding: 18px;border-top:1px solid #ccc;">
+    <%= render 'bib_info' %>
+  </td>
+</tr>
+
+<tr>
+  <td colspan="2" style="padding: 18px;border-top:1px solid #ccc;">
+    <%= render partial: 'item_info', locals: { show_edd_fields: false } %>
+  </td>
+</tr>

--- a/app/views/requests/request_mailer/annex_in_library_email.text.erb
+++ b/app/views/requests/request_mailer/annex_in_library_email.text.erb
@@ -1,0 +1,8 @@
+==============================================
+Forrestal Annex Request
+
+<%= I18n.t('requests.annex.email_conf_msg') %>
+
+<%= render 'patron_info' %>
+<%= render 'bib_info' %>
+<%= render partial: 'item_info', locals: { show_edd_fields: false } %>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -23,6 +23,7 @@ en:
       pres_success: "We will notify you when the preservation work is complete and this item is available."
       in_process_success: "Request submitted. See confirmation email with details about when your item(s) will be available."
       annex_success: "Request submitted. See confirmation email with details about when your item(s) will be available."
+      annex_in_library_success: "Request submitted. See confirmation email with details about when your item(s) will be available to view."
       ppl_success: ""
       clancy_in_library_success: "Request submitted. See confirmation email with details about when your item(s) will be available to view."
       clancy_edd_success: "Request submitted. See confirmation email with details about when your scan(s) will be available."
@@ -50,6 +51,11 @@ en:
       #email_conf_msg: "You will be notified via email when your item is ready for pick-up. Most items are ready in 1 to 2 business days."
       email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email when the book is available for pick-up."
       in_library_use_msg_html: After notification of your item's arrival at %{location_label}, you should visit the Library to view it
+    annex_in_library:
+      email: "forranx@princeton.edu"
+      email_subject: "Annex In Library Use Request"
+      brief_msg: "Item offsite at Forrestal Annex. Requests for viewing in a library typically take 1-2 business days to process."
+      email_conf_msg: "Your request to pick this item up has been received. We will process the requests as soon as possible, but given the demand and the current circumstances some delay may occur. You will receive an email when the book is available for viewing."
     anxadoc:
       email: "docstor@princeton.edu"
     digitize:

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -1255,6 +1255,31 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
           expect(confirm_email.html_part.body.to_s).to have_content("Han'guk hyŏndaesa sanch'aek. No Mu-hyŏn sidae ŭi myŏngam")
           expect(confirm_email.html_part.body.to_s).not_to have_content("Remain only in the designated pick-up area")
         end
+
+        it 'Request an annex in library book correctly' do
+          stub_alma_hold_success('9941347943506421', '22560381400006421', '23560381360006421', '960594184')
+          visit 'requests/9941347943506421?mfhd=22560381400006421'
+          expect(page).to have_content "Er ru ting Qun fang pu : [san shi juan]"
+          check('requestable_selected_23560381360006421')
+          choose('requestable__delivery_mode_23560381360006421_in_library')
+          expect { click_button 'Request Selected Items' }.to change { ActionMailer::Base.deliveries.count }.by(2)
+          expect(page).to have_content I18n.t("requests.submit.annex_in_library_success")
+          email = ActionMailer::Base.deliveries[ActionMailer::Base.deliveries.count - 2]
+          confirm_email = ActionMailer::Base.deliveries.last
+          expect(email.subject).to eq("Patron Initiated Catalog Request In Library Confirmation")
+          expect(email.to).to eq(["forranx@princeton.edu"])
+          expect(email.cc).to be_blank
+          expect(email.html_part.body.to_s).to have_content("Er ru ting Qun fang pu : [san shi juan]")
+          expect(email.html_part.body.to_s).to have_content("vol.9-16")
+          expect(email.text_part.body.to_s).to have_content("vol.9-16")
+          expect(confirm_email.subject).to eq("Patron Initiated Catalog Request In Library Confirmation")
+          expect(confirm_email.html_part.body.to_s).not_to have_content("translation missing")
+          expect(confirm_email.text_part.body.to_s).not_to have_content("translation missing")
+          expect(confirm_email.to).to eq(["a@b.com"])
+          expect(confirm_email.cc).to be_blank
+          expect(confirm_email.html_part.body.to_s).to have_content("Er ru ting Qun fang pu : [san shi juan]")
+          expect(confirm_email.html_part.body.to_s).not_to have_content("Remain only in the designated pick-up area")
+        end
       end
     end
 


### PR DESCRIPTION
Items are only sent to Firestone Library, which may or may not be accurate.  
It is a bigger change to figure out how to send them to the correct library.  
This just fixes #1099 and does not put the request into illiad